### PR TITLE
Add basic Photoshop-like canvas editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# photoshop-clone
+# Photoshop Clone
+
+A simple Photoshop-like web application built with HTML5 Canvas, CSS, and JavaScript.
+
+## Features
+
+- Pencil and eraser tools
+- Rectangle, line, and circle drawing
+- Text insertion
+- Color picker and line width control
+- Undo/redo support
+- Load external images onto the canvas
+- Save canvas as PNG
+
+Open `index.html` in your browser to use the app.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Photoshop Clone</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="toolbar">
+    <input type="color" id="colorPicker" value="#000000" />
+    <input type="range" id="lineWidth" min="1" max="50" value="5" />
+    <button id="pencil">Pencil</button>
+    <button id="eraser">Eraser</button>
+    <button id="rectangle">Rectangle</button>
+    <button id="line">Line</button>
+    <button id="circle">Circle</button>
+    <button id="text">Text</button>
+    <input type="file" id="imageLoader" accept="image/*" />
+    <button id="undo">Undo</button>
+    <button id="redo">Redo</button>
+    <button id="save">Save</button>
+  </div>
+  <canvas id="canvas" width="800" height="600"></canvas>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,123 @@
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+
+let drawing = false;
+let startX = 0;
+let startY = 0;
+let currentTool = 'pencil';
+const undoStack = [];
+const redoStack = [];
+
+function saveState() {
+  undoStack.push(canvas.toDataURL());
+  if (undoStack.length > 50) undoStack.shift();
+  redoStack.length = 0;
+}
+
+function restoreState(stack, oppositeStack) {
+  if (stack.length) {
+    oppositeStack.push(canvas.toDataURL());
+    const img = new Image();
+    img.src = stack.pop();
+    img.onload = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(img, 0, 0);
+    };
+  }
+}
+
+document.getElementById('undo').onclick = () => restoreState(undoStack, redoStack);
+document.getElementById('redo').onclick = () => restoreState(redoStack, undoStack);
+
+canvas.addEventListener('mousedown', e => {
+  drawing = true;
+  startX = e.offsetX;
+  startY = e.offsetY;
+  if (currentTool === 'pencil' || currentTool === 'eraser') {
+    ctx.beginPath();
+    ctx.moveTo(startX, startY);
+    saveState();
+  } else if (currentTool === 'text') {
+    const text = prompt('Enter text:');
+    if (text) {
+      saveState();
+      ctx.fillStyle = document.getElementById('colorPicker').value;
+      ctx.font = `${document.getElementById('lineWidth').value * 5}px sans-serif`;
+      ctx.fillText(text, startX, startY);
+    }
+    drawing = false;
+  } else {
+    saveState();
+  }
+});
+
+canvas.addEventListener('mousemove', e => {
+  if (!drawing) return;
+  const x = e.offsetX;
+  const y = e.offsetY;
+  ctx.lineWidth = document.getElementById('lineWidth').value;
+  ctx.strokeStyle = currentTool === 'eraser' ? '#ffffff' : document.getElementById('colorPicker').value;
+  ctx.fillStyle = document.getElementById('colorPicker').value;
+
+  if (currentTool === 'pencil' || currentTool === 'eraser') {
+    ctx.lineTo(x, y);
+    ctx.stroke();
+  }
+});
+
+canvas.addEventListener('mouseup', e => {
+  if (!drawing) return;
+  drawing = false;
+  const x = e.offsetX;
+  const y = e.offsetY;
+
+  ctx.lineWidth = document.getElementById('lineWidth').value;
+  ctx.strokeStyle = document.getElementById('colorPicker').value;
+  ctx.fillStyle = document.getElementById('colorPicker').value;
+
+  switch (currentTool) {
+    case 'rectangle':
+      ctx.strokeRect(startX, startY, x - startX, y - startY);
+      break;
+    case 'line':
+      ctx.beginPath();
+      ctx.moveTo(startX, startY);
+      ctx.lineTo(x, y);
+      ctx.stroke();
+      break;
+    case 'circle':
+      const radius = Math.hypot(x - startX, y - startY);
+      ctx.beginPath();
+      ctx.arc(startX, startY, radius, 0, Math.PI * 2);
+      ctx.stroke();
+      break;
+  }
+});
+
+['pencil','eraser','rectangle','line','circle','text'].forEach(tool => {
+  document.getElementById(tool).onclick = () => currentTool = tool;
+});
+
+
+document.getElementById('imageLoader').addEventListener('change', e => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = evt => {
+    const img = new Image();
+    img.onload = () => {
+      saveState();
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+    };
+    img.src = evt.target.result;
+  };
+  reader.readAsDataURL(file);
+});
+
+document.getElementById('save').onclick = () => {
+  const link = document.createElement('a');
+  link.download = 'image.png';
+  link.href = canvas.toDataURL();
+  link.click();
+};

--- a/style.css
+++ b/style.css
@@ -1,0 +1,18 @@
+body {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+#toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 10px;
+}
+
+#canvas {
+  border: 1px solid #000;
+  cursor: crosshair;
+}


### PR DESCRIPTION
## Summary
- create HTML/CSS/JS canvas app with pencil, shapes, text, image load, undo/redo, and save features
- document usage and features in README

## Testing
- `npm test` *(fails: no package.json)*
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6896e3711c9883289e0b36bc2002c2e3