### PR TITLE
refactor: modularize editor initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,10 @@
     <button id="redo">Redo</button>
     <button id="save">Save</button>
   </div>
-  <canvas id="canvas" width="800" height="600"></canvas>
-  <script src="script.js"></script>
-</body>
+    <canvas id="canvas" width="800" height="600"></canvas>
+    <script type="module">
+      import { initEditor } from './src/editor.js';
+      initEditor();
+    </script>
+  </body>
 </html>

--- a/src/editor.js
+++ b/src/editor.js
@@ -1,6 +1,5 @@
-const canvas = document.getElementById('canvas');
-const ctx = canvas.getContext('2d');
-
+let canvas, ctx, colorPicker, lineWidth, imageLoader, saveBtn;
+const toolButtons = {};
 let drawing = false;
 let startX = 0;
 let startY = 0;
@@ -26,10 +25,7 @@ function restoreState(stack, oppositeStack) {
   }
 }
 
-document.getElementById('undo').onclick = () => restoreState(undoStack, redoStack);
-document.getElementById('redo').onclick = () => restoreState(redoStack, undoStack);
-
-canvas.addEventListener('mousedown', e => {
+function handleMouseDown(e) {
   drawing = true;
   startX = e.offsetX;
   startY = e.offsetY;
@@ -41,39 +37,39 @@ canvas.addEventListener('mousedown', e => {
     const text = prompt('Enter text:');
     if (text) {
       saveState();
-      ctx.fillStyle = document.getElementById('colorPicker').value;
-      ctx.font = `${document.getElementById('lineWidth').value * 5}px sans-serif`;
+      ctx.fillStyle = colorPicker.value;
+      ctx.font = `${lineWidth.value * 5}px sans-serif`;
       ctx.fillText(text, startX, startY);
     }
     drawing = false;
   } else {
     saveState();
   }
-});
+}
 
-canvas.addEventListener('mousemove', e => {
+function handleMouseMove(e) {
   if (!drawing) return;
   const x = e.offsetX;
   const y = e.offsetY;
-  ctx.lineWidth = document.getElementById('lineWidth').value;
-  ctx.strokeStyle = currentTool === 'eraser' ? '#ffffff' : document.getElementById('colorPicker').value;
-  ctx.fillStyle = document.getElementById('colorPicker').value;
+  ctx.lineWidth = lineWidth.value;
+  ctx.strokeStyle = currentTool === 'eraser' ? '#ffffff' : colorPicker.value;
+  ctx.fillStyle = colorPicker.value;
 
   if (currentTool === 'pencil' || currentTool === 'eraser') {
     ctx.lineTo(x, y);
     ctx.stroke();
   }
-});
+}
 
-canvas.addEventListener('mouseup', e => {
+function handleMouseUp(e) {
   if (!drawing) return;
   drawing = false;
   const x = e.offsetX;
   const y = e.offsetY;
 
-  ctx.lineWidth = document.getElementById('lineWidth').value;
-  ctx.strokeStyle = document.getElementById('colorPicker').value;
-  ctx.fillStyle = document.getElementById('colorPicker').value;
+  ctx.lineWidth = lineWidth.value;
+  ctx.strokeStyle = colorPicker.value;
+  ctx.fillStyle = colorPicker.value;
 
   switch (currentTool) {
     case 'rectangle':
@@ -92,14 +88,9 @@ canvas.addEventListener('mouseup', e => {
       ctx.stroke();
       break;
   }
-});
+}
 
-['pencil','eraser','rectangle','line','circle','text'].forEach(tool => {
-  document.getElementById(tool).onclick = () => currentTool = tool;
-});
-
-
-document.getElementById('imageLoader').addEventListener('change', e => {
+function handleImageLoad(e) {
   const file = e.target.files[0];
   if (!file) return;
   const reader = new FileReader();
@@ -113,11 +104,36 @@ document.getElementById('imageLoader').addEventListener('change', e => {
     img.src = evt.target.result;
   };
   reader.readAsDataURL(file);
-});
+}
 
-document.getElementById('save').onclick = () => {
+function handleSave() {
   const link = document.createElement('a');
   link.download = 'image.png';
   link.href = canvas.toDataURL();
   link.click();
-};
+}
+
+export function initEditor() {
+  canvas = document.getElementById('canvas');
+  ctx = canvas.getContext('2d');
+  colorPicker = document.getElementById('colorPicker');
+  lineWidth = document.getElementById('lineWidth');
+  imageLoader = document.getElementById('imageLoader');
+  saveBtn = document.getElementById('save');
+
+  document.getElementById('undo').onclick = () => restoreState(undoStack, redoStack);
+  document.getElementById('redo').onclick = () => restoreState(redoStack, undoStack);
+
+  ['pencil', 'eraser', 'rectangle', 'line', 'circle', 'text'].forEach(tool => {
+    const btn = document.getElementById(tool);
+    toolButtons[tool] = btn;
+    btn.onclick = () => currentTool = tool;
+  });
+
+  canvas.addEventListener('mousedown', handleMouseDown);
+  canvas.addEventListener('mousemove', handleMouseMove);
+  canvas.addEventListener('mouseup', handleMouseUp);
+
+  imageLoader.addEventListener('change', handleImageLoad);
+  saveBtn.onclick = handleSave;
+}


### PR DESCRIPTION
## Summary
- add `src/editor.js` module with `initEditor` and internal state
- cache DOM lookups and attach handlers once
- load editor module via `<script type="module">` in `index.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68998471ece08328b5dd17ed78eb1251