### PR TITLE
Add keyboard shortcuts and active tool indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,13 @@ A simple Photoshop-like web application built with HTML5 Canvas, CSS, and JavaSc
 - Save canvas as PNG
 
 Open `index.html` in your browser to use the app.
+
+## Keyboard Shortcuts
+
+- **P**: Pencil
+- **E**: Eraser
+- **R**: Rectangle
+- **L**: Line
+- **C**: Circle
+- **T**: Text
+- **Ctrl+Z**: Undo

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,5 +1,5 @@
 let canvas, ctx, colorPicker, lineWidth, imageLoader, saveBtn;
-const toolButtons = {};
+const toolButtons: Record<string, HTMLButtonElement> = {};
 let drawing = false;
 let startX = 0;
 let startY = 0;
@@ -129,11 +129,13 @@ export function initEditor() {
 
   ["pencil", "eraser", "rectangle", "line", "circle", "text"].forEach(
     (tool) => {
-      const btn = document.getElementById(tool);
+      const btn = document.getElementById(tool) as HTMLButtonElement;
       toolButtons[tool] = btn;
-      btn.onclick = () => (currentTool = tool);
+      btn.onclick = () => setTool(tool);
     },
   );
+
+  setTool("pencil");
 
   canvas.addEventListener("mousedown", handleMouseDown);
   canvas.addEventListener("mousemove", handleMouseMove);
@@ -141,4 +143,33 @@ export function initEditor() {
 
   imageLoader.addEventListener("change", handleImageLoad);
   saveBtn.onclick = handleSave;
+
+  document.addEventListener("keydown", handleKeyDown);
+}
+
+function setTool(tool: string) {
+  currentTool = tool;
+  Object.values(toolButtons).forEach((btn) => btn.classList.remove("active"));
+  const btn = toolButtons[tool];
+  if (btn) btn.classList.add("active");
+}
+
+function handleKeyDown(e: KeyboardEvent) {
+  const key = e.key.toLowerCase();
+  if (e.ctrlKey && key === "z") {
+    e.preventDefault();
+    restoreState(undoStack, redoStack);
+    return;
+  }
+
+  const keyMap: Record<string, string> = {
+    p: "pencil",
+    e: "eraser",
+    r: "rectangle",
+    l: "line",
+    c: "circle",
+    t: "text",
+  };
+  const tool = keyMap[key];
+  if (tool) setTool(tool);
 }

--- a/style.css
+++ b/style.css
@@ -16,3 +16,7 @@ body {
   border: 1px solid #000;
   cursor: crosshair;
 }
+
+#toolbar button.active {
+  outline: 2px solid #007bff;
+}


### PR DESCRIPTION
## Summary
- Enable switching tools with keyboard shortcuts and Ctrl+Z undo.
- Highlight the selected tool button for visual feedback.
- Document available shortcuts in README.

## Testing
- `npm test`
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689aed7f0fa483289e007ec986fd80c8