### PR TITLE
Add CI workflow and status badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm install
+      - run: npm run lint
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Photoshop Clone
 
+[![CI](https://github.com/OWNER/REPO/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/OWNER/REPO/actions/workflows/ci.yml)
+
 A simple Photoshop-like web application built with HTML5 Canvas, CSS, and JavaScript.
 
 ## Features


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running npm install, lint, and test on pushes and PRs to main
- show CI status badge in README

## Testing
- `npm install`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689aed7fe470832899fe747aa9fc95ce