### PR TITLE
Use pointer events and scale canvas for high-DPI displays

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
       <button id="redo">Redo</button>
       <button id="save">Save</button>
     </div>
-    <canvas id="canvas" width="800" height="600"></canvas>
+    <canvas id="canvas"></canvas>
     <script type="module" src="dist/index.js"></script>
   </body>
 </html>

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -6,6 +6,7 @@ let startY = 0;
 let currentTool = "pencil";
 const undoStack = [];
 const redoStack = [];
+let dpr = window.devicePixelRatio || 1;
 
 function saveState() {
   undoStack.push(canvas.toDataURL());
@@ -19,13 +20,13 @@ function restoreState(stack, oppositeStack) {
     const img = new Image();
     img.src = stack.pop();
     img.onload = () => {
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-      ctx.drawImage(img, 0, 0);
+      ctx.clearRect(0, 0, canvas.width / dpr, canvas.height / dpr);
+      ctx.drawImage(img, 0, 0, canvas.width / dpr, canvas.height / dpr);
     };
   }
 }
 
-function handleMouseDown(e) {
+function handlePointerDown(e) {
   drawing = true;
   startX = e.offsetX;
   startY = e.offsetY;
@@ -47,7 +48,7 @@ function handleMouseDown(e) {
   }
 }
 
-function handleMouseMove(e) {
+function handlePointerMove(e) {
   if (!drawing) return;
   const x = e.offsetX;
   const y = e.offsetY;
@@ -61,7 +62,7 @@ function handleMouseMove(e) {
   }
 }
 
-function handleMouseUp(e) {
+function handlePointerUp(e) {
   if (!drawing) return;
   drawing = false;
   const x = e.offsetX;
@@ -99,8 +100,14 @@ function handleImageLoad(e) {
     const img = new Image();
     img.onload = () => {
       saveState();
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+      ctx.clearRect(0, 0, canvas.width / dpr, canvas.height / dpr);
+      ctx.drawImage(
+        img,
+        0,
+        0,
+        canvas.width / dpr,
+        canvas.height / dpr,
+      );
     };
     img.src = evt.target.result as string;
   };
@@ -117,6 +124,14 @@ function handleSave() {
 export function initEditor() {
   canvas = document.getElementById("canvas");
   ctx = canvas.getContext("2d");
+  const resizeCanvas = () => {
+    const rect = canvas.getBoundingClientRect();
+    dpr = window.devicePixelRatio || 1;
+    canvas.width = rect.width * dpr;
+    canvas.height = rect.height * dpr;
+    ctx.scale(dpr, dpr);
+  };
+  resizeCanvas();
   colorPicker = document.getElementById("colorPicker");
   lineWidth = document.getElementById("lineWidth");
   imageLoader = document.getElementById("imageLoader");
@@ -135,9 +150,9 @@ export function initEditor() {
     },
   );
 
-  canvas.addEventListener("mousedown", handleMouseDown);
-  canvas.addEventListener("mousemove", handleMouseMove);
-  canvas.addEventListener("mouseup", handleMouseUp);
+  canvas.addEventListener("pointerdown", handlePointerDown);
+  canvas.addEventListener("pointermove", handlePointerMove);
+  canvas.addEventListener("pointerup", handlePointerUp);
 
   imageLoader.addEventListener("change", handleImageLoad);
   saveBtn.onclick = handleSave;

--- a/style.css
+++ b/style.css
@@ -13,6 +13,9 @@ body {
 }
 
 #canvas {
+  width: 800px;
+  height: 600px;
   border: 1px solid #000;
   cursor: crosshair;
+  touch-action: none;
 }


### PR DESCRIPTION
## Summary
- Size canvas via CSS instead of width/height attributes
- Switch to pointer events for unified mouse/touch input
- Scale canvas using device pixel ratio for sharper rendering

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689aed7e5908832880593e3174e5e17d