### PR TITLE
Resize canvas via CSS and handle pixel ratio

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
       <button id="redo">Redo</button>
       <button id="save">Save</button>
     </div>
-    <canvas id="canvas" width="800" height="600"></canvas>
+    <canvas id="canvas"></canvas>
     <script type="module" src="dist/index.js"></script>
   </body>
 </html>

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -20,6 +20,8 @@ export class Editor {
     this.ctx = ctx;
     this.colorPicker = colorPicker;
     this.lineWidth = lineWidth;
+    this.adjustForPixelRatio();
+    window.addEventListener("resize", this.handleResize);
 
     this.canvas.addEventListener("pointerdown", this.handlePointerDown);
     this.canvas.addEventListener("pointermove", this.handlePointerMove);
@@ -41,6 +43,30 @@ export class Editor {
 
   private handlePointerUp = (e: PointerEvent) => {
     this.currentTool?.onPointerUp(e, this);
+  };
+
+  private adjustForPixelRatio() {
+    const dpr = window.devicePixelRatio || 1;
+    const rect = this.canvas.getBoundingClientRect();
+    this.canvas.width = rect.width * dpr;
+    this.canvas.height = rect.height * dpr;
+    this.ctx.scale(dpr, dpr);
+  }
+
+  private handleResize = () => {
+    const data = this.canvas.toDataURL();
+    this.adjustForPixelRatio();
+    const img = new Image();
+    img.src = data;
+    img.onload = () => {
+      this.ctx.drawImage(
+        img,
+        0,
+        0,
+        this.canvas.clientWidth,
+        this.canvas.clientHeight,
+      );
+    };
   };
 
   saveState() {

--- a/style.css
+++ b/style.css
@@ -1,8 +1,12 @@
+html,
+body {
+  height: 100%;
+}
+
 body {
   margin: 0;
   display: flex;
   flex-direction: column;
-  align-items: center;
 }
 
 #toolbar {
@@ -15,4 +19,7 @@ body {
 #canvas {
   border: 1px solid #000;
   cursor: crosshair;
+  width: 100%;
+  height: 100%;
+  flex: 1;
 }


### PR DESCRIPTION
## Summary
- Remove fixed canvas width and height attributes from HTML
- Style canvas via CSS to fill available space
- Adjust canvas for device pixel ratio and redraw content on window resize

## Testing
- `npm test` *(fails: Cannot find module '../src/editor')*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any in tests)*

------
https://chatgpt.com/codex/tasks/task_e_689afbc5783c8328b2962723c5aea54b