### PR TITLE
Rewrite editor test for pointer events and undo/redo

### DIFF
--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -1,24 +1,24 @@
-import { initEditor } from "../src/editor";
+import { Editor } from "../src/core/Editor";
+import { PencilTool } from "../src/tools/PencilTool";
 
-describe("editor", () => {
+class TestPointerEvent extends MouseEvent {
+  constructor(type: string, props?: any) {
+    super(type, props);
+  }
+}
+
+(global as any).PointerEvent = TestPointerEvent;
+
+describe("Editor", () => {
   let canvas: HTMLCanvasElement;
   let ctx: any;
+  let editor: Editor;
 
   beforeEach(() => {
     document.body.innerHTML = `
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
-      <input id="imageLoader" />
-      <button id="save"></button>
-      <button id="undo"></button>
-      <button id="redo"></button>
-      <button id="pencil"></button>
-      <button id="eraser"></button>
-      <button id="rectangle"></button>
-      <button id="line"></button>
-      <button id="circle"></button>
-      <button id="text"></button>
     `;
 
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
@@ -28,11 +28,11 @@ describe("editor", () => {
       moveTo: jest.fn(),
       lineTo: jest.fn(),
       stroke: jest.fn(),
+      closePath: jest.fn(),
       clearRect: jest.fn(),
       drawImage: jest.fn(),
-      arc: jest.fn(),
-      strokeRect: jest.fn(),
-      fillText: jest.fn(),
+      getImageData: jest.fn().mockReturnValue({}),
+      putImageData: jest.fn(),
     };
 
     canvas.getContext = jest.fn().mockReturnValue(ctx);
@@ -45,32 +45,40 @@ describe("editor", () => {
       }
     };
 
-    initEditor();
+    const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
+    const lineWidth = document.getElementById("lineWidth") as HTMLInputElement;
+
+    editor = new Editor(canvas, colorPicker, lineWidth);
+    editor.setTool(new PencilTool());
   });
 
-  function dispatch(type: string, x: number, y: number) {
-    const event = new MouseEvent(type, { bubbles: true } as MouseEventInit);
+  function dispatch(type: string, x: number, y: number, init: PointerEventInit = {}) {
+    const event = new PointerEvent(type, { bubbles: true, ...init });
     Object.defineProperty(event, "offsetX", { value: x });
     Object.defineProperty(event, "offsetY", { value: y });
     canvas.dispatchEvent(event);
   }
 
   it("draws and supports undo/redo", async () => {
-    dispatch("mousedown", 0, 0);
-    dispatch("mousemove", 10, 10);
-    dispatch("mouseup", 10, 10);
+    dispatch("pointerdown", 0, 0, { button: 0 });
+    dispatch("pointermove", 10, 10, { buttons: 1 });
+    dispatch("pointerup", 10, 10);
 
     expect(ctx.beginPath).toHaveBeenCalled();
     expect(ctx.moveTo).toHaveBeenCalledWith(0, 0);
     expect(ctx.lineTo).toHaveBeenCalledWith(10, 10);
     expect(ctx.stroke).toHaveBeenCalled();
+    expect(ctx.closePath).toHaveBeenCalled();
 
-    (document.getElementById("undo") as HTMLButtonElement).click();
+    editor.undo();
     await new Promise((r) => setTimeout(r, 0));
-    expect(ctx.drawImage).toHaveBeenCalledTimes(1);
+    const undoCalls = ctx.putImageData.mock.calls.length || ctx.drawImage.mock.calls.length;
+    expect(undoCalls).toBe(1);
 
-    (document.getElementById("redo") as HTMLButtonElement).click();
+    editor.redo();
     await new Promise((r) => setTimeout(r, 0));
-    expect(ctx.drawImage).toHaveBeenCalledTimes(2);
+    const redoCalls = ctx.putImageData.mock.calls.length || ctx.drawImage.mock.calls.length;
+    expect(redoCalls).toBe(2);
   });
 });
+


### PR DESCRIPTION
## Summary
- rewrite editor unit test to instantiate `Editor` from `src/core/Editor`
- use pointer events and mock canvas image data methods for undo/redo
- verify drawing plus undo/redo behavior with Jest assertions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689afbc273f0832899e1204fced78711