### PR TITLE
Enable TypeScript strict mode and linting in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,5 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - run: npm run lint
       - run: npm test

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,0 +1,34 @@
+import { Editor } from "./core/Editor";
+import { PencilTool } from "./tools/PencilTool";
+import { RectangleTool } from "./tools/RectangleTool";
+
+export function initEditor(): Editor {
+  const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+  const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
+  const lineWidth = document.getElementById("lineWidth") as HTMLInputElement;
+
+  const editor = new Editor(canvas, colorPicker, lineWidth);
+
+  const pencil = new PencilTool();
+  const rectangle = new RectangleTool();
+
+  editor.setTool(pencil);
+
+  document.getElementById("pencil")?.addEventListener("click", () =>
+    editor.setTool(pencil),
+  );
+
+  document.getElementById("rectangle")?.addEventListener("click", () =>
+    editor.setTool(rectangle),
+  );
+
+  document.getElementById("undo")?.addEventListener("click", () =>
+    editor.undo(),
+  );
+  document.getElementById("redo")?.addEventListener("click", () =>
+    editor.redo(),
+  );
+
+  return editor;
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,25 +1,4 @@
-import { Editor } from "./core/Editor";
-import { PencilTool } from "./tools/PencilTool";
-import { RectangleTool } from "./tools/RectangleTool";
+import { initEditor } from "./editor";
 
-const canvas = document.getElementById("canvas") as HTMLCanvasElement;
-const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
-const lineWidth = document.getElementById("lineWidth") as HTMLInputElement;
+initEditor();
 
-const editor = new Editor(canvas, colorPicker, lineWidth);
-
-const pencil = new PencilTool();
-const rectangle = new RectangleTool();
-
-editor.setTool(pencil);
-
-document.getElementById("pencil")?.addEventListener("click", () =>
-  editor.setTool(pencil),
-);
-
-document.getElementById("rectangle")?.addEventListener("click", () =>
-  editor.setTool(rectangle),
-);
-
-document.getElementById("undo")?.addEventListener("click", () => editor.undo());
-document.getElementById("redo")?.addEventListener("click", () => editor.redo());

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "node",
     "outDir": "dist",
     "rootDir": "src",
-    "strict": false,
+    "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "lib": ["ES2020", "DOM"]


### PR DESCRIPTION
## Summary
- turn on TypeScript strict mode
- check types during CI by running `npm run lint`
- add reusable `initEditor` helper for tests

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689afbc216fc8328a826e4d3147bb843