### PR TITLE
Introduce DrawingTool base class for shared styling

### DIFF
--- a/src/tools/DrawingTool.ts
+++ b/src/tools/DrawingTool.ts
@@ -1,0 +1,15 @@
+import { Editor } from "../core/Editor";
+import { Tool } from "./Tool";
+
+export abstract class DrawingTool implements Tool {
+  abstract onPointerDown(e: PointerEvent, editor: Editor): void;
+  abstract onPointerMove(e: PointerEvent, editor: Editor): void;
+  abstract onPointerUp(e: PointerEvent, editor: Editor): void;
+
+  protected applyStyles(editor: Editor) {
+    const ctx = editor.ctx;
+    ctx.lineWidth = editor.lineWidthValue;
+    ctx.strokeStyle = editor.strokeStyle;
+  }
+}
+

--- a/src/tools/PencilTool.ts
+++ b/src/tools/PencilTool.ts
@@ -1,7 +1,7 @@
 import { Editor } from "../core/Editor";
-import { Tool } from "./Tool";
+import { DrawingTool } from "./DrawingTool";
 
-export class PencilTool implements Tool {
+export class PencilTool extends DrawingTool {
   onPointerDown(e: PointerEvent, editor: Editor) {
     const ctx = editor.ctx;
     ctx.beginPath();
@@ -11,8 +11,7 @@ export class PencilTool implements Tool {
   onPointerMove(e: PointerEvent, editor: Editor) {
     if (e.buttons !== 1) return;
     const ctx = editor.ctx;
-    ctx.lineWidth = editor.lineWidthValue;
-    ctx.strokeStyle = editor.strokeStyle;
+    this.applyStyles(editor);
     ctx.lineTo(e.offsetX, e.offsetY);
     ctx.stroke();
   }

--- a/src/tools/RectangleTool.ts
+++ b/src/tools/RectangleTool.ts
@@ -1,7 +1,7 @@
 import { Editor } from "../core/Editor";
-import { Tool } from "./Tool";
+import { DrawingTool } from "./DrawingTool";
 
-export class RectangleTool implements Tool {
+export class RectangleTool extends DrawingTool {
   private startX = 0;
   private startY = 0;
 
@@ -19,8 +19,7 @@ export class RectangleTool implements Tool {
 
   onPointerUp(e: PointerEvent, editor: Editor) {
     const ctx = editor.ctx;
-    ctx.lineWidth = editor.lineWidthValue;
-    ctx.strokeStyle = editor.strokeStyle;
+    this.applyStyles(editor);
     const x = e.offsetX;
     const y = e.offsetY;
     ctx.strokeRect(this.startX, this.startY, x - this.startX, y - this.startY);

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -1,4 +1,7 @@
 import { initEditor } from "../src/editor";
+import { DrawingTool } from "../src/tools/DrawingTool";
+import { PencilTool } from "../src/tools/PencilTool";
+import { RectangleTool } from "../src/tools/RectangleTool";
 
 describe("editor", () => {
   let canvas: HTMLCanvasElement;
@@ -34,6 +37,7 @@ describe("editor", () => {
       arc: jest.fn(),
       strokeRect: jest.fn(),
       fillText: jest.fn(),
+      scale: jest.fn(),
     };
 
     canvas.getContext = jest
@@ -81,5 +85,12 @@ describe("editor", () => {
     (document.getElementById("redo") as HTMLButtonElement).click();
     await new Promise((r) => setTimeout(r, 0));
     expect(ctx.drawImage).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("tools", () => {
+  it("pencil and rectangle extend DrawingTool", () => {
+    expect(new PencilTool()).toBeInstanceOf(DrawingTool);
+    expect(new RectangleTool()).toBeInstanceOf(DrawingTool);
   });
 });


### PR DESCRIPTION
## Summary
- add `DrawingTool` abstract class with helper to apply stroke style and line width from the editor
- refactor `PencilTool` and `RectangleTool` to extend `DrawingTool`
- test that tools inherit the new base class

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b72d2f4d08328b3d7eb9fb1da2a9d