### PR TITLE
Use ImageData for canvas undo/redo

### DIFF
--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -3,8 +3,8 @@ import { Tool } from "../tools/Tool";
 export class Editor {
   canvas: HTMLCanvasElement;
   ctx: CanvasRenderingContext2D;
-  private undoStack: string[] = [];
-  private redoStack: string[] = [];
+  private undoStack: ImageData[] = [];
+  private redoStack: ImageData[] = [];
   private currentTool: Tool | null = null;
   colorPicker: HTMLInputElement;
   lineWidth: HTMLInputElement;
@@ -70,20 +70,21 @@ export class Editor {
   };
 
   saveState() {
-    this.undoStack.push(this.canvas.toDataURL());
+    this.undoStack.push(
+      this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height),
+    );
     if (this.undoStack.length > 50) this.undoStack.shift();
     this.redoStack.length = 0;
   }
 
-  private restoreState(stack: string[], opposite: string[]) {
+  private restoreState(stack: ImageData[], opposite: ImageData[]) {
     if (!stack.length) return;
-    opposite.push(this.canvas.toDataURL());
-    const img = new Image();
-    img.src = stack.pop()!;
-    img.onload = () => {
-      this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-      this.ctx.drawImage(img, 0, 0);
-    };
+    opposite.push(
+      this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height),
+    );
+    const imageData = stack.pop()!;
+    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    this.ctx.putImageData(imageData, 0, 0);
   }
 
   undo() {

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -31,6 +31,15 @@ describe("editor", () => {
       closePath: jest.fn(),
       clearRect: jest.fn(),
       drawImage: jest.fn(),
+      getImageData: jest
+        .fn()
+        .mockReturnValue({
+          data: new Uint8ClampedArray(),
+          width: 0,
+          height: 0,
+        } as ImageData),
+      putImageData: jest.fn(),
+      scale: jest.fn(),
       arc: jest.fn(),
       strokeRect: jest.fn(),
       fillText: jest.fn(),
@@ -39,19 +48,7 @@ describe("editor", () => {
     canvas.getContext = jest
       .fn()
       .mockReturnValue(ctx as CanvasRenderingContext2D);
-    canvas.toDataURL = jest.fn().mockReturnValue("data:image/png;base64,TEST");
-
-    class MockImage {
-      onload: () => void = () => {};
-      set src(_src: string) {
-        setTimeout(() => this.onload(), 0);
-      }
-    }
-
-    Object.defineProperty(globalThis, "Image", {
-      writable: true,
-      value: MockImage,
-    });
+    canvas.toDataURL = jest.fn();
 
     initEditor();
   });
@@ -75,11 +72,9 @@ describe("editor", () => {
     expect(ctx.stroke).toHaveBeenCalled();
 
     (document.getElementById("undo") as HTMLButtonElement).click();
-    await new Promise((r) => setTimeout(r, 0));
-    expect(ctx.drawImage).toHaveBeenCalledTimes(1);
+    expect(ctx.putImageData).toHaveBeenCalledTimes(1);
 
     (document.getElementById("redo") as HTMLButtonElement).click();
-    await new Promise((r) => setTimeout(r, 0));
-    expect(ctx.drawImage).toHaveBeenCalledTimes(2);
+    expect(ctx.putImageData).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- Store undo/redo history as `ImageData` instead of data URLs
- Capture canvas via `getImageData` and restore with `putImageData`
- Mock `getImageData`/`putImageData` in editor tests and verify undo/redo flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b72ce5b3483289e6b97a775b989da