### PR TITLE
Add editor destroy lifecycle method

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ npm test
 ```
 
 Open `index.html` in your browser to use the app.
+
+## Lifecycle
+
+The `Editor` instance returned from `initEditor()` attaches several event listeners. When the editor is no longer needed, call `editor.destroy()` to remove those listeners and clean up resources.

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -101,4 +101,11 @@ export class Editor {
   get lineWidthValue() {
     return parseInt(this.lineWidth.value, 10) || 1;
   }
+
+  destroy() {
+    window.removeEventListener("resize", this.handleResize);
+    this.canvas.removeEventListener("pointerdown", this.handlePointerDown);
+    this.canvas.removeEventListener("pointermove", this.handlePointerMove);
+    this.canvas.removeEventListener("pointerup", this.handlePointerUp);
+  }
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -29,6 +29,7 @@ export function initEditor(): Editor {
     editor.redo(),
   );
 
+  // Return the Editor instance so callers can clean up via editor.destroy().
   return editor;
 }
 

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -1,8 +1,10 @@
 import { initEditor } from "../src/editor";
+import { Editor } from "../src/core/Editor";
 
 describe("editor", () => {
   let canvas: HTMLCanvasElement;
   let ctx: Partial<CanvasRenderingContext2D>;
+  let editor: Editor | undefined;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -34,6 +36,7 @@ describe("editor", () => {
       arc: jest.fn(),
       strokeRect: jest.fn(),
       fillText: jest.fn(),
+      scale: jest.fn(),
     };
 
     canvas.getContext = jest
@@ -53,7 +56,11 @@ describe("editor", () => {
       value: MockImage,
     });
 
-    initEditor();
+    editor = initEditor();
+  });
+
+  afterEach(() => {
+    editor?.destroy();
   });
 
   function dispatch(type: string, x: number, y: number, buttons = 0) {


### PR DESCRIPTION
## Summary
- add `Editor.destroy` to detach canvas and window event listeners
- document cleanup requirement and return editor instance for destruction
- ensure tests tear down the editor after each run

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b72ce74bc8328b117556c50564f68