### PR TITLE
feat: add rectangle preview

### DIFF
--- a/src/tools/RectangleTool.ts
+++ b/src/tools/RectangleTool.ts
@@ -4,25 +4,36 @@ import { Tool } from "./Tool";
 export class RectangleTool implements Tool {
   private startX = 0;
   private startY = 0;
+  private imageData: ImageData | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor) {
-    void editor;
     this.startX = e.offsetX;
     this.startY = e.offsetY;
+    const ctx = editor.ctx;
+    this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
   }
 
   onPointerMove(e: PointerEvent, editor: Editor) {
-    // No preview implementation
-    void e;
-    void editor;
-  }
-
-  onPointerUp(e: PointerEvent, editor: Editor) {
+    if (e.buttons !== 1 || !this.imageData) return;
     const ctx = editor.ctx;
+    ctx.putImageData(this.imageData, 0, 0);
     ctx.lineWidth = editor.lineWidthValue;
     ctx.strokeStyle = editor.strokeStyle;
     const x = e.offsetX;
     const y = e.offsetY;
     ctx.strokeRect(this.startX, this.startY, x - this.startX, y - this.startY);
+  }
+
+  onPointerUp(e: PointerEvent, editor: Editor) {
+    const ctx = editor.ctx;
+    if (this.imageData) {
+      ctx.putImageData(this.imageData, 0, 0);
+    }
+    ctx.lineWidth = editor.lineWidthValue;
+    ctx.strokeStyle = editor.strokeStyle;
+    const x = e.offsetX;
+    const y = e.offsetY;
+    ctx.strokeRect(this.startX, this.startY, x - this.startX, y - this.startY);
+    this.imageData = null;
   }
 }

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -34,6 +34,9 @@ describe("editor", () => {
       arc: jest.fn(),
       strokeRect: jest.fn(),
       fillText: jest.fn(),
+      getImageData: jest.fn().mockReturnValue({} as ImageData),
+      putImageData: jest.fn(),
+      scale: jest.fn(),
     };
 
     canvas.getContext = jest
@@ -81,5 +84,16 @@ describe("editor", () => {
     (document.getElementById("redo") as HTMLButtonElement).click();
     await new Promise((r) => setTimeout(r, 0));
     expect(ctx.drawImage).toHaveBeenCalledTimes(2);
+  });
+
+  it("previews rectangle during pointer move", () => {
+    (document.getElementById("rectangle") as HTMLButtonElement).click();
+    dispatch("pointerdown", 1, 1, 1);
+    dispatch("pointermove", 3, 3, 1);
+
+    expect(ctx.getImageData).toHaveBeenCalled();
+    const imageData = (ctx.getImageData as jest.Mock).mock.results[0].value;
+    expect(ctx.putImageData).toHaveBeenCalledWith(imageData, 0, 0);
+    expect(ctx.strokeRect).toHaveBeenCalledWith(1, 1, 2, 2);
   });
 });


### PR DESCRIPTION
## Summary
- cache canvas image when starting a rectangle
- restore cached image to draw a preview rectangle while dragging
- test rectangle preview behavior during pointer movements

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b72cef3308328ab7f79a4b51ed452