### PR TITLE
Add line, circle, and text drawing tools with tests

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,6 +1,9 @@
 import { Editor } from "./core/Editor";
 import { PencilTool } from "./tools/PencilTool";
 import { RectangleTool } from "./tools/RectangleTool";
+import { LineTool } from "./tools/LineTool";
+import { CircleTool } from "./tools/CircleTool";
+import { TextTool } from "./tools/TextTool";
 
 export function initEditor(): Editor {
   const canvas = document.getElementById("canvas") as HTMLCanvasElement;
@@ -11,6 +14,9 @@ export function initEditor(): Editor {
 
   const pencil = new PencilTool();
   const rectangle = new RectangleTool();
+  const line = new LineTool();
+  const circle = new CircleTool();
+  const text = new TextTool();
 
   editor.setTool(pencil);
 
@@ -20,6 +26,18 @@ export function initEditor(): Editor {
 
   document.getElementById("rectangle")?.addEventListener("click", () =>
     editor.setTool(rectangle),
+  );
+
+  document.getElementById("line")?.addEventListener("click", () =>
+    editor.setTool(line),
+  );
+
+  document.getElementById("circle")?.addEventListener("click", () =>
+    editor.setTool(circle),
+  );
+
+  document.getElementById("text")?.addEventListener("click", () =>
+    editor.setTool(text),
   );
 
   document.getElementById("undo")?.addEventListener("click", () =>

--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -1,0 +1,30 @@
+import { Editor } from "../core/Editor";
+import { Tool } from "./Tool";
+
+export class CircleTool implements Tool {
+  private startX = 0;
+  private startY = 0;
+
+  onPointerDown(e: PointerEvent, _editor: Editor) {
+    this.startX = e.offsetX;
+    this.startY = e.offsetY;
+  }
+
+  onPointerMove(_e: PointerEvent, _editor: Editor) {
+    // No preview implementation
+  }
+
+  onPointerUp(e: PointerEvent, editor: Editor) {
+    const ctx = editor.ctx;
+    ctx.lineWidth = editor.lineWidthValue;
+    ctx.strokeStyle = editor.strokeStyle;
+    const dx = e.offsetX - this.startX;
+    const dy = e.offsetY - this.startY;
+    const radius = Math.sqrt(dx * dx + dy * dy);
+    ctx.beginPath();
+    ctx.arc(this.startX, this.startY, radius, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.closePath();
+  }
+}
+

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -1,0 +1,28 @@
+import { Editor } from "../core/Editor";
+import { Tool } from "./Tool";
+
+export class LineTool implements Tool {
+  private startX = 0;
+  private startY = 0;
+
+  onPointerDown(e: PointerEvent, _editor: Editor) {
+    this.startX = e.offsetX;
+    this.startY = e.offsetY;
+  }
+
+  onPointerMove(_e: PointerEvent, _editor: Editor) {
+    // No preview implementation
+  }
+
+  onPointerUp(e: PointerEvent, editor: Editor) {
+    const ctx = editor.ctx;
+    ctx.lineWidth = editor.lineWidthValue;
+    ctx.strokeStyle = editor.strokeStyle;
+    ctx.beginPath();
+    ctx.moveTo(this.startX, this.startY);
+    ctx.lineTo(e.offsetX, e.offsetY);
+    ctx.stroke();
+    ctx.closePath();
+  }
+}
+

--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -1,0 +1,22 @@
+import { Editor } from "../core/Editor";
+import { Tool } from "./Tool";
+
+export class TextTool implements Tool {
+  onPointerDown(e: PointerEvent, editor: Editor) {
+    const text = prompt("Enter text:") ?? "";
+    if (!text) return;
+    const ctx = editor.ctx;
+    ctx.fillStyle = editor.strokeStyle;
+    ctx.font = `${editor.lineWidthValue * 4}px sans-serif`;
+    ctx.fillText(text, e.offsetX, e.offsetY);
+  }
+
+  onPointerMove(_e: PointerEvent, _editor: Editor) {
+    // No operation
+  }
+
+  onPointerUp(_e: PointerEvent, _editor: Editor) {
+    // No operation
+  }
+}
+

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -34,6 +34,7 @@ describe("editor", () => {
       arc: jest.fn(),
       strokeRect: jest.fn(),
       fillText: jest.fn(),
+      scale: jest.fn(),
     };
 
     canvas.getContext = jest
@@ -81,5 +82,38 @@ describe("editor", () => {
     (document.getElementById("redo") as HTMLButtonElement).click();
     await new Promise((r) => setTimeout(r, 0));
     expect(ctx.drawImage).toHaveBeenCalledTimes(2);
+  });
+
+  it("draws a line", () => {
+    (document.getElementById("line") as HTMLButtonElement).click();
+    dispatch("pointerdown", 0, 0, 1);
+    dispatch("pointerup", 5, 5, 0);
+
+    expect(ctx.beginPath).toHaveBeenCalled();
+    expect(ctx.moveTo).toHaveBeenCalledWith(0, 0);
+    expect(ctx.lineTo).toHaveBeenCalledWith(5, 5);
+    expect(ctx.stroke).toHaveBeenCalled();
+  });
+
+  it("draws a circle", () => {
+    (document.getElementById("circle") as HTMLButtonElement).click();
+    dispatch("pointerdown", 0, 0, 1);
+    dispatch("pointerup", 3, 4, 0);
+
+    expect(ctx.beginPath).toHaveBeenCalled();
+    expect(ctx.arc).toHaveBeenCalledWith(0, 0, 5, 0, Math.PI * 2);
+    expect(ctx.stroke).toHaveBeenCalled();
+  });
+
+  it("draws text", () => {
+    (document.getElementById("text") as HTMLButtonElement).click();
+    const promptSpy = jest
+      .spyOn(window, "prompt")
+      .mockReturnValue("Hello");
+    dispatch("pointerdown", 10, 20, 1);
+
+    expect(promptSpy).toHaveBeenCalled();
+    expect(ctx.fillText).toHaveBeenCalledWith("Hello", 10, 20);
+    promptSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- implement `LineTool`, `CircleTool`, and `TextTool` classes
- wire new tools into editor and button bindings
- extend editor tests for line, circle, and text drawing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b72d08550832898e5192f917da9cb