### PR TITLE
Add canvas download feature with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A simple Photoshop-like web application built with HTML5 Canvas, CSS, and JavaSc
 - Pencil tool for freehand drawing
 - Rectangle tool for shape creation
 - Undo/redo support
+- Save canvas as PNG
 
 ## Planned Features
 
@@ -17,7 +18,6 @@ A simple Photoshop-like web application built with HTML5 Canvas, CSS, and JavaSc
 - Text insertion
 - Color picker and line width control
 - Load external images onto the canvas
-- Save canvas as PNG
 
 ## Build and Test
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -4,7 +4,9 @@ import { RectangleTool } from "./tools/RectangleTool";
 
 export function initEditor(): Editor {
   const canvas = document.getElementById("canvas") as HTMLCanvasElement;
-  const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
+  const colorPicker = document.getElementById(
+    "colorPicker",
+  ) as HTMLInputElement;
   const lineWidth = document.getElementById("lineWidth") as HTMLInputElement;
 
   const editor = new Editor(canvas, colorPicker, lineWidth);
@@ -14,21 +16,28 @@ export function initEditor(): Editor {
 
   editor.setTool(pencil);
 
-  document.getElementById("pencil")?.addEventListener("click", () =>
-    editor.setTool(pencil),
-  );
+  document
+    .getElementById("pencil")
+    ?.addEventListener("click", () => editor.setTool(pencil));
 
-  document.getElementById("rectangle")?.addEventListener("click", () =>
-    editor.setTool(rectangle),
-  );
+  document
+    .getElementById("rectangle")
+    ?.addEventListener("click", () => editor.setTool(rectangle));
 
-  document.getElementById("undo")?.addEventListener("click", () =>
-    editor.undo(),
-  );
-  document.getElementById("redo")?.addEventListener("click", () =>
-    editor.redo(),
-  );
+  document
+    .getElementById("undo")
+    ?.addEventListener("click", () => editor.undo());
+  document
+    .getElementById("redo")
+    ?.addEventListener("click", () => editor.redo());
+
+  document.getElementById("save")?.addEventListener("click", () => {
+    const dataUrl = canvas.toDataURL("image/png");
+    const link = document.createElement("a");
+    link.download = "canvas.png";
+    link.href = dataUrl;
+    link.click();
+  });
 
   return editor;
 }
-

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -34,6 +34,7 @@ describe("editor", () => {
       arc: jest.fn(),
       strokeRect: jest.fn(),
       fillText: jest.fn(),
+      scale: jest.fn(),
     };
 
     canvas.getContext = jest
@@ -81,5 +82,10 @@ describe("editor", () => {
     (document.getElementById("redo") as HTMLButtonElement).click();
     await new Promise((r) => setTimeout(r, 0));
     expect(ctx.drawImage).toHaveBeenCalledTimes(2);
+  });
+
+  it("calls toDataURL when Save is clicked", () => {
+    (document.getElementById("save") as HTMLButtonElement).click();
+    expect(canvas.toDataURL).toHaveBeenCalledWith("image/png");
   });
 });


### PR DESCRIPTION
## Summary
- Add Save button handler to export canvas as PNG
- Document saving feature in README
- Test Save invokes canvas.toDataURL

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b72d193c083288e0ed4fb8a880ef5