### PR TITLE
Add tool and image tests with coverage configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,16 @@
         "useESM": true
       }
     },
-    "extensionsToTreatAsEsm": [".ts"]
+    "extensionsToTreatAsEsm": [".ts"],
+    "collectCoverage": true,
+    "collectCoverageFrom": ["src/**/*.ts"],
+    "coverageThreshold": {
+      "global": {
+        "branches": 20,
+        "functions": 60,
+        "lines": 70,
+        "statements": 70
+      }
+    }
   }
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,6 +1,7 @@
 import { Editor } from "./core/Editor";
 import { PencilTool } from "./tools/PencilTool";
 import { RectangleTool } from "./tools/RectangleTool";
+import { EraserTool } from "./tools/EraserTool";
 
 export function initEditor(): Editor {
   const canvas = document.getElementById("canvas") as HTMLCanvasElement;
@@ -11,6 +12,7 @@ export function initEditor(): Editor {
 
   const pencil = new PencilTool();
   const rectangle = new RectangleTool();
+  const eraser = new EraserTool();
 
   editor.setTool(pencil);
 
@@ -22,12 +24,40 @@ export function initEditor(): Editor {
     editor.setTool(rectangle),
   );
 
+  document.getElementById("eraser")?.addEventListener("click", () =>
+    editor.setTool(eraser),
+  );
+
   document.getElementById("undo")?.addEventListener("click", () =>
     editor.undo(),
   );
   document.getElementById("redo")?.addEventListener("click", () =>
     editor.redo(),
   );
+
+  const imageLoader = document.getElementById("imageLoader") as
+    | HTMLInputElement
+    | null;
+  imageLoader?.addEventListener("change", (e) => {
+    const file = (e.target as HTMLInputElement).files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.src = reader.result as string;
+      img.onload = () => {
+        editor.ctx.drawImage(img, 0, 0);
+      };
+    };
+    reader.readAsDataURL(file);
+  });
+
+  document.getElementById("save")?.addEventListener("click", () => {
+    const link = document.createElement("a");
+    link.href = editor.canvas.toDataURL("image/png");
+    link.download = "canvas.png";
+    link.click();
+  });
 
   return editor;
 }

--- a/src/tools/EraserTool.ts
+++ b/src/tools/EraserTool.ts
@@ -1,0 +1,23 @@
+import { Editor } from "../core/Editor";
+import { Tool } from "./Tool";
+
+export class EraserTool implements Tool {
+  private erase(e: PointerEvent, editor: Editor) {
+    const size = editor.lineWidthValue;
+    const half = size / 2;
+    editor.ctx.clearRect(e.offsetX - half, e.offsetY - half, size, size);
+  }
+
+  onPointerDown(e: PointerEvent, editor: Editor) {
+    this.erase(e, editor);
+  }
+
+  onPointerMove(e: PointerEvent, editor: Editor) {
+    if (e.buttons !== 1) return;
+    this.erase(e, editor);
+  }
+
+  onPointerUp(_e: PointerEvent, _editor: Editor) {
+    // nothing to do
+  }
+}

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -34,6 +34,7 @@ describe("editor", () => {
       arc: jest.fn(),
       strokeRect: jest.fn(),
       fillText: jest.fn(),
+      scale: jest.fn(),
     };
 
     canvas.getContext = jest

--- a/tests/eraserTool.test.ts
+++ b/tests/eraserTool.test.ts
@@ -1,0 +1,43 @@
+import { Editor } from "../src/core/Editor";
+import { EraserTool } from "../src/tools/EraserTool";
+
+describe("EraserTool", () => {
+  let editor: Editor;
+  let ctx: Partial<CanvasRenderingContext2D>;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <canvas id="canvas"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="10" />
+    `;
+    const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    ctx = {
+      clearRect: jest.fn(),
+      scale: jest.fn(),
+    };
+    canvas.getContext = jest
+      .fn()
+      .mockReturnValue(ctx as CanvasRenderingContext2D);
+    editor = new Editor(
+      canvas,
+      document.getElementById("colorPicker") as HTMLInputElement,
+      document.getElementById("lineWidth") as HTMLInputElement,
+    );
+  });
+
+  it("clears the area under the cursor", () => {
+    const tool = new EraserTool();
+    tool.onPointerDown({ offsetX: 15, offsetY: 15 } as PointerEvent, editor);
+    expect(ctx.clearRect).toHaveBeenCalledWith(10, 10, 10, 10);
+  });
+
+  it("erases on pointer move when pressed", () => {
+    const tool = new EraserTool();
+    tool.onPointerMove(
+      { offsetX: 20, offsetY: 20, buttons: 1 } as PointerEvent,
+      editor,
+    );
+    expect(ctx.clearRect).toHaveBeenCalledWith(15, 15, 10, 10);
+  });
+});

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -1,0 +1,67 @@
+import { initEditor } from "../src/editor";
+
+describe("image operations", () => {
+  let canvas: HTMLCanvasElement;
+  let ctx: Partial<CanvasRenderingContext2D>;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <canvas id="canvas"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="2" />
+      <input id="imageLoader" type="file" />
+      <button id="save"></button>
+    `;
+    canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    ctx = { drawImage: jest.fn(), scale: jest.fn() };
+    canvas.getContext = jest
+      .fn()
+      .mockReturnValue(ctx as CanvasRenderingContext2D);
+    canvas.toDataURL = jest.fn().mockReturnValue("data:img/png;base64,SAVE");
+
+    const readSpy = jest.fn().mockImplementation(function (this: MockFileReader) {
+      this.result = "data:image/png;base64,LOAD";
+      this.onload();
+    });
+    class MockFileReader {
+      result: string | ArrayBuffer | null = null;
+      onload: () => void = () => {};
+      readAsDataURL = readSpy;
+    }
+    (global as any).FileReader = MockFileReader;
+
+    class MockImage {
+      onload: () => void = () => {};
+      set src(_src: string) {
+        setTimeout(() => this.onload(), 0);
+      }
+    }
+    (global as any).Image = MockImage;
+
+    initEditor();
+
+    (global as any).readSpy = readSpy;
+  });
+
+  it("loads an image from input", async () => {
+    const file = new File([""], "test.png", { type: "image/png" });
+    const loader = document.getElementById("imageLoader") as HTMLInputElement;
+    Object.defineProperty(loader, "files", { value: [file], configurable: true });
+    loader.dispatchEvent(new Event("change"));
+    await new Promise((r) => setTimeout(r, 0));
+    expect((global as any).readSpy).toHaveBeenCalled();
+    expect(ctx.drawImage).toHaveBeenCalled();
+  });
+
+  it("saves the canvas as an image", () => {
+    const click = jest.fn();
+    const anchor = { href: "", download: "", click } as any;
+    jest.spyOn(document, "createElement").mockReturnValue(anchor);
+    const save = document.getElementById("save") as HTMLButtonElement;
+    save.click();
+    expect(canvas.toDataURL).toHaveBeenCalledWith("image/png");
+    expect(anchor.href).toBe("data:img/png;base64,SAVE");
+    expect(anchor.download).toBe("canvas.png");
+    expect(click).toHaveBeenCalled();
+  });
+});

--- a/tests/rectangleTool.test.ts
+++ b/tests/rectangleTool.test.ts
@@ -1,0 +1,35 @@
+import { Editor } from "../src/core/Editor";
+import { RectangleTool } from "../src/tools/RectangleTool";
+
+describe("RectangleTool", () => {
+  let editor: Editor;
+  let ctx: Partial<CanvasRenderingContext2D>;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <canvas id="canvas"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="2" />
+    `;
+    const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    ctx = {
+      strokeRect: jest.fn(),
+      scale: jest.fn(),
+    };
+    canvas.getContext = jest
+      .fn()
+      .mockReturnValue(ctx as CanvasRenderingContext2D);
+    editor = new Editor(
+      canvas,
+      document.getElementById("colorPicker") as HTMLInputElement,
+      document.getElementById("lineWidth") as HTMLInputElement,
+    );
+  });
+
+  it("draws a rectangle on pointer up", () => {
+    const tool = new RectangleTool();
+    tool.onPointerDown({ offsetX: 10, offsetY: 15 } as PointerEvent, editor);
+    tool.onPointerUp({ offsetX: 20, offsetY: 25 } as PointerEvent, editor);
+    expect(ctx.strokeRect).toHaveBeenCalledWith(10, 15, 10, 10);
+  });
+});


### PR DESCRIPTION
## Summary
- add eraser tool and hook up eraser, image load, and save handlers
- test rectangle and eraser tools as well as image load/save logic
- enable jest coverage collection with global thresholds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b72d3d8f883288d041d2592e562d2