### PR TITLE
Add canvas download capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A simple Photoshop-like web application built with HTML5 Canvas, CSS, and JavaSc
 - Pencil tool for freehand drawing
 - Rectangle tool for shape creation
 - Undo/redo support
+- Save canvas as PNG
 
 ## Planned Features
 
@@ -17,7 +18,6 @@ A simple Photoshop-like web application built with HTML5 Canvas, CSS, and JavaSc
 - Text insertion
 - Color picker and line width control
 - Load external images onto the canvas
-- Save canvas as PNG
 
 ## Build and Test
 
@@ -29,3 +29,4 @@ npm test
 ```
 
 Open `index.html` in your browser to use the app.
+Click the **Save** button to download your drawing as a PNG file.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,15 @@
 import { initEditor } from "./editor";
 
-initEditor();
+const editor = initEditor();
+
+const saveButton = document.getElementById("save");
+saveButton?.addEventListener("click", () => {
+  const dataUrl = editor.canvas.toDataURL("image/png");
+  const link = document.createElement("a");
+  link.href = dataUrl;
+  link.download = "canvas.png";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+});
 

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -23,18 +23,19 @@ describe("editor", () => {
 
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
 
-    ctx = {
-      beginPath: jest.fn(),
-      moveTo: jest.fn(),
-      lineTo: jest.fn(),
-      stroke: jest.fn(),
-      closePath: jest.fn(),
-      clearRect: jest.fn(),
-      drawImage: jest.fn(),
-      arc: jest.fn(),
-      strokeRect: jest.fn(),
-      fillText: jest.fn(),
-    };
+      ctx = {
+        beginPath: jest.fn(),
+        moveTo: jest.fn(),
+        lineTo: jest.fn(),
+        stroke: jest.fn(),
+        closePath: jest.fn(),
+        clearRect: jest.fn(),
+        drawImage: jest.fn(),
+        arc: jest.fn(),
+        strokeRect: jest.fn(),
+        fillText: jest.fn(),
+        scale: jest.fn(),
+      };
 
     canvas.getContext = jest
       .fn()

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, beforeEach, jest } from "@jest/globals";
+
+describe("save", () => {
+  let canvas: HTMLCanvasElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <canvas id="canvas"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="2" />
+      <input id="imageLoader" />
+      <button id="save"></button>
+      <button id="undo"></button>
+      <button id="redo"></button>
+      <button id="pencil"></button>
+      <button id="eraser"></button>
+      <button id="rectangle"></button>
+      <button id="line"></button>
+      <button id="circle"></button>
+      <button id="text"></button>
+    `;
+
+    canvas = document.getElementById("canvas") as HTMLCanvasElement;
+
+    canvas.getContext = jest
+      .fn()
+      .mockReturnValue({ scale: jest.fn() } as unknown as CanvasRenderingContext2D) as unknown as typeof canvas.getContext;
+
+    canvas.toDataURL = jest
+      .fn()
+      .mockReturnValue("data:image/png;base64,TEST") as unknown as typeof canvas.toDataURL;
+  });
+
+  it("downloads canvas as PNG when save clicked", async () => {
+    const clickMock = jest.fn();
+
+    const createElementOrig = document.createElement.bind(document);
+    const createElementSpy = jest
+      .spyOn(document, "createElement")
+      .mockImplementation((tagName: string) => {
+        const element = createElementOrig(tagName) as HTMLElement;
+        if (tagName.toLowerCase() === "a") {
+          (element as HTMLAnchorElement).click = clickMock;
+        }
+        return element;
+      });
+
+    await import("../src/index");
+
+    (document.getElementById("save") as HTMLButtonElement).click();
+
+    expect(canvas.toDataURL).toHaveBeenCalledWith("image/png");
+    expect(clickMock).toHaveBeenCalled();
+
+    createElementSpy.mockRestore();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add click handler to export canvas as PNG via temporary anchor
- document save functionality in README
- cover save feature with tests

## Testing
- `npm run build`
- `npm run lint`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b0cd5d1a4832899c878335aea866d