### PR TITLE
Add eraser tool and simplify toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,10 +13,6 @@
       <button id="pencil">Pencil</button>
       <button id="eraser">Eraser</button>
       <button id="rectangle">Rectangle</button>
-      <button id="line">Line</button>
-      <button id="circle">Circle</button>
-      <button id="text">Text</button>
-      <input type="file" id="imageLoader" accept="image/*" />
       <button id="undo">Undo</button>
       <button id="redo">Redo</button>
       <button id="save">Save</button>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
 import { initEditor } from "./editor";
+import { EraserTool } from "./tools/EraserTool";
 
-initEditor();
+const editor = initEditor();
+
+const eraser = new EraserTool();
+document.getElementById("eraser")?.addEventListener("click", () =>
+  editor.setTool(eraser),
+);
 

--- a/src/tools/EraserTool.ts
+++ b/src/tools/EraserTool.ts
@@ -1,0 +1,26 @@
+import { Editor } from "../core/Editor";
+import { Tool } from "./Tool";
+
+export class EraserTool implements Tool {
+  onPointerDown(e: PointerEvent, editor: Editor) {
+    const ctx = editor.ctx;
+    ctx.save();
+    ctx.globalCompositeOperation = "destination-out";
+    ctx.beginPath();
+    ctx.moveTo(e.offsetX, e.offsetY);
+  }
+
+  onPointerMove(e: PointerEvent, editor: Editor) {
+    if (e.buttons !== 1) return;
+    const ctx = editor.ctx;
+    ctx.lineWidth = editor.lineWidthValue;
+    ctx.lineTo(e.offsetX, e.offsetY);
+    ctx.stroke();
+  }
+
+  onPointerUp(_e: PointerEvent, editor: Editor) {
+    const ctx = editor.ctx;
+    ctx.closePath();
+    ctx.restore();
+  }
+}

--- a/style.css
+++ b/style.css
@@ -16,6 +16,13 @@ body {
   margin: 10px;
 }
 
+#line,
+#circle,
+#text,
+#imageLoader {
+  display: none;
+}
+
 #canvas {
   border: 1px solid #000;
   cursor: crosshair;

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -9,16 +9,12 @@ describe("editor", () => {
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
-      <input id="imageLoader" />
       <button id="save"></button>
       <button id="undo"></button>
       <button id="redo"></button>
       <button id="pencil"></button>
       <button id="eraser"></button>
       <button id="rectangle"></button>
-      <button id="line"></button>
-      <button id="circle"></button>
-      <button id="text"></button>
     `;
 
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
@@ -34,6 +30,9 @@ describe("editor", () => {
       arc: jest.fn(),
       strokeRect: jest.fn(),
       fillText: jest.fn(),
+      scale: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
     };
 
     canvas.getContext = jest


### PR DESCRIPTION
## Summary
- Add EraserTool that erases using transparent strokes
- Hook up eraser button and remove placeholder buttons for unfinished tools
- Update styles and tests to match the available toolset

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b0cd9276c8328883a3651d6eef098