### PR TITLE
chore: add type checking to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,5 @@ jobs:
           cache: npm
       - run: npm install
       - run: npm run lint
+      - run: npm run typecheck
       - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,5 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run lint
+      - run: npm run typecheck
       - run: npm test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "node dist/index.js",
     "lint": "eslint . --ext .ts",
     "format": "prettier --write .",
-    "test": "jest"
+    "typecheck": "tsc --noEmit",
+    "test": "npm run typecheck && jest"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.0",


### PR DESCRIPTION
## Summary
- add a dedicated `typecheck` script
- run type checking in CI workflows

## Testing
- `npm run typecheck`
- `npm test` *(fails: this.ctx.scale is not a function)*


------
https://chatgpt.com/codex/tasks/task_e_689b0cdc75348328b1bd714f6906a345