### PR TITLE
Use ImageData for history stacks

### DIFF
--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -30,29 +30,21 @@ describe("editor", () => {
       stroke: jest.fn(),
       closePath: jest.fn(),
       clearRect: jest.fn(),
-      drawImage: jest.fn(),
+      putImageData: jest.fn(),
+      getImageData: jest.fn(() => ({
+        data: new Uint8ClampedArray(),
+        width: 1,
+        height: 1,
+      } as ImageData)),
       arc: jest.fn(),
       strokeRect: jest.fn(),
       fillText: jest.fn(),
+      scale: jest.fn(),
     };
 
     canvas.getContext = jest
       .fn()
       .mockReturnValue(ctx as CanvasRenderingContext2D);
-    canvas.toDataURL = jest.fn().mockReturnValue("data:image/png;base64,TEST");
-
-    class MockImage {
-      onload: () => void = () => {};
-      set src(_src: string) {
-        setTimeout(() => this.onload(), 0);
-      }
-    }
-
-    Object.defineProperty(globalThis, "Image", {
-      writable: true,
-      value: MockImage,
-    });
-
     initEditor();
   });
 
@@ -75,11 +67,9 @@ describe("editor", () => {
     expect(ctx.stroke).toHaveBeenCalled();
 
     (document.getElementById("undo") as HTMLButtonElement).click();
-    await new Promise((r) => setTimeout(r, 0));
-    expect(ctx.drawImage).toHaveBeenCalledTimes(1);
+    expect(ctx.putImageData).toHaveBeenCalledTimes(1);
 
     (document.getElementById("redo") as HTMLButtonElement).click();
-    await new Promise((r) => setTimeout(r, 0));
-    expect(ctx.drawImage).toHaveBeenCalledTimes(2);
+    expect(ctx.putImageData).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- store undo/redo history as `ImageData` instead of data URLs
- restore canvas state via `getImageData`/`putImageData` and cap history length at 20
- update tests to expect `putImageData`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b0cdd3fec832899ade41e2a77c277