### PR TITLE
feat: add editor cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,11 @@ Open `index.html` in your browser to use the app.
 
 ## Lifecycle
 
-The `Editor` instance returned from `initEditor()` attaches several event listeners. When the editor is no longer needed, call `editor.destroy()` to remove those listeners and clean up resources.
+`initEditor()` returns an object containing the editor instance and a `destroy` function.
+Call this function when the editor is no longer needed to remove all event listeners and release resources.
+
+```ts
+const { editor, destroy } = initEditor();
+// ...use editor...
+destroy(); // cleanup when done
+```

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -103,7 +103,11 @@ export class Editor {
     return parseInt(this.lineWidth.value, 10) || 1;
   }
 
-  destroy() {
+  /**
+   * Remove all event listeners registered by the editor.
+   * Should be called before discarding the instance to prevent leaks.
+   */
+  destroy(): void {
     window.removeEventListener("resize", this.handleResize);
     this.canvas.removeEventListener("pointerdown", this.handlePointerDown);
     this.canvas.removeEventListener("pointermove", this.handlePointerMove);

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -3,12 +3,14 @@ import { PencilTool } from "./tools/PencilTool";
 import { RectangleTool } from "./tools/RectangleTool";
 import { EraserTool } from "./tools/EraserTool";
 
+export interface EditorHandle {
+  editor: Editor;
+  destroy: () => void;
+}
 
-export function initEditor(): Editor {
+export function initEditor(): EditorHandle {
   const canvas = document.getElementById("canvas") as HTMLCanvasElement;
-  const colorPicker = document.getElementById(
-    "colorPicker",
-  ) as HTMLInputElement;
+  const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
   const lineWidth = document.getElementById("lineWidth") as HTMLInputElement;
 
   const editor = new Editor(canvas, colorPicker, lineWidth);
@@ -17,12 +19,10 @@ export function initEditor(): Editor {
   const rectangle = new RectangleTool();
   const eraser = new EraserTool();
 
-
   editor.setTool(pencil);
 
-
-
-
-
-  return editor;
+  return {
+    editor,
+    destroy: () => editor.destroy(),
+  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { initEditor } from "./editor";
 
-initEditor();
+const { destroy } = initEditor();
+window.addEventListener("beforeunload", destroy);
 

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -1,8 +1,9 @@
-import { initEditor } from "../src/editor";
+import { initEditor, EditorHandle } from "../src/editor";
 
 describe("image operations", () => {
   let canvas: HTMLCanvasElement;
   let ctx: Partial<CanvasRenderingContext2D>;
+  let handle: EditorHandle;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -38,9 +39,13 @@ describe("image operations", () => {
     }
     (global as any).Image = MockImage;
 
-    initEditor();
+    handle = initEditor();
 
     (global as any).readSpy = readSpy;
+  });
+
+  afterEach(() => {
+    handle.destroy();
   });
 
   it("loads an image from input", async () => {


### PR DESCRIPTION
## Summary
- add destroy method to Editor to detach listeners
- return destroy handle from initEditor and clean up on unload
- document editor lifecycle and cleanup

## Testing
- `npm run build` *(fails: src/tools/EraserTool.ts(8,18): error TS1005: ',' expected)*
- `npm test` *(fails: tests/eraserTool.test.ts:31:10 - error TS2339: Property 'onPointerDown' does not exist on type 'EraserTool')*


------
https://chatgpt.com/codex/tasks/task_e_689b8c2067708328b63532a6f9d848e0