### PR TITLE
Support rectangle preview and integrate editor tools

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2,6 +2,9 @@ import { Editor } from "./core/Editor";
 import { PencilTool } from "./tools/PencilTool";
 import { RectangleTool } from "./tools/RectangleTool";
 import { EraserTool } from "./tools/EraserTool";
+import { LineTool } from "./tools/LineTool";
+import { CircleTool } from "./tools/CircleTool";
+import { TextTool } from "./tools/TextTool";
 
 
 export function initEditor(): Editor {
@@ -16,13 +19,78 @@ export function initEditor(): Editor {
   const pencil = new PencilTool();
   const rectangle = new RectangleTool();
   const eraser = new EraserTool();
-
+  const line = new LineTool();
+  const circle = new CircleTool();
+  const text = new TextTool();
 
   editor.setTool(pencil);
 
+  (document.getElementById("pencil") as HTMLButtonElement)?.addEventListener(
+    "click",
+    () => editor.setTool(pencil),
+  );
+  (document.getElementById("rectangle") as HTMLButtonElement)?.addEventListener(
+    "click",
+    () => editor.setTool(rectangle),
+  );
+  (document.getElementById("eraser") as HTMLButtonElement)?.addEventListener(
+    "click",
+    () => editor.setTool(eraser),
+  );
+  (document.getElementById("line") as HTMLButtonElement)?.addEventListener(
+    "click",
+    () => editor.setTool(line),
+  );
+  (document.getElementById("circle") as HTMLButtonElement)?.addEventListener(
+    "click",
+    () => editor.setTool(circle),
+  );
+  (document.getElementById("text") as HTMLButtonElement)?.addEventListener(
+    "click",
+    () => editor.setTool(text),
+  );
 
+  (document.getElementById("undo") as HTMLButtonElement)?.addEventListener(
+    "click",
+    () => editor.undo(),
+  );
+  (document.getElementById("redo") as HTMLButtonElement)?.addEventListener(
+    "click",
+    () => editor.redo(),
+  );
 
+  (document.getElementById("save") as HTMLButtonElement)?.addEventListener(
+    "click",
+    () => {
+      const data = canvas.toDataURL("image/png");
+      const a = document.createElement("a");
+      a.href = data;
+      a.download = "canvas.png";
+      a.click();
+    },
+  );
 
+  const loader = document.getElementById("imageLoader") as HTMLInputElement;
+  loader?.addEventListener("change", () => {
+    const file = loader.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        editor.ctx.drawImage(
+          img,
+          0,
+          0,
+          canvas.width,
+          canvas.height,
+        );
+        canvas.toDataURL();
+      };
+      img.src = reader.result as string;
+    };
+    reader.readAsDataURL(file);
+  });
 
   return editor;
 }

--- a/src/tools/EraserTool.ts
+++ b/src/tools/EraserTool.ts
@@ -2,9 +2,20 @@ import { Editor } from "../core/Editor";
 import { Tool } from "./Tool";
 
 export class EraserTool implements Tool {
+  private erase(e: PointerEvent, editor: Editor) {
+    const size = editor.lineWidthValue;
+    editor.ctx.clearRect(e.offsetX - size / 2, e.offsetY - size / 2, size, size);
+  }
 
+  onPointerDown(e: PointerEvent, editor: Editor) {
+    this.erase(e, editor);
   }
 
   onPointerMove(e: PointerEvent, editor: Editor) {
     if (e.buttons !== 1) return;
+    this.erase(e, editor);
+  }
 
+  // No special action on pointer up
+  onPointerUp(_e: PointerEvent, _editor: Editor) {}
+}

--- a/tests/rectangleTool.test.ts
+++ b/tests/rectangleTool.test.ts
@@ -15,6 +15,8 @@ describe("RectangleTool", () => {
     ctx = {
       strokeRect: jest.fn(),
       scale: jest.fn(),
+      getImageData: jest.fn().mockReturnValue({} as ImageData),
+      putImageData: jest.fn(),
     };
     canvas.getContext = jest
       .fn()
@@ -31,5 +33,16 @@ describe("RectangleTool", () => {
     tool.onPointerDown({ offsetX: 10, offsetY: 15 } as PointerEvent, editor);
     tool.onPointerUp({ offsetX: 20, offsetY: 25 } as PointerEvent, editor);
     expect(ctx.strokeRect).toHaveBeenCalledWith(10, 15, 10, 10);
+  });
+
+  it("previews rectangle on pointer move", () => {
+    const tool = new RectangleTool();
+    tool.onPointerDown({ offsetX: 5, offsetY: 5 } as PointerEvent, editor);
+    tool.onPointerMove(
+      { offsetX: 15, offsetY: 15, buttons: 1 } as unknown as PointerEvent,
+      editor,
+    );
+    expect(ctx.putImageData).toHaveBeenCalled();
+    expect(ctx.strokeRect).toHaveBeenCalledWith(5, 5, 10, 10);
   });
 });


### PR DESCRIPTION
## Summary
- Cache canvas state in RectangleTool to allow previewing rectangles while drawing
- Wire up editor with tool selection, saving, undo/redo and image loading handlers
- Add rectangle preview tests and update editor tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b8c218e0c8328a5e8f7a3f9afa00f