### PR TITLE
feat: add image loader

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -20,6 +20,30 @@ export function initEditor(): Editor {
 
   editor.setTool(pencil);
 
+  const imageLoader = document.getElementById("imageLoader") as HTMLInputElement;
+  if (imageLoader) {
+    imageLoader.addEventListener("change", () => {
+      const file = imageLoader.files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        const img = new Image();
+        img.onload = () => {
+          editor.saveState();
+          editor.ctx.drawImage(
+            img,
+            0,
+            0,
+            editor.canvas.width,
+            editor.canvas.height,
+          );
+        };
+        img.src = reader.result as string;
+      };
+      reader.readAsDataURL(file);
+    });
+  }
+
 
 
 

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -1,4 +1,5 @@
 import { initEditor } from "../src/editor";
+import { Editor } from "../src/core/Editor";
 
 describe("image operations", () => {
   let canvas: HTMLCanvasElement;
@@ -13,7 +14,11 @@ describe("image operations", () => {
       <button id="save"></button>
     `;
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
-    ctx = { drawImage: jest.fn(), scale: jest.fn() };
+    ctx = {
+      drawImage: jest.fn(),
+      scale: jest.fn(),
+      getImageData: jest.fn().mockReturnValue({}),
+    };
     canvas.getContext = jest
       .fn()
       .mockReturnValue(ctx as CanvasRenderingContext2D);
@@ -38,9 +43,11 @@ describe("image operations", () => {
     }
     (global as any).Image = MockImage;
 
+    const saveSpy = jest.spyOn(Editor.prototype, "saveState");
     initEditor();
 
     (global as any).readSpy = readSpy;
+    (global as any).saveSpy = saveSpy;
   });
 
   it("loads an image from input", async () => {
@@ -51,6 +58,7 @@ describe("image operations", () => {
     await new Promise((r) => setTimeout(r, 0));
     expect((global as any).readSpy).toHaveBeenCalled();
     expect(ctx.drawImage).toHaveBeenCalled();
+    expect((global as any).saveSpy).toHaveBeenCalled();
   });
 
   it("saves the canvas as an image", () => {


### PR DESCRIPTION
## Summary
- handle `#imageLoader` change to draw uploaded image on canvas
- save canvas state when image is loaded for undo
- test image load using mocked FileReader

## Testing
- `npm test` *(fails: TypeError: ctx.getImageData is not a function and EraserTool compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b8c2556f88328bbf80122440894e1