### PR TITLE
Implement canvas saving feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A simple Photoshop-like web application built with HTML5 Canvas, CSS, and JavaSc
 - Adjustable line width
 - Undo/redo support
 - Eraser tool for removing parts of your drawing
+- Save the canvas as a PNG image
 
 ## Planned Features
 
@@ -21,7 +22,7 @@ A simple Photoshop-like web application built with HTML5 Canvas, CSS, and JavaSc
 
 ## Usage
 
-Select a tool from the toolbar. Use the **Eraser** button to remove portions of your drawing.
+Select a tool from the toolbar. Use the **Eraser** button to remove portions of your drawing. Click **Save** to download the current canvas as an image.
 
 ## Build and Test
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -17,12 +17,15 @@ export function initEditor(): Editor {
   const rectangle = new RectangleTool();
   const eraser = new EraserTool();
 
-
   editor.setTool(pencil);
-
-
-
-
+  const save = document.getElementById("save") as HTMLButtonElement;
+  save.addEventListener("click", () => {
+    const data = canvas.toDataURL("image/png");
+    const link = document.createElement("a");
+    link.href = data;
+    link.download = "canvas.png";
+    link.click();
+  });
 
   return editor;
 }

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -1,0 +1,38 @@
+import { initEditor } from "../src/editor";
+
+describe("save button", () => {
+  it("calls toDataURL on click", () => {
+    document.body.innerHTML = `
+      <canvas id="canvas"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="2" />
+      <button id="save"></button>
+    `;
+
+    const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    const ctx = { scale: jest.fn(), getImageData: jest.fn(), putImageData: jest.fn(), clearRect: jest.fn() } as any;
+    canvas.getContext = jest.fn().mockReturnValue(ctx);
+    canvas.toDataURL = jest.fn().mockReturnValue("data:image/png;base64,TEST");
+    canvas.getBoundingClientRect = () => ({
+      width: 100,
+      height: 100,
+      top: 0,
+      left: 0,
+      bottom: 0,
+      right: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+
+    const click = jest.fn();
+    const anchor = { href: "", download: "", click } as any;
+    jest.spyOn(document, "createElement").mockReturnValue(anchor);
+
+    initEditor();
+
+    (document.getElementById("save") as HTMLButtonElement).click();
+    expect(canvas.toDataURL).toHaveBeenCalledWith("image/png");
+    expect(click).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add click handler for Save to export canvas PNG via temporary anchor link
- document Save button usage
- test Save button invokes `toDataURL`

## Testing
- `npm run build` *(fails: src/tools/EraserTool.ts parse errors)*
- `npm test` *(fails: TypeScript errors in EraserTool and tests)*
- `npm run lint` *(fails: various lint errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_689b8c26a024832897ce7ebf3840c05c