### PR TITLE
Implement path-based eraser tool

### DIFF
--- a/src/tools/EraserTool.ts
+++ b/src/tools/EraserTool.ts
@@ -2,9 +2,25 @@ import { Editor } from "../core/Editor";
 import { Tool } from "./Tool";
 
 export class EraserTool implements Tool {
-
+  onPointerDown(e: PointerEvent, editor: Editor) {
+    const ctx = editor.ctx;
+    ctx.globalCompositeOperation = "destination-out";
+    ctx.beginPath();
+    ctx.moveTo(e.offsetX, e.offsetY);
   }
 
   onPointerMove(e: PointerEvent, editor: Editor) {
     if (e.buttons !== 1) return;
+    const ctx = editor.ctx;
+    ctx.lineWidth = editor.lineWidthValue;
+    ctx.strokeStyle = editor.strokeStyle;
+    ctx.lineTo(e.offsetX, e.offsetY);
+    ctx.stroke();
+  }
 
+  onPointerUp(_e: PointerEvent, editor: Editor) {
+    const ctx = editor.ctx;
+    ctx.closePath();
+    ctx.globalCompositeOperation = "source-over";
+  }
+}


### PR DESCRIPTION
## Summary
- Replace placeholder eraser with path-based eraser
- Use destination-out composite operation to erase drawn strokes
- Restore composite operation after pointer release

## Testing
- `npm test` *(fails: canvas context mock lacks required methods & coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_689b8c3018bc8328a4cc1bec35af6618