### PR TITLE
Reset canvas transform before scaling

### DIFF
--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -50,6 +50,7 @@ export class Editor {
     const rect = this.canvas.getBoundingClientRect();
     this.canvas.width = rect.width * dpr;
     this.canvas.height = rect.height * dpr;
+    this.ctx.setTransform(1, 0, 0, 1, 0, 0);
     this.ctx.scale(dpr, dpr);
   }
 


### PR DESCRIPTION
## Summary
- reset canvas transform to identity before scaling for device pixel ratio adjustments

## Testing
- `npm test` (fails: ts-jest configuration warnings, TypeError setTransform not a function, coverage thresholds not met)

------
https://chatgpt.com/codex/tasks/task_e_689b8c31f4d883289d7470ae62e050e5