### PR TITLE
Mock canvas context for editor tests

### DIFF
--- a/src/tools/EraserTool.ts
+++ b/src/tools/EraserTool.ts
@@ -2,9 +2,37 @@ import { Editor } from "../core/Editor";
 import { Tool } from "./Tool";
 
 export class EraserTool implements Tool {
-
+  onPointerDown(e: PointerEvent, editor: Editor) {
+    const ctx = editor.ctx;
+    ctx.globalCompositeOperation = "destination-out";
+    ctx.lineWidth = editor.lineWidthValue;
+    ctx.beginPath?.();
+    ctx.moveTo?.(e.offsetX, e.offsetY);
+    ctx.clearRect(
+      e.offsetX - editor.lineWidthValue / 2,
+      e.offsetY - editor.lineWidthValue / 2,
+      editor.lineWidthValue,
+      editor.lineWidthValue,
+    );
   }
 
   onPointerMove(e: PointerEvent, editor: Editor) {
     if (e.buttons !== 1) return;
+    const ctx = editor.ctx;
+    ctx.lineWidth = editor.lineWidthValue;
+    ctx.lineTo?.(e.offsetX, e.offsetY);
+    ctx.stroke?.();
+    ctx.clearRect(
+      e.offsetX - editor.lineWidthValue / 2,
+      e.offsetY - editor.lineWidthValue / 2,
+      editor.lineWidthValue,
+      editor.lineWidthValue,
+    );
+  }
 
+  onPointerUp(_e: PointerEvent, editor: Editor) {
+    const ctx = editor.ctx;
+    ctx.globalCompositeOperation = "source-over";
+    ctx.closePath?.();
+  }
+}

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -24,14 +24,28 @@ describe("editor", () => {
     `;
 
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
-
+    ctx = {
+      beginPath: jest.fn(),
+      moveTo: jest.fn(),
+      lineTo: jest.fn(),
+      stroke: jest.fn(),
+      arc: jest.fn(),
+      strokeRect: jest.fn(),
+      fillText: jest.fn(),
+      closePath: jest.fn(),
+      clearRect: jest.fn(),
+      putImageData: jest.fn(),
+      getImageData: jest.fn().mockReturnValue({}),
+      drawImage: jest.fn(),
+      scale: jest.fn(),
+    };
 
     canvas.getContext = jest
       .fn()
       .mockReturnValue(ctx as CanvasRenderingContext2D);
     canvas.toDataURL = jest.fn();
 
-
+    editor = initEditor();
   });
 
   function dispatch(type: string, x: number, y: number, buttons = 0) {

--- a/tests/rectangleTool.test.ts
+++ b/tests/rectangleTool.test.ts
@@ -5,26 +5,28 @@ describe("RectangleTool", () => {
   let editor: Editor;
   let ctx: Partial<CanvasRenderingContext2D>;
 
-  beforeEach(() => {
-    document.body.innerHTML = `
-      <canvas id="canvas"></canvas>
-      <input id="colorPicker" value="#000000" />
-      <input id="lineWidth" value="2" />
-    `;
-    const canvas = document.getElementById("canvas") as HTMLCanvasElement;
-    ctx = {
-      strokeRect: jest.fn(),
-      scale: jest.fn(),
-    };
-    canvas.getContext = jest
-      .fn()
-      .mockReturnValue(ctx as CanvasRenderingContext2D);
-    editor = new Editor(
-      canvas,
-      document.getElementById("colorPicker") as HTMLInputElement,
-      document.getElementById("lineWidth") as HTMLInputElement,
-    );
-  });
+    beforeEach(() => {
+      document.body.innerHTML = `
+        <canvas id="canvas"></canvas>
+        <input id="colorPicker" value="#000000" />
+        <input id="lineWidth" value="2" />
+      `;
+      const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+      ctx = {
+        strokeRect: jest.fn(),
+        scale: jest.fn(),
+        getImageData: jest.fn().mockReturnValue({}),
+        putImageData: jest.fn(),
+      };
+      canvas.getContext = jest
+        .fn()
+        .mockReturnValue(ctx as CanvasRenderingContext2D);
+      editor = new Editor(
+        canvas,
+        document.getElementById("colorPicker") as HTMLInputElement,
+        document.getElementById("lineWidth") as HTMLInputElement,
+      );
+    });
 
   it("draws a rectangle on pointer up", () => {
     const tool = new RectangleTool();

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1,0 +1,76 @@
+import { Editor } from "../src/core/Editor";
+import { PencilTool } from "../src/tools/PencilTool";
+import { LineTool } from "../src/tools/LineTool";
+import { CircleTool } from "../src/tools/CircleTool";
+import { TextTool } from "../src/tools/TextTool";
+
+describe("additional tools", () => {
+  let canvas: HTMLCanvasElement;
+  let ctx: Partial<CanvasRenderingContext2D>;
+  let editor: Editor;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <canvas id="canvas"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="2" />
+    `;
+    canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    ctx = {
+      beginPath: jest.fn(),
+      moveTo: jest.fn(),
+      lineTo: jest.fn(),
+      stroke: jest.fn(),
+      arc: jest.fn(),
+      fillText: jest.fn(),
+      closePath: jest.fn(),
+      scale: jest.fn(),
+    };
+    canvas.getContext = jest
+      .fn()
+      .mockReturnValue(ctx as CanvasRenderingContext2D);
+    editor = new Editor(
+      canvas,
+      document.getElementById("colorPicker") as HTMLInputElement,
+      document.getElementById("lineWidth") as HTMLInputElement,
+    );
+  });
+
+  it("pencil draws lines", () => {
+    const tool = new PencilTool();
+    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+    tool.onPointerMove(
+      { offsetX: 5, offsetY: 5, buttons: 1 } as PointerEvent,
+      editor,
+    );
+    tool.onPointerUp({ offsetX: 5, offsetY: 5 } as PointerEvent, editor);
+    expect(ctx.beginPath).toHaveBeenCalled();
+    expect(ctx.lineTo).toHaveBeenCalledWith(5, 5);
+    expect(ctx.closePath).toHaveBeenCalled();
+  });
+
+  it("line tool draws a line", () => {
+    const tool = new LineTool();
+    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+    tool.onPointerUp({ offsetX: 3, offsetY: 4 } as PointerEvent, editor);
+    expect(ctx.moveTo).toHaveBeenCalledWith(0, 0);
+    expect(ctx.lineTo).toHaveBeenCalledWith(3, 4);
+  });
+
+  it("circle tool draws a circle", () => {
+    const tool = new CircleTool();
+    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+    tool.onPointerUp({ offsetX: 3, offsetY: 4 } as PointerEvent, editor);
+    expect(ctx.arc).toHaveBeenCalledWith(0, 0, 5, 0, Math.PI * 2);
+  });
+
+  it("text tool draws text", () => {
+    const tool = new TextTool();
+    const promptSpy = jest
+      .spyOn(window, "prompt")
+      .mockReturnValue("Hi");
+    tool.onPointerDown({ offsetX: 1, offsetY: 2 } as PointerEvent, editor);
+    expect(ctx.fillText).toHaveBeenCalledWith("Hi", 1, 2);
+    promptSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- mock full canvas 2D context in editor tests and initialize editor
- stub context for rectangle tests
- implement eraser tool and add coverage tests for tools

## Testing
- `npm test` *(fails: image operations and several editor tests)*

------
https://chatgpt.com/codex/tasks/task_e_689b8c3320a08328b5c27d810a9a60cb