### PR TITLE
refactor drawing tools with shared stroke helper

### DIFF
--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -1,7 +1,7 @@
 import { Editor } from "../core/Editor";
-import { Tool } from "./Tool";
+import { DrawingTool } from "./DrawingTool";
 
-export class CircleTool implements Tool {
+export class CircleTool extends DrawingTool {
   private startX = 0;
   private startY = 0;
 
@@ -16,8 +16,7 @@ export class CircleTool implements Tool {
 
   onPointerUp(e: PointerEvent, editor: Editor) {
     const ctx = editor.ctx;
-    ctx.lineWidth = editor.lineWidthValue;
-    ctx.strokeStyle = editor.strokeStyle;
+    this.applyStroke(editor);
     const dx = e.offsetX - this.startX;
     const dy = e.offsetY - this.startY;
     const radius = Math.sqrt(dx * dx + dy * dy);

--- a/src/tools/DrawingTool.ts
+++ b/src/tools/DrawingTool.ts
@@ -1,0 +1,14 @@
+import { Editor } from "../core/Editor";
+import { Tool } from "./Tool";
+
+export abstract class DrawingTool implements Tool {
+  protected applyStroke(editor: Editor) {
+    const ctx = editor.ctx;
+    ctx.lineWidth = editor.lineWidthValue;
+    ctx.strokeStyle = editor.strokeStyle;
+  }
+
+  abstract onPointerDown(e: PointerEvent, editor: Editor): void;
+  abstract onPointerMove(e: PointerEvent, editor: Editor): void;
+  abstract onPointerUp(e: PointerEvent, editor: Editor): void;
+}

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -1,7 +1,7 @@
 import { Editor } from "../core/Editor";
-import { Tool } from "./Tool";
+import { DrawingTool } from "./DrawingTool";
 
-export class LineTool implements Tool {
+export class LineTool extends DrawingTool {
   private startX = 0;
   private startY = 0;
 
@@ -16,8 +16,7 @@ export class LineTool implements Tool {
 
   onPointerUp(e: PointerEvent, editor: Editor) {
     const ctx = editor.ctx;
-    ctx.lineWidth = editor.lineWidthValue;
-    ctx.strokeStyle = editor.strokeStyle;
+    this.applyStroke(editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
     ctx.lineTo(e.offsetX, e.offsetY);

--- a/src/tools/PencilTool.ts
+++ b/src/tools/PencilTool.ts
@@ -1,7 +1,7 @@
 import { Editor } from "../core/Editor";
-import { Tool } from "./Tool";
+import { DrawingTool } from "./DrawingTool";
 
-export class PencilTool implements Tool {
+export class PencilTool extends DrawingTool {
   onPointerDown(e: PointerEvent, editor: Editor) {
     const ctx = editor.ctx;
     ctx.beginPath();
@@ -11,8 +11,7 @@ export class PencilTool implements Tool {
   onPointerMove(e: PointerEvent, editor: Editor) {
     if (e.buttons !== 1) return;
     const ctx = editor.ctx;
-    ctx.lineWidth = editor.lineWidthValue;
-    ctx.strokeStyle = editor.strokeStyle;
+    this.applyStroke(editor);
     ctx.lineTo(e.offsetX, e.offsetY);
     ctx.stroke();
   }

--- a/src/tools/RectangleTool.ts
+++ b/src/tools/RectangleTool.ts
@@ -1,7 +1,7 @@
 import { Editor } from "../core/Editor";
-import { Tool } from "./Tool";
+import { DrawingTool } from "./DrawingTool";
 
-export class RectangleTool implements Tool {
+export class RectangleTool extends DrawingTool {
   private startX = 0;
   private startY = 0;
   private imageData: ImageData | null = null;
@@ -17,8 +17,7 @@ export class RectangleTool implements Tool {
     if (e.buttons !== 1 || !this.imageData) return;
     const ctx = editor.ctx;
     ctx.putImageData(this.imageData, 0, 0);
-    ctx.lineWidth = editor.lineWidthValue;
-    ctx.strokeStyle = editor.strokeStyle;
+    this.applyStroke(editor);
     const x = e.offsetX;
     const y = e.offsetY;
     ctx.strokeRect(this.startX, this.startY, x - this.startX, y - this.startY);
@@ -29,8 +28,7 @@ export class RectangleTool implements Tool {
     if (this.imageData) {
       ctx.putImageData(this.imageData, 0, 0);
     }
-    ctx.lineWidth = editor.lineWidthValue;
-    ctx.strokeStyle = editor.strokeStyle;
+    this.applyStroke(editor);
     const x = e.offsetX;
     const y = e.offsetY;
     ctx.strokeRect(this.startX, this.startY, x - this.startX, y - this.startY);

--- a/tests/drawingTool.test.ts
+++ b/tests/drawingTool.test.ts
@@ -1,0 +1,23 @@
+import { DrawingTool } from "../src/tools/DrawingTool";
+import { PencilTool } from "../src/tools/PencilTool";
+import { RectangleTool } from "../src/tools/RectangleTool";
+import { LineTool } from "../src/tools/LineTool";
+import { CircleTool } from "../src/tools/CircleTool";
+
+describe("DrawingTool subclasses", () => {
+  it("PencilTool extends DrawingTool", () => {
+    expect(new PencilTool()).toBeInstanceOf(DrawingTool);
+  });
+
+  it("RectangleTool extends DrawingTool", () => {
+    expect(new RectangleTool()).toBeInstanceOf(DrawingTool);
+  });
+
+  it("LineTool extends DrawingTool", () => {
+    expect(new LineTool()).toBeInstanceOf(DrawingTool);
+  });
+
+  it("CircleTool extends DrawingTool", () => {
+    expect(new CircleTool()).toBeInstanceOf(DrawingTool);
+  });
+});

--- a/tests/rectangleTool.test.ts
+++ b/tests/rectangleTool.test.ts
@@ -1,5 +1,6 @@
 import { Editor } from "../src/core/Editor";
 import { RectangleTool } from "../src/tools/RectangleTool";
+import { DrawingTool } from "../src/tools/DrawingTool";
 
 describe("RectangleTool", () => {
   let editor: Editor;
@@ -28,8 +29,11 @@ describe("RectangleTool", () => {
 
   it("draws a rectangle on pointer up", () => {
     const tool = new RectangleTool();
+    expect(tool).toBeInstanceOf(DrawingTool);
     tool.onPointerDown({ offsetX: 10, offsetY: 15 } as PointerEvent, editor);
     tool.onPointerUp({ offsetX: 20, offsetY: 25 } as PointerEvent, editor);
     expect(ctx.strokeRect).toHaveBeenCalledWith(10, 15, 10, 10);
+    expect((ctx as any).lineWidth).toBe(2);
+    expect((ctx as any).strokeStyle).toBe("#000000");
   });
 });


### PR DESCRIPTION
## Summary
- add abstract `DrawingTool` with `applyStroke` helper
- extend drawing tools to use `applyStroke`
- test drawing tool inheritance

## Testing
- `npx jest --runInBand` *(fails: Class 'EraserTool' incorrectly implements interface 'Tool', coverage thresholds not met)*
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars and @typescript-eslint/no-explicit-any errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b8c33ff808328b00bf9fccc7193cf