### PR TITLE
Add cached preview for line and circle tools

### DIFF
--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -1,23 +1,33 @@
 import { Editor } from "../core/Editor";
 import { Tool } from "./Tool";
 
+function applyStroke(ctx: CanvasRenderingContext2D, editor: Editor) {
+  ctx.lineWidth = editor.lineWidthValue;
+  ctx.strokeStyle = editor.strokeStyle;
+}
+
 export class CircleTool implements Tool {
   private startX = 0;
   private startY = 0;
+  private imageData: ImageData | null = null;
 
-  onPointerDown(e: PointerEvent, _editor: Editor) {
+  onPointerDown(e: PointerEvent, editor: Editor) {
     this.startX = e.offsetX;
     this.startY = e.offsetY;
-  }
-
-  onPointerMove(_e: PointerEvent, _editor: Editor) {
-    // No preview implementation
-  }
-
-  onPointerUp(e: PointerEvent, editor: Editor) {
     const ctx = editor.ctx;
-    ctx.lineWidth = editor.lineWidthValue;
-    ctx.strokeStyle = editor.strokeStyle;
+    this.imageData = ctx.getImageData(
+      0,
+      0,
+      editor.canvas.width,
+      editor.canvas.height,
+    );
+  }
+
+  onPointerMove(e: PointerEvent, editor: Editor) {
+    if (e.buttons !== 1 || !this.imageData) return;
+    const ctx = editor.ctx;
+    ctx.putImageData(this.imageData, 0, 0);
+    applyStroke(ctx, editor);
     const dx = e.offsetX - this.startX;
     const dy = e.offsetY - this.startY;
     const radius = Math.sqrt(dx * dx + dy * dy);
@@ -25,6 +35,22 @@ export class CircleTool implements Tool {
     ctx.arc(this.startX, this.startY, radius, 0, Math.PI * 2);
     ctx.stroke();
     ctx.closePath();
+  }
+
+  onPointerUp(e: PointerEvent, editor: Editor) {
+    const ctx = editor.ctx;
+    if (this.imageData) {
+      ctx.putImageData(this.imageData, 0, 0);
+    }
+    applyStroke(ctx, editor);
+    const dx = e.offsetX - this.startX;
+    const dy = e.offsetY - this.startY;
+    const radius = Math.sqrt(dx * dx + dy * dy);
+    ctx.beginPath();
+    ctx.arc(this.startX, this.startY, radius, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.closePath();
+    this.imageData = null;
   }
 }
 

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -1,28 +1,52 @@
 import { Editor } from "../core/Editor";
 import { Tool } from "./Tool";
 
+function applyStroke(ctx: CanvasRenderingContext2D, editor: Editor) {
+  ctx.lineWidth = editor.lineWidthValue;
+  ctx.strokeStyle = editor.strokeStyle;
+}
+
 export class LineTool implements Tool {
   private startX = 0;
   private startY = 0;
+  private imageData: ImageData | null = null;
 
-  onPointerDown(e: PointerEvent, _editor: Editor) {
+  onPointerDown(e: PointerEvent, editor: Editor) {
     this.startX = e.offsetX;
     this.startY = e.offsetY;
-  }
-
-  onPointerMove(_e: PointerEvent, _editor: Editor) {
-    // No preview implementation
-  }
-
-  onPointerUp(e: PointerEvent, editor: Editor) {
     const ctx = editor.ctx;
-    ctx.lineWidth = editor.lineWidthValue;
-    ctx.strokeStyle = editor.strokeStyle;
+    this.imageData = ctx.getImageData(
+      0,
+      0,
+      editor.canvas.width,
+      editor.canvas.height,
+    );
+  }
+
+  onPointerMove(e: PointerEvent, editor: Editor) {
+    if (e.buttons !== 1 || !this.imageData) return;
+    const ctx = editor.ctx;
+    ctx.putImageData(this.imageData, 0, 0);
+    applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
     ctx.lineTo(e.offsetX, e.offsetY);
     ctx.stroke();
     ctx.closePath();
+  }
+
+  onPointerUp(e: PointerEvent, editor: Editor) {
+    const ctx = editor.ctx;
+    if (this.imageData) {
+      ctx.putImageData(this.imageData, 0, 0);
+    }
+    applyStroke(ctx, editor);
+    ctx.beginPath();
+    ctx.moveTo(this.startX, this.startY);
+    ctx.lineTo(e.offsetX, e.offsetY);
+    ctx.stroke();
+    ctx.closePath();
+    this.imageData = null;
   }
 }
 

--- a/tests/circleTool.test.ts
+++ b/tests/circleTool.test.ts
@@ -1,0 +1,55 @@
+import { Editor } from "../src/core/Editor";
+import { CircleTool } from "../src/tools/CircleTool";
+
+describe("CircleTool", () => {
+  let editor: Editor;
+  let ctx: Partial<CanvasRenderingContext2D>;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <canvas id="canvas"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="2" />
+    `;
+    const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    const imageData = {} as ImageData;
+    ctx = {
+      getImageData: jest.fn().mockReturnValue(imageData),
+      putImageData: jest.fn(),
+      beginPath: jest.fn(),
+      arc: jest.fn(),
+      stroke: jest.fn(),
+      closePath: jest.fn(),
+      scale: jest.fn(),
+    };
+    canvas.getContext = jest
+      .fn()
+      .mockReturnValue(ctx as CanvasRenderingContext2D);
+    editor = new Editor(
+      canvas,
+      document.getElementById("colorPicker") as HTMLInputElement,
+      document.getElementById("lineWidth") as HTMLInputElement,
+    );
+  });
+
+  it("previews circle during pointer move", () => {
+    const tool = new CircleTool();
+    tool.onPointerDown({ offsetX: 2, offsetY: 3 } as PointerEvent, editor);
+    tool.onPointerMove({
+      offsetX: 5,
+      offsetY: 7,
+      buttons: 1,
+    } as PointerEvent, editor);
+
+    expect(ctx.getImageData).toHaveBeenCalled();
+    const image = (ctx.getImageData as jest.Mock).mock.results[0].value;
+    expect(ctx.putImageData).toHaveBeenCalledWith(image, 0, 0);
+    const dx = 5 - 2;
+    const dy = 7 - 3;
+    const radius = Math.sqrt(dx * dx + dy * dy);
+    expect(ctx.beginPath).toHaveBeenCalled();
+    expect(ctx.arc).toHaveBeenCalledWith(2, 3, radius, 0, Math.PI * 2);
+    expect(ctx.stroke).toHaveBeenCalled();
+    expect(ctx.closePath).toHaveBeenCalled();
+  });
+});

--- a/tests/lineTool.test.ts
+++ b/tests/lineTool.test.ts
@@ -1,0 +1,54 @@
+import { Editor } from "../src/core/Editor";
+import { LineTool } from "../src/tools/LineTool";
+
+describe("LineTool", () => {
+  let editor: Editor;
+  let ctx: Partial<CanvasRenderingContext2D>;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <canvas id="canvas"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="2" />
+    `;
+    const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    const imageData = {} as ImageData;
+    ctx = {
+      getImageData: jest.fn().mockReturnValue(imageData),
+      putImageData: jest.fn(),
+      beginPath: jest.fn(),
+      moveTo: jest.fn(),
+      lineTo: jest.fn(),
+      stroke: jest.fn(),
+      closePath: jest.fn(),
+      scale: jest.fn(),
+    };
+    canvas.getContext = jest
+      .fn()
+      .mockReturnValue(ctx as CanvasRenderingContext2D);
+    editor = new Editor(
+      canvas,
+      document.getElementById("colorPicker") as HTMLInputElement,
+      document.getElementById("lineWidth") as HTMLInputElement,
+    );
+  });
+
+  it("previews line during pointer move", () => {
+    const tool = new LineTool();
+    tool.onPointerDown({ offsetX: 1, offsetY: 2 } as PointerEvent, editor);
+    tool.onPointerMove({
+      offsetX: 3,
+      offsetY: 4,
+      buttons: 1,
+    } as PointerEvent, editor);
+
+    expect(ctx.getImageData).toHaveBeenCalled();
+    const image = (ctx.getImageData as jest.Mock).mock.results[0].value;
+    expect(ctx.putImageData).toHaveBeenCalledWith(image, 0, 0);
+    expect(ctx.beginPath).toHaveBeenCalled();
+    expect(ctx.moveTo).toHaveBeenCalledWith(1, 2);
+    expect(ctx.lineTo).toHaveBeenCalledWith(3, 4);
+    expect(ctx.stroke).toHaveBeenCalled();
+    expect(ctx.closePath).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- cache canvas image data on pointer down in LineTool and CircleTool
- restore cached image to preview and finalize shapes
- add unit tests for line and circle preview behavior

## Testing
- `npm test` *(fails: RectangleTool and EraserTool missing implementations, coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_689b8c34778083288868bf3171c72acf