### PR TITLE
Add fill mode and shape filling support

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,8 @@
   <body>
     <div id="toolbar">
       <input type="color" id="colorPicker" value="#000000" />
-      <input type="range" id="lineWidth" min="1" max="50" value="5" />
+        <input type="range" id="lineWidth" min="1" max="50" value="5" />
+        <input type="checkbox" id="fillMode" />
       <button id="pencil">Pencil</button>
       <button id="eraser">Eraser</button>
       <button id="rectangle">Rectangle</button>

--- a/package.json
+++ b/package.json
@@ -31,8 +31,6 @@
         "useESM": true
       }
     },
-    "extensionsToTreatAsEsm": [".ts"],
-
-      }
-    }
+    "extensionsToTreatAsEsm": [".ts"]
   }
+}

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -8,11 +8,13 @@ export class Editor {
   private currentTool: Tool | null = null;
   colorPicker: HTMLInputElement;
   lineWidth: HTMLInputElement;
+  fillMode: HTMLInputElement;
 
   constructor(
     canvas: HTMLCanvasElement,
     colorPicker: HTMLInputElement,
     lineWidth: HTMLInputElement,
+    fillMode: HTMLInputElement,
   ) {
     this.canvas = canvas;
     const ctx = canvas.getContext("2d");
@@ -20,6 +22,7 @@ export class Editor {
     this.ctx = ctx;
     this.colorPicker = colorPicker;
     this.lineWidth = lineWidth;
+    this.fillMode = fillMode;
     this.adjustForPixelRatio();
     window.addEventListener("resize", this.handleResize);
 
@@ -97,6 +100,14 @@ export class Editor {
   }
 
   get strokeStyle() {
+    return this.colorPicker.value;
+  }
+
+  get fill() {
+    return this.fillMode.checked;
+  }
+
+  get fillStyle() {
     return this.colorPicker.value;
   }
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -5,16 +5,19 @@ import { LineTool } from "./tools/LineTool";
 import { CircleTool } from "./tools/CircleTool";
 import { TextTool } from "./tools/TextTool";
 import { EraserTool } from "./tools/EraserTool";
-import { LineTool } from "./tools/LineTool";
-import { CircleTool } from "./tools/CircleTool";
-import { TextTool } from "./tools/TextTool";
 
+export interface EditorHandle {
+  destroy(): void;
+  editor: Editor;
+}
 
+export function initEditor(): EditorHandle {
   const canvas = document.getElementById("canvas") as HTMLCanvasElement;
   const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
   const lineWidth = document.getElementById("lineWidth") as HTMLInputElement;
+  const fillMode = document.getElementById("fillMode") as HTMLInputElement;
 
-  const editor = new Editor(canvas, colorPicker, lineWidth);
+  const editor = new Editor(canvas, colorPicker, lineWidth, fillMode);
 
   const pencil = new PencilTool();
   const rectangle = new RectangleTool();
@@ -22,12 +25,60 @@ import { TextTool } from "./tools/TextTool";
   const circle = new CircleTool();
   const text = new TextTool();
   const eraser = new EraserTool();
-  const imageLoader = document.getElementById("imageLoader") as
-    | HTMLInputElement
-    | null;
-  const saveButton = document.getElementById("save") as
-    | HTMLButtonElement
-    | null;
 
+  const tools: Record<string, any> = {
+    pencil,
+    rectangle,
+    line,
+    circle,
+    text,
+    eraser,
+  };
 
+  editor.setTool(pencil);
+
+  Object.entries(tools).forEach(([id, tool]) => {
+    const btn = document.getElementById(id);
+    btn?.addEventListener("click", () => editor.setTool(tool));
+  });
+
+  document.getElementById("undo")?.addEventListener("click", () => editor.undo());
+  document.getElementById("redo")?.addEventListener("click", () => editor.redo());
+
+  const imageLoader = document.getElementById("imageLoader") as HTMLInputElement | null;
+  imageLoader?.addEventListener("change", () => {
+    const file = imageLoader.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        editor.ctx.drawImage(
+          img,
+          0,
+          0,
+          editor.canvas.width,
+          editor.canvas.height,
+        );
+      };
+      img.src = reader.result as string;
+    };
+    reader.readAsDataURL(file);
+  });
+
+  const saveBtn = document.getElementById("save") as HTMLButtonElement | null;
+  saveBtn?.addEventListener("click", () => {
+    const dataUrl = editor.canvas.toDataURL("image/png");
+    const a = document.createElement("a");
+    a.href = dataUrl;
+    a.download = "canvas.png";
+    a.click();
+  });
+
+  return {
+    destroy() {
+      editor.destroy();
+    },
+    editor,
+  };
 }

--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -1,12 +1,12 @@
 import { Editor } from "../core/Editor";
 import { DrawingTool } from "./DrawingTool";
 
-
+export class CircleTool extends DrawingTool {
   private startX = 0;
   private startY = 0;
   private imageData: ImageData | null = null;
 
-  onPointerDown(e: PointerEvent, editor: Editor) {
+  onPointerDown(e: PointerEvent, editor: Editor): void {
     this.startX = e.offsetX;
     this.startY = e.offsetY;
     const ctx = editor.ctx;
@@ -18,31 +18,38 @@ import { DrawingTool } from "./DrawingTool";
     );
   }
 
-  onPointerMove(e: PointerEvent, editor: Editor) {
+  onPointerMove(e: PointerEvent, editor: Editor): void {
     if (e.buttons !== 1 || !this.imageData) return;
     const ctx = editor.ctx;
     ctx.putImageData(this.imageData, 0, 0);
-    applyStroke(ctx, editor);
+    this.applyStroke(ctx, editor);
     const dx = e.offsetX - this.startX;
     const dy = e.offsetY - this.startY;
     const radius = Math.sqrt(dx * dx + dy * dy);
     ctx.beginPath();
     ctx.arc(this.startX, this.startY, radius, 0, Math.PI * 2);
     ctx.stroke();
+    if (editor.fill) {
+      ctx.fillStyle = editor.fillStyle;
+      ctx.fill();
+    }
     ctx.closePath();
   }
 
-  onPointerUp(e: PointerEvent, editor: Editor) {
+  onPointerUp(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
-
     const dx = e.offsetX - this.startX;
     const dy = e.offsetY - this.startY;
     const radius = Math.sqrt(dx * dx + dy * dy);
+    this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.arc(this.startX, this.startY, radius, 0, Math.PI * 2);
     ctx.stroke();
+    if (editor.fill) {
+      ctx.fillStyle = editor.fillStyle;
+      ctx.fill();
+    }
     ctx.closePath();
     this.imageData = null;
   }
 }
-

--- a/src/tools/DrawingTool.ts
+++ b/src/tools/DrawingTool.ts
@@ -2,8 +2,10 @@ import { Editor } from "../core/Editor";
 import { Tool } from "./Tool";
 
 export abstract class DrawingTool implements Tool {
-
-    const ctx = editor.ctx;
+  protected applyStroke(
+    ctx: CanvasRenderingContext2D,
+    editor: Editor,
+  ): void {
     ctx.lineWidth = editor.lineWidthValue;
     ctx.strokeStyle = editor.strokeStyle;
   }

--- a/src/tools/EraserTool.ts
+++ b/src/tools/EraserTool.ts
@@ -2,12 +2,12 @@ import { Editor } from "../core/Editor";
 import { Tool } from "./Tool";
 
 export class EraserTool implements Tool {
-  onPointerDown(e: PointerEvent, editor: Editor) {
+  onPointerDown(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
     ctx.globalCompositeOperation = "destination-out";
     ctx.lineWidth = editor.lineWidthValue;
-    ctx.beginPath?.();
-    ctx.moveTo?.(e.offsetX, e.offsetY);
+    ctx.beginPath();
+    ctx.moveTo(e.offsetX, e.offsetY);
     ctx.clearRect(
       e.offsetX - editor.lineWidthValue / 2,
       e.offsetY - editor.lineWidthValue / 2,
@@ -16,12 +16,12 @@ export class EraserTool implements Tool {
     );
   }
 
-  onPointerMove(e: PointerEvent, editor: Editor) {
+  onPointerMove(e: PointerEvent, editor: Editor): void {
     if (e.buttons !== 1) return;
     const ctx = editor.ctx;
     ctx.lineWidth = editor.lineWidthValue;
-    ctx.lineTo?.(e.offsetX, e.offsetY);
-    ctx.stroke?.();
+    ctx.lineTo(e.offsetX, e.offsetY);
+    ctx.stroke();
     ctx.clearRect(
       e.offsetX - editor.lineWidthValue / 2,
       e.offsetY - editor.lineWidthValue / 2,
@@ -30,5 +30,9 @@ export class EraserTool implements Tool {
     );
   }
 
-
+  onPointerUp(_e: PointerEvent, editor: Editor): void {
+    const ctx = editor.ctx;
+    ctx.closePath();
+    ctx.globalCompositeOperation = "source-over";
+  }
 }

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -1,11 +1,12 @@
 import { Editor } from "../core/Editor";
 import { DrawingTool } from "./DrawingTool";
 
+export class LineTool extends DrawingTool {
   private startX = 0;
   private startY = 0;
   private imageData: ImageData | null = null;
 
-  onPointerDown(e: PointerEvent, editor: Editor) {
+  onPointerDown(e: PointerEvent, editor: Editor): void {
     this.startX = e.offsetX;
     this.startY = e.offsetY;
     const ctx = editor.ctx;
@@ -17,11 +18,11 @@ import { DrawingTool } from "./DrawingTool";
     );
   }
 
-  onPointerMove(e: PointerEvent, editor: Editor) {
+  onPointerMove(e: PointerEvent, editor: Editor): void {
     if (e.buttons !== 1 || !this.imageData) return;
     const ctx = editor.ctx;
     ctx.putImageData(this.imageData, 0, 0);
-    applyStroke(ctx, editor);
+    this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
     ctx.lineTo(e.offsetX, e.offsetY);
@@ -29,9 +30,9 @@ import { DrawingTool } from "./DrawingTool";
     ctx.closePath();
   }
 
-  onPointerUp(e: PointerEvent, editor: Editor) {
+  onPointerUp(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
-
+    this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
     ctx.lineTo(e.offsetX, e.offsetY);
@@ -40,4 +41,3 @@ import { DrawingTool } from "./DrawingTool";
     this.imageData = null;
   }
 }
-

--- a/src/tools/RectangleTool.ts
+++ b/src/tools/RectangleTool.ts
@@ -17,10 +17,14 @@ export class RectangleTool extends DrawingTool {
     if (e.buttons !== 1 || !this.imageData) return;
     const ctx = editor.ctx;
     ctx.putImageData(this.imageData, 0, 0);
-
+    this.applyStroke(ctx, editor);
     const x = e.offsetX;
     const y = e.offsetY;
     ctx.strokeRect(this.startX, this.startY, x - this.startX, y - this.startY);
+    if (editor.fill) {
+      ctx.fillStyle = editor.fillStyle;
+      ctx.fillRect(this.startX, this.startY, x - this.startX, y - this.startY);
+    }
   }
 
   onPointerUp(e: PointerEvent, editor: Editor) {
@@ -31,7 +35,12 @@ export class RectangleTool extends DrawingTool {
 
     const x = e.offsetX;
     const y = e.offsetY;
+    this.applyStroke(ctx, editor);
     ctx.strokeRect(this.startX, this.startY, x - this.startX, y - this.startY);
+    if (editor.fill) {
+      ctx.fillStyle = editor.fillStyle;
+      ctx.fillRect(this.startX, this.startY, x - this.startX, y - this.startY);
+    }
     this.imageData = null;
   }
 }

--- a/tests/circleTool.test.ts
+++ b/tests/circleTool.test.ts
@@ -10,6 +10,7 @@ describe("CircleTool", () => {
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
     `;
     const canvas = document.getElementById("canvas") as HTMLCanvasElement;
     const imageData = {} as ImageData;
@@ -20,7 +21,9 @@ describe("CircleTool", () => {
       arc: jest.fn(),
       stroke: jest.fn(),
       closePath: jest.fn(),
+      fill: jest.fn(),
       scale: jest.fn(),
+      setTransform: jest.fn(),
     };
     canvas.getContext = jest
       .fn()
@@ -29,6 +32,7 @@ describe("CircleTool", () => {
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
+      document.getElementById("fillMode") as HTMLInputElement,
     );
   });
 
@@ -51,5 +55,14 @@ describe("CircleTool", () => {
     expect(ctx.arc).toHaveBeenCalledWith(2, 3, radius, 0, Math.PI * 2);
     expect(ctx.stroke).toHaveBeenCalled();
     expect(ctx.closePath).toHaveBeenCalled();
+    expect(ctx.fill).not.toHaveBeenCalled();
+  });
+
+  it("fills circle when fillMode checked", () => {
+    const tool = new CircleTool();
+    (document.getElementById("fillMode") as HTMLInputElement).checked = true;
+    tool.onPointerDown({ offsetX: 1, offsetY: 1 } as PointerEvent, editor);
+    tool.onPointerUp({ offsetX: 4, offsetY: 5 } as PointerEvent, editor);
+    expect(ctx.fill).toHaveBeenCalled();
   });
 });

--- a/tests/eraserTool.test.ts
+++ b/tests/eraserTool.test.ts
@@ -6,30 +6,34 @@ describe("EraserTool", () => {
   let ctx: Partial<CanvasRenderingContext2D>;
 
   beforeEach(() => {
-    document.body.innerHTML = `
-      <canvas id="canvas"></canvas>
-      <input id="colorPicker" value="#000000" />
-      <input id="lineWidth" value="10" />
-    `;
+      document.body.innerHTML = `
+        <canvas id="canvas"></canvas>
+        <input id="colorPicker" value="#000000" />
+        <input id="lineWidth" value="10" />
+        <input id="fillMode" type="checkbox" />
+      `;
     const canvas = document.getElementById("canvas") as HTMLCanvasElement;
     ctx = {
-      beginPath: jest.fn(),
-      moveTo: jest.fn(),
-      lineTo: jest.fn(),
-      stroke: jest.fn(),
-      closePath: jest.fn(),
-      scale: jest.fn(),
-      globalCompositeOperation: "source-over" as GlobalCompositeOperation,
-      lineWidth: 0,
+        beginPath: jest.fn(),
+        moveTo: jest.fn(),
+        lineTo: jest.fn(),
+        stroke: jest.fn(),
+        closePath: jest.fn(),
+        scale: jest.fn(),
+        setTransform: jest.fn(),
+        clearRect: jest.fn(),
+        globalCompositeOperation: "source-over" as GlobalCompositeOperation,
+        lineWidth: 0,
     };
     canvas.getContext = jest
       .fn()
       .mockReturnValue(ctx as CanvasRenderingContext2D);
     editor = new Editor(
       canvas,
-      document.getElementById("colorPicker") as HTMLInputElement,
-      document.getElementById("lineWidth") as HTMLInputElement,
-    );
+        document.getElementById("colorPicker") as HTMLInputElement,
+        document.getElementById("lineWidth") as HTMLInputElement,
+        document.getElementById("fillMode") as HTMLInputElement,
+      );
   });
 
   it("uses destination-out compositing to erase", () => {

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -2,19 +2,20 @@ import { initEditor, EditorHandle } from "../src/editor";
 
 describe("image operations", () => {
   let canvas: HTMLCanvasElement;
-  let ctx: Partial<CanvasRenderingContext2D>;
+    let ctx: Partial<CanvasRenderingContext2D>;
   let handle: EditorHandle;
 
   beforeEach(() => {
     document.body.innerHTML = `
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
-      <input id="lineWidth" value="2" />
-      <input id="imageLoader" type="file" />
-      <button id="save"></button>
+        <input id="lineWidth" value="2" />
+        <input id="fillMode" type="checkbox" />
+        <input id="imageLoader" type="file" />
+        <button id="save"></button>
     `;
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
-    ctx = { drawImage: jest.fn(), scale: jest.fn() };
+      ctx = { drawImage: jest.fn(), scale: jest.fn(), setTransform: jest.fn() };
     canvas.getContext = jest
       .fn()
       .mockReturnValue(ctx as CanvasRenderingContext2D);

--- a/tests/lineTool.test.ts
+++ b/tests/lineTool.test.ts
@@ -6,31 +6,34 @@ describe("LineTool", () => {
   let ctx: Partial<CanvasRenderingContext2D>;
 
   beforeEach(() => {
-    document.body.innerHTML = `
-      <canvas id="canvas"></canvas>
-      <input id="colorPicker" value="#000000" />
-      <input id="lineWidth" value="2" />
-    `;
+      document.body.innerHTML = `
+        <canvas id="canvas"></canvas>
+        <input id="colorPicker" value="#000000" />
+        <input id="lineWidth" value="2" />
+        <input id="fillMode" type="checkbox" />
+      `;
     const canvas = document.getElementById("canvas") as HTMLCanvasElement;
     const imageData = {} as ImageData;
     ctx = {
       getImageData: jest.fn().mockReturnValue(imageData),
       putImageData: jest.fn(),
-      beginPath: jest.fn(),
-      moveTo: jest.fn(),
-      lineTo: jest.fn(),
-      stroke: jest.fn(),
-      closePath: jest.fn(),
-      scale: jest.fn(),
+        beginPath: jest.fn(),
+        moveTo: jest.fn(),
+        lineTo: jest.fn(),
+        stroke: jest.fn(),
+        closePath: jest.fn(),
+        scale: jest.fn(),
+        setTransform: jest.fn(),
     };
     canvas.getContext = jest
       .fn()
       .mockReturnValue(ctx as CanvasRenderingContext2D);
     editor = new Editor(
       canvas,
-      document.getElementById("colorPicker") as HTMLInputElement,
-      document.getElementById("lineWidth") as HTMLInputElement,
-    );
+        document.getElementById("colorPicker") as HTMLInputElement,
+        document.getElementById("lineWidth") as HTMLInputElement,
+        document.getElementById("fillMode") as HTMLInputElement,
+      );
   });
 
   it("previews line during pointer move", () => {

--- a/tests/rectangleTool.test.ts
+++ b/tests/rectangleTool.test.ts
@@ -6,7 +6,33 @@ describe("RectangleTool", () => {
   let editor: Editor;
   let ctx: Partial<CanvasRenderingContext2D>;
 
-
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <canvas id="canvas"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
+    `;
+    const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    const imageData = {} as ImageData;
+    ctx = {
+      getImageData: jest.fn().mockReturnValue(imageData),
+      putImageData: jest.fn(),
+      strokeRect: jest.fn(),
+      fillRect: jest.fn(),
+      scale: jest.fn(),
+      setTransform: jest.fn(),
+    };
+    canvas.getContext = jest
+      .fn()
+      .mockReturnValue(ctx as CanvasRenderingContext2D);
+    editor = new Editor(
+      canvas,
+      document.getElementById("colorPicker") as HTMLInputElement,
+      document.getElementById("lineWidth") as HTMLInputElement,
+      document.getElementById("fillMode") as HTMLInputElement,
+    );
+  });
 
   it("draws a rectangle on pointer up", () => {
     const tool = new RectangleTool();
@@ -14,5 +40,14 @@ describe("RectangleTool", () => {
     tool.onPointerDown({ offsetX: 10, offsetY: 15 } as PointerEvent, editor);
     tool.onPointerUp({ offsetX: 20, offsetY: 25 } as PointerEvent, editor);
     expect(ctx.strokeRect).toHaveBeenCalledWith(10, 15, 10, 10);
+    expect(ctx.fillRect).not.toHaveBeenCalled();
+  });
 
+  it("fills rectangle when fillMode checked", () => {
+    const tool = new RectangleTool();
+    (document.getElementById("fillMode") as HTMLInputElement).checked = true;
+    tool.onPointerDown({ offsetX: 1, offsetY: 2 } as PointerEvent, editor);
+    tool.onPointerUp({ offsetX: 3, offsetY: 4 } as PointerEvent, editor);
+    expect(ctx.fillRect).toHaveBeenCalled();
+  });
 });

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -5,12 +5,13 @@ describe("save button", () => {
     document.body.innerHTML = `
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
-      <input id="lineWidth" value="2" />
-      <button id="save"></button>
+        <input id="lineWidth" value="2" />
+        <input id="fillMode" type="checkbox" />
+        <button id="save"></button>
     `;
 
     const canvas = document.getElementById("canvas") as HTMLCanvasElement;
-    const ctx = { scale: jest.fn(), getImageData: jest.fn(), putImageData: jest.fn(), clearRect: jest.fn() } as any;
+      const ctx = { scale: jest.fn(), getImageData: jest.fn(), putImageData: jest.fn(), clearRect: jest.fn(), setTransform: jest.fn() } as any;
     canvas.getContext = jest.fn().mockReturnValue(ctx);
     canvas.toDataURL = jest.fn().mockReturnValue("data:image/png;base64,TEST");
     canvas.getBoundingClientRect = () => ({

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -9,32 +9,38 @@ describe("additional tools", () => {
   let ctx: Partial<CanvasRenderingContext2D>;
   let editor: Editor;
 
-  beforeEach(() => {
-    document.body.innerHTML = `
-      <canvas id="canvas"></canvas>
-      <input id="colorPicker" value="#000000" />
-      <input id="lineWidth" value="2" />
-    `;
-    canvas = document.getElementById("canvas") as HTMLCanvasElement;
-    ctx = {
-      beginPath: jest.fn(),
-      moveTo: jest.fn(),
-      lineTo: jest.fn(),
-      stroke: jest.fn(),
-      arc: jest.fn(),
-      fillText: jest.fn(),
-      closePath: jest.fn(),
-      scale: jest.fn(),
-    };
-    canvas.getContext = jest
-      .fn()
-      .mockReturnValue(ctx as CanvasRenderingContext2D);
-    editor = new Editor(
-      canvas,
-      document.getElementById("colorPicker") as HTMLInputElement,
-      document.getElementById("lineWidth") as HTMLInputElement,
-    );
-  });
+    beforeEach(() => {
+      document.body.innerHTML = `
+        <canvas id="canvas"></canvas>
+        <input id="colorPicker" value="#000000" />
+        <input id="lineWidth" value="2" />
+        <input id="fillMode" type="checkbox" />
+      `;
+      canvas = document.getElementById("canvas") as HTMLCanvasElement;
+      const imageData = {} as ImageData;
+      ctx = {
+        beginPath: jest.fn(),
+        moveTo: jest.fn(),
+        lineTo: jest.fn(),
+        stroke: jest.fn(),
+        arc: jest.fn(),
+        fillText: jest.fn(),
+        closePath: jest.fn(),
+        scale: jest.fn(),
+        setTransform: jest.fn(),
+        getImageData: jest.fn().mockReturnValue(imageData),
+        putImageData: jest.fn(),
+      };
+      canvas.getContext = jest
+        .fn()
+        .mockReturnValue(ctx as CanvasRenderingContext2D);
+      editor = new Editor(
+        canvas,
+        document.getElementById("colorPicker") as HTMLInputElement,
+        document.getElementById("lineWidth") as HTMLInputElement,
+        document.getElementById("fillMode") as HTMLInputElement,
+      );
+    });
 
   it("pencil draws lines", () => {
     const tool = new PencilTool();


### PR DESCRIPTION
## Summary
- add fill mode checkbox to toolbar and wire it through initEditor
- expose fill and fillStyle getters on Editor
- support filled rectangles and circles when fill mode is enabled
- expand tests to cover both outlines and filled shapes

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689be7d042d483288858daefc2ec0dd3