### PR TITLE
feat: overlay textarea for text tool

### DIFF
--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -2,13 +2,44 @@ import { Editor } from "../core/Editor";
 import { Tool } from "./Tool";
 
 export class TextTool implements Tool {
+  private textarea: HTMLTextAreaElement | null = null;
+
   onPointerDown(e: PointerEvent, editor: Editor) {
-    const text = prompt("Enter text:") ?? "";
-    if (!text) return;
-    const ctx = editor.ctx;
-    ctx.fillStyle = editor.strokeStyle;
-    ctx.font = `${editor.lineWidthValue * 4}px sans-serif`;
-    ctx.fillText(text, e.offsetX, e.offsetY);
+    const canvas = editor.canvas;
+    const container = canvas.parentElement || document.body;
+    const textarea = document.createElement("textarea");
+    textarea.style.position = "absolute";
+    textarea.style.left = `${canvas.offsetLeft + e.offsetX}px`;
+    textarea.style.top = `${canvas.offsetTop + e.offsetY}px`;
+    textarea.style.color = editor.strokeStyle;
+    textarea.style.fontSize = `${editor.lineWidthValue * 4}px`;
+    textarea.style.background = "transparent";
+    textarea.style.border = "1px solid " + editor.strokeStyle;
+    textarea.style.padding = "0";
+    textarea.style.margin = "0";
+    container.appendChild(textarea);
+    textarea.focus();
+    this.textarea = textarea;
+
+    const finalize = () => {
+      const text = textarea.value;
+      if (text) {
+        const ctx = editor.ctx;
+        ctx.fillStyle = editor.strokeStyle;
+        ctx.font = `${editor.lineWidthValue * 4}px sans-serif`;
+        ctx.fillText(text, e.offsetX, e.offsetY);
+      }
+      textarea.remove();
+      this.textarea = null;
+    };
+
+    textarea.addEventListener("blur", finalize, { once: true });
+    textarea.addEventListener("keydown", (evt) => {
+      if (evt.key === "Enter") {
+        evt.preventDefault();
+        textarea.blur();
+      }
+    });
   }
 
   onPointerMove(_e: PointerEvent, _editor: Editor) {

--- a/tests/textTool.test.ts
+++ b/tests/textTool.test.ts
@@ -1,0 +1,52 @@
+import { Editor } from "../src/core/Editor";
+import { TextTool } from "../src/tools/TextTool";
+
+describe("TextTool", () => {
+  let canvas: HTMLCanvasElement;
+  let ctx: Partial<CanvasRenderingContext2D>;
+  let editor: Editor;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="container"><canvas id="canvas"></canvas></div>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="2" />
+    `;
+    canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    ctx = {
+      fillText: jest.fn(),
+      scale: jest.fn(),
+    };
+    canvas.getContext = jest
+      .fn()
+      .mockReturnValue(ctx as CanvasRenderingContext2D);
+    editor = new Editor(
+      canvas,
+      document.getElementById("colorPicker") as HTMLInputElement,
+      document.getElementById("lineWidth") as HTMLInputElement,
+    );
+  });
+
+  it("renders text on Enter and cleans up overlay", () => {
+    const tool = new TextTool();
+    tool.onPointerDown({ offsetX: 1, offsetY: 2 } as PointerEvent, editor);
+    const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea).not.toBeNull();
+    textarea.value = "Hi";
+    textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    expect(ctx.fillText).toHaveBeenCalledWith("Hi", 1, 2);
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("renders text on blur and cleans up overlay", () => {
+    const tool = new TextTool();
+    tool.onPointerDown({ offsetX: 3, offsetY: 4 } as PointerEvent, editor);
+    const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea).not.toBeNull();
+    textarea.value = "Blur";
+    textarea.dispatchEvent(new Event("blur"));
+    expect(ctx.fillText).toHaveBeenCalledWith("Blur", 3, 4);
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+});
+

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -2,7 +2,6 @@ import { Editor } from "../src/core/Editor";
 import { PencilTool } from "../src/tools/PencilTool";
 import { LineTool } from "../src/tools/LineTool";
 import { CircleTool } from "../src/tools/CircleTool";
-import { TextTool } from "../src/tools/TextTool";
 
 describe("additional tools", () => {
   let canvas: HTMLCanvasElement;
@@ -62,15 +61,5 @@ describe("additional tools", () => {
     tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
     tool.onPointerUp({ offsetX: 3, offsetY: 4 } as PointerEvent, editor);
     expect(ctx.arc).toHaveBeenCalledWith(0, 0, 5, 0, Math.PI * 2);
-  });
-
-  it("text tool draws text", () => {
-    const tool = new TextTool();
-    const promptSpy = jest
-      .spyOn(window, "prompt")
-      .mockReturnValue("Hi");
-    tool.onPointerDown({ offsetX: 1, offsetY: 2 } as PointerEvent, editor);
-    expect(ctx.fillText).toHaveBeenCalledWith("Hi", 1, 2);
-    promptSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- render a positioned textarea on pointer down for TextTool
- commit text to canvas on blur or Enter and style to current settings
- add tests ensuring text is drawn and overlay removed

## Testing
- `npm test` *(fails: Invalid package.json: JSONParseError)*

------
https://chatgpt.com/codex/tasks/task_e_689c09b73e6c832889535adcbd33099c