### PR TITLE
feat: add drawing tool base class

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,13 +1,13 @@
 import { Editor } from "./core/Editor";
 import { PencilTool } from "./tools/PencilTool";
 
-
-export function initEditor() {
+export function initEditor(): Editor {
   const canvas = document.getElementById("canvas") as HTMLCanvasElement;
   const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
   const lineWidth = document.getElementById("lineWidth") as HTMLInputElement;
 
   const editor = new Editor(canvas, colorPicker, lineWidth);
   editor.setTool(new PencilTool());
+  return editor;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { initEditor } from "./editor";
 
-const handle = initEditor();
-window.addEventListener("beforeunload", handle.destroy);
+const editor = initEditor();
+window.addEventListener("beforeunload", () => editor.destroy());
 

--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -33,6 +33,7 @@ export class CircleTool extends DrawingTool {
   }
 
   onPointerUp(e: PointerEvent, editor: Editor): void {
+    this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
     const dx = e.offsetX - this.startX;
     const dy = e.offsetY - this.startY;

--- a/src/tools/DrawingTool.ts
+++ b/src/tools/DrawingTool.ts
@@ -7,7 +7,10 @@ import { Tool } from "./Tool";
  * rendering context. Concrete tools must implement the pointer handlers.
  */
 export abstract class DrawingTool implements Tool {
-
+  /**
+   * Apply the editor's stroke settings to the given rendering context.
+   */
+  protected applyStroke(ctx: CanvasRenderingContext2D, editor: Editor): void {
     ctx.lineWidth = editor.lineWidthValue;
     ctx.strokeStyle = editor.strokeStyle;
   }
@@ -16,4 +19,3 @@ export abstract class DrawingTool implements Tool {
   abstract onPointerMove(e: PointerEvent, editor: Editor): void;
   abstract onPointerUp(e: PointerEvent, editor: Editor): void;
 }
-

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -31,6 +31,7 @@ export class LineTool extends DrawingTool {
   }
 
   onPointerUp(e: PointerEvent, editor: Editor): void {
+    this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);

--- a/src/tools/PencilTool.ts
+++ b/src/tools/PencilTool.ts
@@ -3,16 +3,16 @@ import { DrawingTool } from "./DrawingTool";
 
 export class PencilTool extends DrawingTool {
   onPointerDown(e: PointerEvent, editor: Editor) {
+    this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
-    this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(e.offsetX, e.offsetY);
   }
 
   onPointerMove(e: PointerEvent, editor: Editor) {
     if (e.buttons !== 1) return;
+    this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
-    this.applyStroke(ctx, editor);
     ctx.lineTo(e.offsetX, e.offsetY);
     ctx.stroke();
   }


### PR DESCRIPTION
## Summary
- add `DrawingTool` abstract base class with shared stroke helper
- apply stroke settings in pencil, line, and circle tools using new helper
- return `Editor` from `initEditor` for clean TypeScript build

## Testing
- `tsc --noEmit`
- `npm test` *(fails: Invalid package.json: Expected double-quoted property name)*

------
https://chatgpt.com/codex/tasks/task_e_689c2dd253e48328bef69a16293a6203