### PR TITLE
Add fill mode option for drawing tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <div id="toolbar">
       <input type="color" id="colorPicker" value="#000000" />
       <input type="range" id="lineWidth" min="1" max="50" value="5" />
+      <input type="checkbox" id="fillMode" />
       <button id="pencil">Pencil</button>
       <button id="eraser">Eraser</button>
       <button id="rectangle">Rectangle</button>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node dist/index.js",
     "lint": "eslint . --ext .ts",
     "format": "prettier --write .",
-    "test": "jest tests/editor.test.ts tests/rectangleTool.test.ts"
+    "test": "jest tests/editor.test.ts tests/rectangleTool.test.ts tests/circleTool.test.ts"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.0",
@@ -30,7 +30,6 @@
       "ts-jest": {
         "useESM": true
       }
-    },
-
+    }
   }
 }

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -8,11 +8,13 @@ export class Editor {
   private currentTool: Tool | null = null;
   colorPicker: HTMLInputElement;
   lineWidth: HTMLInputElement;
+  fillMode: HTMLInputElement;
 
   constructor(
     canvas: HTMLCanvasElement,
     colorPicker: HTMLInputElement,
     lineWidth: HTMLInputElement,
+    fillMode: HTMLInputElement,
   ) {
     this.canvas = canvas;
     const ctx = canvas.getContext("2d");
@@ -20,6 +22,7 @@ export class Editor {
     this.ctx = ctx;
     this.colorPicker = colorPicker;
     this.lineWidth = lineWidth;
+    this.fillMode = fillMode;
     this.adjustForPixelRatio();
     window.addEventListener("resize", this.handleResize);
 
@@ -102,6 +105,14 @@ export class Editor {
 
   get lineWidthValue() {
     return parseInt(this.lineWidth.value, 10) || 1;
+  }
+
+  get fill() {
+    return this.fillMode.checked;
+  }
+
+  get fillStyle() {
+    return this.colorPicker.value;
   }
 
   /**

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -6,8 +6,9 @@ export function initEditor() {
   const canvas = document.getElementById("canvas") as HTMLCanvasElement;
   const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
   const lineWidth = document.getElementById("lineWidth") as HTMLInputElement;
+  const fillMode = document.getElementById("fillMode") as HTMLInputElement;
 
-  const editor = new Editor(canvas, colorPicker, lineWidth);
+  const editor = new Editor(canvas, colorPicker, lineWidth, fillMode);
   editor.setTool(new PencilTool());
 }
 

--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -29,6 +29,9 @@ export class CircleTool extends DrawingTool {
     ctx.beginPath();
     ctx.arc(this.startX, this.startY, radius, 0, Math.PI * 2);
     ctx.stroke();
+    if (editor.fill) {
+      ctx.fill();
+    }
     ctx.closePath();
   }
 
@@ -40,6 +43,9 @@ export class CircleTool extends DrawingTool {
     ctx.beginPath();
     ctx.arc(this.startX, this.startY, radius, 0, Math.PI * 2);
     ctx.stroke();
+    if (editor.fill) {
+      ctx.fill();
+    }
     ctx.closePath();
     this.imageData = null;
   }

--- a/src/tools/DrawingTool.ts
+++ b/src/tools/DrawingTool.ts
@@ -7,13 +7,13 @@ import { Tool } from "./Tool";
  * rendering context. Concrete tools must implement the pointer handlers.
  */
 export abstract class DrawingTool implements Tool {
-
+  protected applyStroke(ctx: CanvasRenderingContext2D, editor: Editor) {
     ctx.lineWidth = editor.lineWidthValue;
     ctx.strokeStyle = editor.strokeStyle;
+    ctx.fillStyle = editor.fillStyle;
   }
 
   abstract onPointerDown(e: PointerEvent, editor: Editor): void;
   abstract onPointerMove(e: PointerEvent, editor: Editor): void;
   abstract onPointerUp(e: PointerEvent, editor: Editor): void;
 }
-

--- a/src/tools/RectangleTool.ts
+++ b/src/tools/RectangleTool.ts
@@ -22,6 +22,9 @@ export class RectangleTool extends DrawingTool {
     const x = e.offsetX;
     const y = e.offsetY;
     ctx.strokeRect(this.startX, this.startY, x - this.startX, y - this.startY);
+    if (editor.fill) {
+      ctx.fillRect(this.startX, this.startY, x - this.startX, y - this.startY);
+    }
   }
 
   onPointerUp(e: PointerEvent, editor: Editor) {
@@ -34,6 +37,9 @@ export class RectangleTool extends DrawingTool {
     const x = e.offsetX;
     const y = e.offsetY;
     ctx.strokeRect(this.startX, this.startY, x - this.startX, y - this.startY);
+    if (editor.fill) {
+      ctx.fillRect(this.startX, this.startY, x - this.startX, y - this.startY);
+    }
     this.imageData = null;
   }
 }

--- a/tests/circleTool.test.ts
+++ b/tests/circleTool.test.ts
@@ -10,6 +10,7 @@ describe("CircleTool", () => {
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
     `;
     const canvas = document.getElementById("canvas") as HTMLCanvasElement;
     const imageData = {} as ImageData;
@@ -19,7 +20,9 @@ describe("CircleTool", () => {
       beginPath: jest.fn(),
       arc: jest.fn(),
       stroke: jest.fn(),
+      fill: jest.fn(),
       closePath: jest.fn(),
+      setTransform: jest.fn(),
       scale: jest.fn(),
     };
     canvas.getContext = jest
@@ -29,6 +32,7 @@ describe("CircleTool", () => {
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
+      document.getElementById("fillMode") as HTMLInputElement,
     );
   });
 
@@ -51,5 +55,13 @@ describe("CircleTool", () => {
     expect(ctx.arc).toHaveBeenCalledWith(2, 3, radius, 0, Math.PI * 2);
     expect(ctx.stroke).toHaveBeenCalled();
     expect(ctx.closePath).toHaveBeenCalled();
+  });
+
+  it("fills circle on pointer up when enabled", () => {
+    const tool = new CircleTool();
+    (document.getElementById("fillMode") as HTMLInputElement).checked = true;
+    tool.onPointerDown({ offsetX: 2, offsetY: 3 } as PointerEvent, editor);
+    tool.onPointerUp({ offsetX: 5, offsetY: 7 } as PointerEvent, editor);
+    expect(ctx.fill).toHaveBeenCalled();
   });
 });

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -13,6 +13,7 @@ describe("editor integration", () => {
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
       <button id="pencil"></button>
       <button id="eraser"></button>
       <button id="rectangle"></button>
@@ -37,6 +38,7 @@ describe("editor integration", () => {
       getImageData: jest.fn(() => mockImage),
       putImageData: jest.fn(),
       strokeRect: jest.fn(),
+      fillRect: jest.fn(),
       setTransform: jest.fn(),
       scale: jest.fn(),
     };
@@ -61,6 +63,7 @@ describe("editor integration", () => {
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
+      document.getElementById("fillMode") as HTMLInputElement,
     );
 
     (document.getElementById("pencil") as HTMLButtonElement).addEventListener(
@@ -131,6 +134,14 @@ describe("editor integration", () => {
     expect(ctx.getImageData).toHaveBeenCalled();
     expect(ctx.putImageData).toHaveBeenCalled();
     expect(ctx.strokeRect).toHaveBeenCalledWith(1, 1, 2, 3);
+  });
+
+  it("draws filled rectangle when fill mode is enabled", () => {
+    (document.getElementById("rectangle") as HTMLButtonElement).click();
+    (document.getElementById("fillMode") as HTMLInputElement).checked = true;
+    dispatch("pointerdown", 1, 1, 1);
+    dispatch("pointerup", 3, 4, 0);
+    expect(ctx.fillRect).toHaveBeenCalledWith(1, 1, 2, 3);
   });
 });
 

--- a/tests/rectangleTool.test.ts
+++ b/tests/rectangleTool.test.ts
@@ -11,6 +11,7 @@ describe("RectangleTool", () => {
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
     `;
 
     const canvas = document.getElementById("canvas") as HTMLCanvasElement;
@@ -24,6 +25,7 @@ describe("RectangleTool", () => {
       getImageData: jest.fn(() => mockImage),
       putImageData: jest.fn(),
       strokeRect: jest.fn(),
+      fillRect: jest.fn(),
       clearRect: jest.fn(),
       beginPath: jest.fn(),
       moveTo: jest.fn(),
@@ -53,6 +55,7 @@ describe("RectangleTool", () => {
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
+      document.getElementById("fillMode") as HTMLInputElement,
     );
   });
 
@@ -66,6 +69,14 @@ describe("RectangleTool", () => {
     tool.onPointerDown({ offsetX: 10, offsetY: 15 } as PointerEvent, editor);
     tool.onPointerUp({ offsetX: 20, offsetY: 25 } as PointerEvent, editor);
     expect(ctx.strokeRect).toHaveBeenCalledWith(10, 15, 10, 10);
+  });
+
+  it("fills a rectangle when fill mode is enabled", () => {
+    const tool = new RectangleTool();
+    (document.getElementById("fillMode") as HTMLInputElement).checked = true;
+    tool.onPointerDown({ offsetX: 10, offsetY: 15 } as PointerEvent, editor);
+    tool.onPointerUp({ offsetX: 20, offsetY: 25 } as PointerEvent, editor);
+    expect(ctx.fillRect).toHaveBeenCalledWith(10, 15, 10, 10);
   });
 });
 


### PR DESCRIPTION
## Summary
- add fill-mode checkbox in toolbar and wire editor getters
- allow rectangle and circle tools to fill shapes when enabled
- cover filled shapes with new tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c2dd562f48328bd3ba15811268d1e