### PR TITLE
Add fill mode support and tests for shapes

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <div id="toolbar">
       <input type="color" id="colorPicker" value="#000000" />
       <input type="range" id="lineWidth" min="1" max="50" value="5" />
+      <input type="checkbox" id="fillMode" />
       <button id="pencil">Pencil</button>
       <button id="eraser">Eraser</button>
       <button id="rectangle">Rectangle</button>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node dist/index.js",
     "lint": "eslint . --ext .ts",
     "format": "prettier --write .",
-    "test": "jest tests/editor.test.ts tests/rectangleTool.test.ts"
+    "test": "jest tests/editor.test.ts tests/rectangleTool.test.ts tests/circleTool.test.ts"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.0",
@@ -30,7 +30,6 @@
       "ts-jest": {
         "useESM": true
       }
-    },
-
+    }
   }
 }

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -8,11 +8,13 @@ export class Editor {
   private currentTool: Tool | null = null;
   colorPicker: HTMLInputElement;
   lineWidth: HTMLInputElement;
+  fillMode: HTMLInputElement;
 
   constructor(
     canvas: HTMLCanvasElement,
     colorPicker: HTMLInputElement,
     lineWidth: HTMLInputElement,
+    fillMode: HTMLInputElement,
   ) {
     this.canvas = canvas;
     const ctx = canvas.getContext("2d");
@@ -20,6 +22,7 @@ export class Editor {
     this.ctx = ctx;
     this.colorPicker = colorPicker;
     this.lineWidth = lineWidth;
+    this.fillMode = fillMode;
     this.adjustForPixelRatio();
     window.addEventListener("resize", this.handleResize);
 
@@ -102,6 +105,14 @@ export class Editor {
 
   get lineWidthValue() {
     return parseInt(this.lineWidth.value, 10) || 1;
+  }
+
+  get fill() {
+    return this.fillMode.checked;
+  }
+
+  get fillStyle() {
+    return this.colorPicker.value;
   }
 
   /**

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -6,8 +6,10 @@ export function initEditor() {
   const canvas = document.getElementById("canvas") as HTMLCanvasElement;
   const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
   const lineWidth = document.getElementById("lineWidth") as HTMLInputElement;
+  const fillMode = document.getElementById("fillMode") as HTMLInputElement;
 
-  const editor = new Editor(canvas, colorPicker, lineWidth);
+  const editor = new Editor(canvas, colorPicker, lineWidth, fillMode);
   editor.setTool(new PencilTool());
+  return editor;
 }
 

--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -29,6 +29,10 @@ export class CircleTool extends DrawingTool {
     ctx.beginPath();
     ctx.arc(this.startX, this.startY, radius, 0, Math.PI * 2);
     ctx.stroke();
+    if (editor.fill) {
+      ctx.fillStyle = editor.fillStyle;
+      ctx.fill();
+    }
     ctx.closePath();
   }
 
@@ -40,6 +44,10 @@ export class CircleTool extends DrawingTool {
     ctx.beginPath();
     ctx.arc(this.startX, this.startY, radius, 0, Math.PI * 2);
     ctx.stroke();
+    if (editor.fill) {
+      ctx.fillStyle = editor.fillStyle;
+      ctx.fill();
+    }
     ctx.closePath();
     this.imageData = null;
   }

--- a/src/tools/DrawingTool.ts
+++ b/src/tools/DrawingTool.ts
@@ -7,7 +7,7 @@ import { Tool } from "./Tool";
  * rendering context. Concrete tools must implement the pointer handlers.
  */
 export abstract class DrawingTool implements Tool {
-
+  protected applyStroke(ctx: CanvasRenderingContext2D, editor: Editor) {
     ctx.lineWidth = editor.lineWidthValue;
     ctx.strokeStyle = editor.strokeStyle;
   }

--- a/src/tools/RectangleTool.ts
+++ b/src/tools/RectangleTool.ts
@@ -21,7 +21,13 @@ export class RectangleTool extends DrawingTool {
 
     const x = e.offsetX;
     const y = e.offsetY;
-    ctx.strokeRect(this.startX, this.startY, x - this.startX, y - this.startY);
+    const width = x - this.startX;
+    const height = y - this.startY;
+    ctx.strokeRect(this.startX, this.startY, width, height);
+    if (editor.fill) {
+      ctx.fillStyle = editor.fillStyle;
+      ctx.fillRect(this.startX, this.startY, width, height);
+    }
   }
 
   onPointerUp(e: PointerEvent, editor: Editor) {
@@ -33,7 +39,13 @@ export class RectangleTool extends DrawingTool {
     this.applyStroke(editor.ctx, editor);
     const x = e.offsetX;
     const y = e.offsetY;
-    ctx.strokeRect(this.startX, this.startY, x - this.startX, y - this.startY);
+    const width = x - this.startX;
+    const height = y - this.startY;
+    ctx.strokeRect(this.startX, this.startY, width, height);
+    if (editor.fill) {
+      ctx.fillStyle = editor.fillStyle;
+      ctx.fillRect(this.startX, this.startY, width, height);
+    }
     this.imageData = null;
   }
 }

--- a/tests/circleTool.test.ts
+++ b/tests/circleTool.test.ts
@@ -10,6 +10,7 @@ describe("CircleTool", () => {
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
     `;
     const canvas = document.getElementById("canvas") as HTMLCanvasElement;
     const imageData = {} as ImageData;
@@ -19,8 +20,10 @@ describe("CircleTool", () => {
       beginPath: jest.fn(),
       arc: jest.fn(),
       stroke: jest.fn(),
+      fill: jest.fn(),
       closePath: jest.fn(),
       scale: jest.fn(),
+      setTransform: jest.fn(),
     };
     canvas.getContext = jest
       .fn()
@@ -29,6 +32,7 @@ describe("CircleTool", () => {
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
+      document.getElementById("fillMode") as HTMLInputElement,
     );
   });
 
@@ -51,5 +55,13 @@ describe("CircleTool", () => {
     expect(ctx.arc).toHaveBeenCalledWith(2, 3, radius, 0, Math.PI * 2);
     expect(ctx.stroke).toHaveBeenCalled();
     expect(ctx.closePath).toHaveBeenCalled();
+  });
+
+  it("fills circle when fill mode is enabled", () => {
+    const tool = new CircleTool();
+    (document.getElementById("fillMode") as HTMLInputElement).checked = true;
+    tool.onPointerDown({ offsetX: 2, offsetY: 3 } as PointerEvent, editor);
+    tool.onPointerUp({ offsetX: 5, offsetY: 7 } as PointerEvent, editor);
+    expect(ctx.fill).toHaveBeenCalled();
   });
 });

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -13,6 +13,7 @@ describe("editor integration", () => {
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
       <button id="pencil"></button>
       <button id="eraser"></button>
       <button id="rectangle"></button>
@@ -37,6 +38,7 @@ describe("editor integration", () => {
       getImageData: jest.fn(() => mockImage),
       putImageData: jest.fn(),
       strokeRect: jest.fn(),
+      fillRect: jest.fn(),
       setTransform: jest.fn(),
       scale: jest.fn(),
     };
@@ -61,6 +63,7 @@ describe("editor integration", () => {
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
+      document.getElementById("fillMode") as HTMLInputElement,
     );
 
     (document.getElementById("pencil") as HTMLButtonElement).addEventListener(
@@ -131,6 +134,23 @@ describe("editor integration", () => {
     expect(ctx.getImageData).toHaveBeenCalled();
     expect(ctx.putImageData).toHaveBeenCalled();
     expect(ctx.strokeRect).toHaveBeenCalledWith(1, 1, 2, 3);
+  });
+
+  it("fills rectangle when fill mode is enabled", () => {
+    (document.getElementById("rectangle") as HTMLButtonElement).click();
+    (document.getElementById("fillMode") as HTMLInputElement).checked = true;
+    dispatch("pointerdown", 1, 1, 1);
+    dispatch("pointerup", 3, 4, 0);
+    expect(ctx.fillRect).toHaveBeenCalledWith(1, 1, 2, 3);
+  });
+
+  it("exposes fill and fillStyle getters", () => {
+    const fill = document.getElementById("fillMode") as HTMLInputElement;
+    const color = document.getElementById("colorPicker") as HTMLInputElement;
+    fill.checked = true;
+    color.value = "#123456";
+    expect(editor.fill).toBe(true);
+    expect(editor.fillStyle).toBe("#123456");
   });
 });
 

--- a/tests/eraserTool.test.ts
+++ b/tests/eraserTool.test.ts
@@ -10,6 +10,7 @@ describe("EraserTool", () => {
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="10" />
+      <input id="fillMode" type="checkbox" />
     `;
     const canvas = document.getElementById("canvas") as HTMLCanvasElement;
     ctx = {
@@ -31,6 +32,7 @@ describe("EraserTool", () => {
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
+      document.getElementById("fillMode") as HTMLInputElement,
     );
   });
 

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -1,15 +1,17 @@
-import { initEditor, EditorHandle } from "../src/editor";
+import { initEditor } from "../src/editor";
+import { Editor } from "../src/core/Editor";
 
 describe("image operations", () => {
   let canvas: HTMLCanvasElement;
   let ctx: Partial<CanvasRenderingContext2D>;
-  let handle: EditorHandle;
+  let editor: Editor;
 
   beforeEach(() => {
     document.body.innerHTML = `
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
       <input id="imageLoader" type="file" />
       <button id="save"></button>
     `;
@@ -39,13 +41,13 @@ describe("image operations", () => {
     }
     (global as any).Image = MockImage;
 
-    handle = initEditor();
+    editor = initEditor();
 
     (global as any).readSpy = readSpy;
   });
 
   afterEach(() => {
-    handle.destroy();
+    editor.destroy();
   });
 
   it("loads an image from input", async () => {

--- a/tests/lineTool.test.ts
+++ b/tests/lineTool.test.ts
@@ -10,6 +10,7 @@ describe("LineTool", () => {
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
     `;
     const canvas = document.getElementById("canvas") as HTMLCanvasElement;
     const imageData = {} as ImageData;
@@ -30,6 +31,7 @@ describe("LineTool", () => {
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
+      document.getElementById("fillMode") as HTMLInputElement,
     );
   });
 

--- a/tests/rectangleTool.test.ts
+++ b/tests/rectangleTool.test.ts
@@ -11,6 +11,7 @@ describe("RectangleTool", () => {
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
     `;
 
     const canvas = document.getElementById("canvas") as HTMLCanvasElement;
@@ -24,6 +25,7 @@ describe("RectangleTool", () => {
       getImageData: jest.fn(() => mockImage),
       putImageData: jest.fn(),
       strokeRect: jest.fn(),
+      fillRect: jest.fn(),
       clearRect: jest.fn(),
       beginPath: jest.fn(),
       moveTo: jest.fn(),
@@ -53,6 +55,7 @@ describe("RectangleTool", () => {
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
+      document.getElementById("fillMode") as HTMLInputElement,
     );
   });
 
@@ -66,6 +69,14 @@ describe("RectangleTool", () => {
     tool.onPointerDown({ offsetX: 10, offsetY: 15 } as PointerEvent, editor);
     tool.onPointerUp({ offsetX: 20, offsetY: 25 } as PointerEvent, editor);
     expect(ctx.strokeRect).toHaveBeenCalledWith(10, 15, 10, 10);
+  });
+
+  it("fills rectangle when fill mode is enabled", () => {
+    const tool = new RectangleTool();
+    (document.getElementById("fillMode") as HTMLInputElement).checked = true;
+    tool.onPointerDown({ offsetX: 10, offsetY: 15 } as PointerEvent, editor);
+    tool.onPointerUp({ offsetX: 20, offsetY: 25 } as PointerEvent, editor);
+    expect(ctx.fillRect).toHaveBeenCalledWith(10, 15, 10, 10);
   });
 });
 

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -6,6 +6,7 @@ describe("save button", () => {
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
       <button id="save"></button>
     `;
 

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -14,6 +14,7 @@ describe("additional tools", () => {
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
     `;
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
     ctx = {
@@ -33,6 +34,7 @@ describe("additional tools", () => {
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
+      document.getElementById("fillMode") as HTMLInputElement,
     );
   });
 


### PR DESCRIPTION
## Summary
- add fill mode checkbox and expose `fill`/`fillStyle` in editor
- fill rectangles and circles when fill mode is active
- expand unit tests to cover shape filling and editor getters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c8906bab08328be2edcfd7296bb84