### PR TITLE
refactor: centralize stroke styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,14 +23,13 @@
     "ts-jest": "^29.2.3",
     "jest-environment-jsdom": "^29.7.0"
   },
-  "jest": {
-    "preset": "ts-jest",
-    "testEnvironment": "jsdom",
-    "globals": {
-      "ts-jest": {
-        "useESM": true
+    "jest": {
+      "preset": "ts-jest",
+      "testEnvironment": "jsdom",
+      "globals": {
+        "ts-jest": {
+          "useESM": true
+        }
       }
-    },
-
+    }
   }
-}

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2,12 +2,13 @@ import { Editor } from "./core/Editor";
 import { PencilTool } from "./tools/PencilTool";
 
 
-export function initEditor() {
+export function initEditor(): Editor {
   const canvas = document.getElementById("canvas") as HTMLCanvasElement;
   const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
   const lineWidth = document.getElementById("lineWidth") as HTMLInputElement;
 
   const editor = new Editor(canvas, colorPicker, lineWidth);
   editor.setTool(new PencilTool());
+  return editor;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { initEditor } from "./editor";
 
 const handle = initEditor();
-window.addEventListener("beforeunload", handle.destroy);
+window.addEventListener("beforeunload", () => handle.destroy());
 

--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -34,6 +34,7 @@ export class CircleTool extends DrawingTool {
 
   onPointerUp(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
+    this.applyStroke(ctx, editor);
     const dx = e.offsetX - this.startX;
     const dy = e.offsetY - this.startY;
     const radius = Math.sqrt(dx * dx + dy * dy);

--- a/src/tools/DrawingTool.ts
+++ b/src/tools/DrawingTool.ts
@@ -7,7 +7,16 @@ import { Tool } from "./Tool";
  * rendering context. Concrete tools must implement the pointer handlers.
  */
 export abstract class DrawingTool implements Tool {
-
+  /**
+   * Apply the editor's current stroke settings to the provided context.
+   *
+   * @param ctx - canvas rendering context to configure
+   * @param editor - editor providing the stroke configuration
+   */
+  protected applyStroke(
+    ctx: CanvasRenderingContext2D,
+    editor: Editor,
+  ): void {
     ctx.lineWidth = editor.lineWidthValue;
     ctx.strokeStyle = editor.strokeStyle;
   }

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -32,6 +32,7 @@ export class LineTool extends DrawingTool {
 
   onPointerUp(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
+    this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
     ctx.lineTo(e.offsetX, e.offsetY);


### PR DESCRIPTION
## Summary
- add `DrawingTool` base with `applyStroke` helper
- update drawing tools to use `applyStroke`
- fix editor init so TypeScript build passes

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c8904efd883289f951b5bc1011c94