### PR TITLE
feat: add textarea based text tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node dist/index.js",
     "lint": "eslint . --ext .ts",
     "format": "prettier --write .",
-    "test": "jest tests/editor.test.ts tests/rectangleTool.test.ts"
+    "test": "jest tests/editor.test.ts tests/rectangleTool.test.ts tests/textTool.test.ts"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.0",
@@ -30,7 +30,6 @@
       "ts-jest": {
         "useESM": true
       }
-    },
-
+    }
   }
 }

--- a/src/tools/DrawingTool.ts
+++ b/src/tools/DrawingTool.ts
@@ -7,7 +7,10 @@ import { Tool } from "./Tool";
  * rendering context. Concrete tools must implement the pointer handlers.
  */
 export abstract class DrawingTool implements Tool {
-
+  protected applyStroke(
+    ctx: CanvasRenderingContext2D,
+    editor: Editor,
+  ): void {
     ctx.lineWidth = editor.lineWidthValue;
     ctx.strokeStyle = editor.strokeStyle;
   }
@@ -16,4 +19,3 @@ export abstract class DrawingTool implements Tool {
   abstract onPointerMove(e: PointerEvent, editor: Editor): void;
   abstract onPointerUp(e: PointerEvent, editor: Editor): void;
 }
-

--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -2,13 +2,56 @@ import { Editor } from "../core/Editor";
 import { Tool } from "./Tool";
 
 export class TextTool implements Tool {
+  private textarea: HTMLTextAreaElement | null = null;
+  private startX = 0;
+  private startY = 0;
+
   onPointerDown(e: PointerEvent, editor: Editor) {
-    const text = prompt("Enter text:") ?? "";
-    if (!text) return;
-    const ctx = editor.ctx;
-    ctx.fillStyle = editor.strokeStyle;
-    ctx.font = `${editor.lineWidthValue * 4}px sans-serif`;
-    ctx.fillText(text, e.offsetX, e.offsetY);
+    const container = editor.canvas.parentElement || document.body;
+    this.startX = e.offsetX;
+    this.startY = e.offsetY;
+
+    const textarea = document.createElement("textarea");
+    textarea.style.position = "absolute";
+    textarea.style.left = `${this.startX}px`;
+    textarea.style.top = `${this.startY}px`;
+    textarea.style.color = editor.strokeStyle;
+    textarea.style.font = `${editor.lineWidthValue * 4}px sans-serif`;
+    textarea.style.background = "transparent";
+    textarea.style.border = "none";
+    textarea.style.padding = "0";
+    textarea.style.margin = "0";
+    textarea.style.outline = "none";
+
+    const remove = (draw: boolean) => {
+      if (draw && textarea.value) {
+        const ctx = editor.ctx;
+        ctx.fillStyle = editor.strokeStyle;
+        ctx.font = `${editor.lineWidthValue * 4}px sans-serif`;
+        ctx.fillText(textarea.value, this.startX, this.startY);
+      }
+      textarea.remove();
+      textarea.removeEventListener("blur", onBlur);
+      textarea.removeEventListener("keydown", onKeyDown);
+      this.textarea = null;
+    };
+
+    const onBlur = () => remove(true);
+    const onKeyDown = (ev: KeyboardEvent) => {
+      if (ev.key === "Enter") {
+        ev.preventDefault();
+        remove(true);
+      } else if (ev.key === "Escape") {
+        ev.preventDefault();
+        remove(false);
+      }
+    };
+
+    textarea.addEventListener("blur", onBlur, { once: true });
+    textarea.addEventListener("keydown", onKeyDown);
+    container.appendChild(textarea);
+    textarea.focus();
+    this.textarea = textarea;
   }
 
   onPointerMove(_e: PointerEvent, _editor: Editor) {
@@ -19,4 +62,3 @@ export class TextTool implements Tool {
     // No operation
   }
 }
-

--- a/tests/textTool.test.ts
+++ b/tests/textTool.test.ts
@@ -1,0 +1,80 @@
+import { Editor } from "../src/core/Editor";
+import { TextTool } from "../src/tools/TextTool";
+
+describe("text tool overlay", () => {
+  let canvas: HTMLCanvasElement;
+  let ctx: Partial<CanvasRenderingContext2D>;
+  let editor: Editor;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="container">
+        <canvas id="canvas"></canvas>
+      </div>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="2" />
+    `;
+    canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    ctx = {
+      fillText: jest.fn(),
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+    };
+    canvas.getContext = jest
+      .fn()
+      .mockReturnValue(ctx as CanvasRenderingContext2D);
+    canvas.getBoundingClientRect = () => ({
+      width: 100,
+      height: 100,
+      top: 0,
+      left: 0,
+      bottom: 100,
+      right: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+    editor = new Editor(
+      canvas,
+      document.getElementById("colorPicker") as HTMLInputElement,
+      document.getElementById("lineWidth") as HTMLInputElement,
+    );
+  });
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  it("creates a textarea on pointer down", () => {
+    const tool = new TextTool();
+    tool.onPointerDown({ offsetX: 10, offsetY: 15 } as PointerEvent, editor);
+    const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea).not.toBeNull();
+    expect(textarea.style.left).toBe("10px");
+    expect(textarea.style.top).toBe("15px");
+  });
+
+  it("renders text on enter and removes the textarea", () => {
+    const tool = new TextTool();
+    tool.onPointerDown({ offsetX: 10, offsetY: 20 } as PointerEvent, editor);
+    const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
+    textarea.value = "Hello";
+    textarea.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+    expect(ctx.fillText).toHaveBeenCalledWith("Hello", 10, 20);
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("removes textarea on escape without drawing", () => {
+    const tool = new TextTool();
+    tool.onPointerDown({ offsetX: 5, offsetY: 6 } as PointerEvent, editor);
+    const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
+    textarea.value = "Hi";
+    textarea.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    expect(ctx.fillText).not.toHaveBeenCalled();
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- replace prompt-driven text entry with an overlay `<textarea>` positioned on pointer down
- render text to the canvas on blur or Enter and remove overlay on Escape
- add unit tests verifying creation, rendering, and cleanup of the text overlay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c89085d08832885295ca4400f5d84