### PR TITLE
chore: fix package scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node dist/index.js",
     "lint": "eslint . --ext .ts",
     "format": "prettier --write .",
-
+    "test": "jest"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.0",


### PR DESCRIPTION
## Summary
- add `test` script for jest
- remove trailing comma in package scripts

## Testing
- `npm install`
- `npm test` *(fails: Property 'applyStroke' does not exist on type 'PencilTool')*
- `npm run build` *(fails: Unexpected keyword or identifier in DrawingTool.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689cf4d93dd48328b78dfa16ab721cc2