### PR TITLE
Refactor stroke handling for drawing tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "lint": "eslint . --ext .ts",
-    "format": "prettier --write .",
-
+    "format": "prettier --write ."
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.0",

--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -37,6 +37,7 @@ export class CircleTool extends DrawingTool {
 
   onPointerUp(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
+    this.applyStroke(editor.ctx, editor);
     const dx = e.offsetX - this.startX;
     const dy = e.offsetY - this.startY;
     const radius = Math.sqrt(dx * dx + dy * dy);

--- a/src/tools/DrawingTool.ts
+++ b/src/tools/DrawingTool.ts
@@ -7,7 +7,7 @@ import { Tool } from "./Tool";
  * rendering context. Concrete tools must implement the pointer handlers.
  */
 export abstract class DrawingTool implements Tool {
-
+  protected applyStroke(ctx: CanvasRenderingContext2D, editor: Editor): void {
     ctx.lineWidth = editor.lineWidthValue;
     ctx.strokeStyle = editor.strokeStyle;
     ctx.fillStyle = editor.fillStyle;

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -32,6 +32,7 @@ export class LineTool extends DrawingTool {
 
   onPointerUp(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
+    this.applyStroke(editor.ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
     ctx.lineTo(e.offsetX, e.offsetY);


### PR DESCRIPTION
## Summary
- Add protected `applyStroke` helper to `DrawingTool` and abstract pointer handlers
- Ensure line and circle tools apply stroke styles before drawing
- Fix `package.json` scripts syntax for npm compatibility

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*
- `npx jest` *(fails: this.ctx.setTransform is not a function; Expected 4 arguments, but got 3)*


------
https://chatgpt.com/codex/tasks/task_e_689cf4da89e08328a8bbc6957d492df3