### PR TITLE
feat: add textarea overlay for text tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "lint": "eslint . --ext .ts",
-    "format": "prettier --write .",
-
+    "format": "prettier --write ."
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.0",

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -32,6 +32,7 @@ export class Editor {
   }
 
   setTool(tool: Tool) {
+    this.currentTool?.destroy?.();
     this.currentTool = tool;
   }
 
@@ -120,6 +121,7 @@ export class Editor {
    * Should be called before discarding the instance to prevent leaks.
    */
   destroy(): void {
+    this.currentTool?.destroy?.();
     window.removeEventListener("resize", this.handleResize);
     this.canvas.removeEventListener("pointerdown", this.handlePointerDown);
     this.canvas.removeEventListener("pointermove", this.handlePointerMove);

--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -2,13 +2,62 @@ import { Editor } from "../core/Editor";
 import { Tool } from "./Tool";
 
 export class TextTool implements Tool {
+  private textarea: HTMLTextAreaElement | null = null;
+  private x = 0;
+  private y = 0;
+  private blurListener: (() => void) | null = null;
+  private keydownListener: ((e: KeyboardEvent) => void) | null = null;
+
   onPointerDown(e: PointerEvent, editor: Editor) {
-    const text = prompt("Enter text:") ?? "";
-    if (!text) return;
-    const ctx = editor.ctx;
-    ctx.fillStyle = editor.strokeStyle;
-    ctx.font = `${editor.lineWidthValue * 4}px sans-serif`;
-    ctx.fillText(text, e.offsetX, e.offsetY);
+    this.cleanup();
+    this.x = e.offsetX;
+    this.y = e.offsetY;
+
+    const textarea = document.createElement("textarea");
+    this.textarea = textarea;
+    const container = editor.canvas.parentElement || document.body;
+    textarea.style.position = "absolute";
+    textarea.style.left = `${this.x}px`;
+    textarea.style.top = `${this.y}px`;
+    textarea.style.color = editor.strokeStyle;
+    textarea.style.fontSize = `${editor.lineWidthValue * 4}px`;
+    textarea.style.background = "transparent";
+    textarea.style.border = "none";
+    textarea.style.padding = "0";
+    textarea.style.margin = "0";
+    textarea.style.outline = "none";
+    textarea.style.resize = "none";
+    container.appendChild(textarea);
+    textarea.focus();
+
+    const commit = () => {
+      if (!this.textarea) return;
+      const text = this.textarea.value;
+      this.cleanup();
+      if (!text) return;
+      const ctx = editor.ctx;
+      ctx.fillStyle = editor.strokeStyle;
+      ctx.font = `${editor.lineWidthValue * 4}px sans-serif`;
+      ctx.fillText(text, this.x, this.y);
+    };
+
+    const cancel = () => {
+      this.cleanup();
+    };
+
+    this.blurListener = commit;
+    this.keydownListener = (ev: KeyboardEvent) => {
+      if (ev.key === "Enter") {
+        ev.preventDefault();
+        commit();
+      } else if (ev.key === "Escape") {
+        ev.preventDefault();
+        cancel();
+      }
+    };
+
+    textarea.addEventListener("blur", this.blurListener);
+    textarea.addEventListener("keydown", this.keydownListener);
   }
 
   onPointerMove(_e: PointerEvent, _editor: Editor) {
@@ -16,7 +65,26 @@ export class TextTool implements Tool {
   }
 
   onPointerUp(_e: PointerEvent, _editor: Editor) {
-    // No operation
+    if (this.textarea && document.activeElement !== this.textarea) {
+      this.cleanup();
+    }
+  }
+
+  destroy() {
+    this.cleanup();
+  }
+
+  private cleanup() {
+    if (!this.textarea) return;
+    if (this.blurListener) {
+      this.textarea.removeEventListener("blur", this.blurListener);
+    }
+    if (this.keydownListener) {
+      this.textarea.removeEventListener("keydown", this.keydownListener);
+    }
+    this.textarea.remove();
+    this.textarea = null;
+    this.blurListener = null;
+    this.keydownListener = null;
   }
 }
-

--- a/src/tools/Tool.ts
+++ b/src/tools/Tool.ts
@@ -4,4 +4,5 @@ export interface Tool {
   onPointerDown(e: PointerEvent, editor: Editor): void;
   onPointerMove(e: PointerEvent, editor: Editor): void;
   onPointerUp(e: PointerEvent, editor: Editor): void;
+  destroy?(): void;
 }

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -64,13 +64,33 @@ describe("additional tools", () => {
     expect(ctx.arc).toHaveBeenCalledWith(0, 0, 5, 0, Math.PI * 2);
   });
 
-  it("text tool draws text", () => {
+  it("text tool commits text on Enter", () => {
     const tool = new TextTool();
-    const promptSpy = jest
-      .spyOn(window, "prompt")
-      .mockReturnValue("Hi");
     tool.onPointerDown({ offsetX: 1, offsetY: 2 } as PointerEvent, editor);
+    const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
+    textarea.value = "Hi";
+    textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
     expect(ctx.fillText).toHaveBeenCalledWith("Hi", 1, 2);
-    promptSpy.mockRestore();
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("text tool commits text on blur", () => {
+    const tool = new TextTool();
+    tool.onPointerDown({ offsetX: 1, offsetY: 2 } as PointerEvent, editor);
+    const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
+    textarea.value = "Blur";
+    textarea.dispatchEvent(new Event("blur"));
+    expect(ctx.fillText).toHaveBeenCalledWith("Blur", 1, 2);
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("text tool cancels on Escape", () => {
+    const tool = new TextTool();
+    tool.onPointerDown({ offsetX: 1, offsetY: 2 } as PointerEvent, editor);
+    const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
+    textarea.value = "Hi";
+    textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(ctx.fillText).not.toHaveBeenCalled();
+    expect(document.querySelector("textarea")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- add positioned textarea overlay for text tool with commit and cancel handlers
- clean up overlays when switching tools or destroying editor
- cover text entry commit and cancellation in tests

## Testing
- `npx jest --runInBand` (fails: Property 'applyStroke' does not exist on type 'PencilTool')

------
https://chatgpt.com/codex/tasks/task_e_689cf4de0dd88328b1fadbf9941b25ae