### PR TITLE
Add toolbar control listeners and tests

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,6 +1,11 @@
 import { Editor } from "./core/Editor";
 import { Shortcuts } from "./core/Shortcuts";
 import { PencilTool } from "./tools/PencilTool";
+import { EraserTool } from "./tools/EraserTool";
+import { RectangleTool } from "./tools/RectangleTool";
+import { LineTool } from "./tools/LineTool";
+import { CircleTool } from "./tools/CircleTool";
+import { TextTool } from "./tools/TextTool";
 
 export interface EditorHandle {
   editor: Editor;
@@ -17,9 +22,63 @@ export function initEditor(): EditorHandle {
   editor.setTool(new PencilTool());
   const shortcuts = new Shortcuts(editor);
 
+  const pencil = document.getElementById("pencil");
+  const eraser = document.getElementById("eraser");
+  const rectangle = document.getElementById("rectangle");
+  const line = document.getElementById("line");
+  const circle = document.getElementById("circle");
+  const text = document.getElementById("text");
+  const undo = document.getElementById("undo");
+  const redo = document.getElementById("redo");
+  const imageLoader = document.getElementById("imageLoader") as HTMLInputElement | null;
+  const save = document.getElementById("save");
+
+  type Listener = [Element, string, EventListener];
+  const listeners: Listener[] = [];
+
+  function addListener(el: Element | null, type: string, handler: EventListener) {
+    if (!el) return;
+    el.addEventListener(type, handler);
+    listeners.push([el, type, handler]);
+  }
+
+  addListener(pencil, "click", () => editor.setTool(new PencilTool()));
+  addListener(eraser, "click", () => editor.setTool(new EraserTool()));
+  addListener(rectangle, "click", () => editor.setTool(new RectangleTool()));
+  addListener(line, "click", () => editor.setTool(new LineTool()));
+  addListener(circle, "click", () => editor.setTool(new CircleTool()));
+  addListener(text, "click", () => editor.setTool(new TextTool()));
+  addListener(undo, "click", () => editor.undo());
+  addListener(redo, "click", () => editor.redo());
+
+  addListener(imageLoader, "change", () => {
+    const file = imageLoader?.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        editor.ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+      };
+      img.src = reader.result as string;
+    };
+    reader.readAsDataURL(file);
+  });
+
+  addListener(save, "click", () => {
+    const data = canvas.toDataURL("image/png");
+    const a = document.createElement("a");
+    a.href = data;
+    a.download = "canvas.png";
+    a.click();
+  });
+
   return {
     editor,
     destroy() {
+      listeners.forEach(([el, type, handler]) =>
+        el.removeEventListener(type, handler),
+      );
       shortcuts.destroy();
       editor.destroy();
     },

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -10,6 +10,7 @@ describe("image operations", () => {
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
       <input id="imageLoader" type="file" />
       <button id="save"></button>
     `;

--- a/tests/toolbar.test.ts
+++ b/tests/toolbar.test.ts
@@ -1,0 +1,88 @@
+import { initEditor, EditorHandle } from "../src/editor";
+import { PencilTool } from "../src/tools/PencilTool";
+import { EraserTool } from "../src/tools/EraserTool";
+import { RectangleTool } from "../src/tools/RectangleTool";
+import { LineTool } from "../src/tools/LineTool";
+import { CircleTool } from "../src/tools/CircleTool";
+import { TextTool } from "../src/tools/TextTool";
+
+describe("toolbar controls", () => {
+  let handle: EditorHandle;
+  let canvas: HTMLCanvasElement;
+  let ctx: Partial<CanvasRenderingContext2D>;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <canvas id="canvas"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
+      <button id="pencil"></button>
+      <button id="eraser"></button>
+      <button id="rectangle"></button>
+      <button id="line"></button>
+      <button id="circle"></button>
+      <button id="text"></button>
+      <button id="undo"></button>
+      <button id="redo"></button>
+    `;
+
+    canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    ctx = {
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+      getImageData: jest.fn(),
+      putImageData: jest.fn(),
+      clearRect: jest.fn(),
+    };
+    canvas.getContext = jest.fn().mockReturnValue(ctx as CanvasRenderingContext2D);
+    canvas.getBoundingClientRect = () => ({
+      width: 100,
+      height: 100,
+      top: 0,
+      left: 0,
+      bottom: 100,
+      right: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+
+    handle = initEditor();
+  });
+
+  afterEach(() => {
+    handle.destroy();
+  });
+
+  it("switches tools when buttons are clicked", () => {
+    const spy = jest.spyOn(handle.editor, "setTool");
+    (document.getElementById("pencil") as HTMLButtonElement).click();
+    expect(spy.mock.calls[0][0]).toBeInstanceOf(PencilTool);
+
+    (document.getElementById("eraser") as HTMLButtonElement).click();
+    expect(spy.mock.calls[1][0]).toBeInstanceOf(EraserTool);
+
+    (document.getElementById("rectangle") as HTMLButtonElement).click();
+    expect(spy.mock.calls[2][0]).toBeInstanceOf(RectangleTool);
+
+    (document.getElementById("line") as HTMLButtonElement).click();
+    expect(spy.mock.calls[3][0]).toBeInstanceOf(LineTool);
+
+    (document.getElementById("circle") as HTMLButtonElement).click();
+    expect(spy.mock.calls[4][0]).toBeInstanceOf(CircleTool);
+
+    (document.getElementById("text") as HTMLButtonElement).click();
+    expect(spy.mock.calls[5][0]).toBeInstanceOf(TextTool);
+  });
+
+  it("triggers undo and redo when buttons are clicked", () => {
+    const undo = jest.spyOn(handle.editor, "undo").mockImplementation(() => {});
+    const redo = jest.spyOn(handle.editor, "redo").mockImplementation(() => {});
+    (document.getElementById("undo") as HTMLButtonElement).click();
+    expect(undo).toHaveBeenCalled();
+    (document.getElementById("redo") as HTMLButtonElement).click();
+    expect(redo).toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- wire up toolbar buttons for tools, undo/redo, image load and save
- clean up listeners via destroy function
- test toolbar controls trigger tool changes and undo/redo

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cf4df02c48328bd6a71fd067b7400