### PR TITLE
Implement textarea overlay for text tool with tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node dist/index.js",
     "lint": "eslint . --ext .ts",
     "format": "prettier --write .",
-
+    "test": "jest"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.0",

--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -2,13 +2,64 @@ import { Editor } from "../core/Editor";
 import { Tool } from "./Tool";
 
 export class TextTool implements Tool {
+  private textarea: HTMLTextAreaElement | null = null;
+  private startX = 0;
+  private startY = 0;
+
   onPointerDown(e: PointerEvent, editor: Editor) {
-    const text = prompt("Enter text:") ?? "";
-    if (!text) return;
-    const ctx = editor.ctx;
-    ctx.fillStyle = editor.strokeStyle;
-    ctx.font = `${editor.lineWidthValue * 4}px sans-serif`;
-    ctx.fillText(text, e.offsetX, e.offsetY);
+    if (this.textarea) return; // prevent multiple overlays
+
+    this.startX = e.offsetX;
+    this.startY = e.offsetY;
+
+    const textarea = document.createElement("textarea");
+    this.textarea = textarea;
+    textarea.style.position = "absolute";
+    const container = editor.canvas.parentElement || document.body;
+    const canvasRect = editor.canvas.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+    textarea.style.left = `${canvasRect.left - containerRect.left + this.startX}px`;
+    textarea.style.top = `${canvasRect.top - containerRect.top + this.startY}px`;
+    textarea.style.color = editor.strokeStyle;
+    textarea.style.fontSize = `${editor.lineWidthValue * 4}px`;
+    textarea.style.border = "1px solid";
+    textarea.style.background = "transparent";
+    textarea.style.padding = "0";
+    textarea.style.margin = "0";
+    textarea.style.outline = "none";
+    textarea.style.resize = "none";
+
+    const commit = () => {
+      if (!this.textarea) return;
+      const text = this.textarea.value;
+      container.removeChild(this.textarea);
+      this.textarea = null;
+      if (!text) return;
+      const ctx = editor.ctx;
+      ctx.fillStyle = editor.strokeStyle;
+      ctx.font = `${editor.lineWidthValue * 4}px sans-serif`;
+      ctx.fillText(text, this.startX, this.startY);
+    };
+
+    const cancel = () => {
+      if (!this.textarea) return;
+      container.removeChild(this.textarea);
+      this.textarea = null;
+    };
+
+    textarea.addEventListener("blur", commit, { once: true });
+    textarea.addEventListener("keydown", (ev) => {
+      if (ev.key === "Enter") {
+        ev.preventDefault();
+        commit();
+      } else if (ev.key === "Escape") {
+        ev.preventDefault();
+        cancel();
+      }
+    });
+
+    container.appendChild(textarea);
+    textarea.focus();
   }
 
   onPointerMove(_e: PointerEvent, _editor: Editor) {

--- a/tests/textTool.test.ts
+++ b/tests/textTool.test.ts
@@ -1,0 +1,104 @@
+import { Editor } from "../src/core/Editor";
+import { TextTool } from "../src/tools/TextTool";
+
+describe("TextTool", () => {
+  let editor: Editor;
+  let ctx: Partial<CanvasRenderingContext2D>;
+  let canvas: HTMLCanvasElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="container">
+        <canvas id="canvas"></canvas>
+      </div>
+      <input id="colorPicker" value="#123456" />
+      <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
+    `;
+
+    canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    const container = document.getElementById("container") as HTMLElement;
+
+    ctx = {
+      fillText: jest.fn(),
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+    };
+
+    canvas.getContext = jest
+      .fn()
+      .mockReturnValue(ctx as CanvasRenderingContext2D);
+    canvas.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      width: 0,
+      height: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+    container.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      width: 0,
+      height: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+
+    editor = new Editor(
+      canvas,
+      document.getElementById("colorPicker") as HTMLInputElement,
+      document.getElementById("lineWidth") as HTMLInputElement,
+      document.getElementById("fillMode") as HTMLInputElement,
+    );
+  });
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  it("creates textarea overlay on pointer down", () => {
+    const tool = new TextTool();
+    tool.onPointerDown({ offsetX: 10, offsetY: 20 } as PointerEvent, editor);
+    const ta = document.querySelector("textarea") as HTMLTextAreaElement;
+    expect(ta).toBeTruthy();
+    expect(ta.style.left).toBe("10px");
+    expect(ta.style.top).toBe("20px");
+    const hexToRgb = (hex: string) => {
+      const v = hex.replace("#", "");
+      const r = parseInt(v.substring(0, 2), 16);
+      const g = parseInt(v.substring(2, 4), 16);
+      const b = parseInt(v.substring(4, 6), 16);
+      return `rgb(${r}, ${g}, ${b})`;
+    };
+    expect(ta.style.color).toBe(hexToRgb(editor.strokeStyle));
+    expect(ta.style.fontSize).toBe(`${editor.lineWidthValue * 4}px`);
+  });
+
+  it("commits text on Enter", () => {
+    const tool = new TextTool();
+    tool.onPointerDown({ offsetX: 5, offsetY: 6 } as PointerEvent, editor);
+    const ta = document.querySelector("textarea") as HTMLTextAreaElement;
+    ta.value = "hello";
+    ta.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(ctx.fillText).toHaveBeenCalledWith("hello", 5, 6);
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("cancels text on Escape", () => {
+    const tool = new TextTool();
+    tool.onPointerDown({ offsetX: 7, offsetY: 8 } as PointerEvent, editor);
+    const ta = document.querySelector("textarea") as HTMLTextAreaElement;
+    ta.value = "cancel";
+    ta.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    expect(ctx.fillText).not.toHaveBeenCalled();
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Summary
- Replace prompt-based text input with an editable textarea overlay that commits to the canvas on blur or Enter and cancels on Escape
- Add Jest tests for overlay creation, commit, and cancellation flows
- Fix package.json scripts to enable running tests

## Testing
- `npm test` (fails: TypeScript errors in unrelated tool tests)
- `npm test tests/textTool.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689d3f99d98083288d8d2e856cd446a4