### PR TITLE
chore(ci): harden workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,19 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v4.1.0
+      - uses: actions/setup-node@v4.0.2
         with:
           node-version: 20
           cache: npm
-      - run: npm install
+          cache-dependency-path: package-lock.json
+      - run: npm ci
       - run: npm run lint
       - run: npm test


### PR DESCRIPTION
## Summary
- ensure workflow uses read-only permissions
- pin checkout and setup-node actions to specific patch versions
- use npm ci with lockfile cache

## Testing
- `npm ci` *(fails: JSON.parse error in package.json)*
- `npm test` *(fails: JSON.parse error in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d50232c1c8328b35c94f7cc173a18