### PR TITLE
test: simulate textarea overlay in editor test

### DIFF
--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -136,9 +136,14 @@ describe("editor toolbar controls", () => {
   });
 
   it("writes text with text tool", () => {
-    window.prompt = jest.fn().mockReturnValue("hi");
     (document.getElementById("text") as HTMLButtonElement).click();
     dispatch("pointerdown", 10, 10, 1);
+    const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
+    textarea.value = "hi";
+    textarea.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true })
+    );
     expect(ctx.fillText).toHaveBeenCalledWith("hi", 10, 10);
+    expect(document.querySelector("textarea")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- simulate text entry via textarea overlay in editor integration test

## Testing
- `npm test` *(fails: TypeScript compilation errors in src/editor.ts and related tests)*

------
https://chatgpt.com/codex/tasks/task_e_689d84dabc28832891e8bdba96acc654