### PR TITLE
Refactor eraser tool to use DrawingTool

### DIFF
--- a/src/tools/EraserTool.ts
+++ b/src/tools/EraserTool.ts
@@ -1,13 +1,13 @@
 import { Editor } from "../core/Editor";
-import { Tool } from "./Tool";
+import { DrawingTool } from "./DrawingTool";
 
-export class EraserTool implements Tool {
+export class EraserTool extends DrawingTool {
   onPointerDown(e: PointerEvent, editor: Editor) {
     const ctx = editor.ctx;
     ctx.globalCompositeOperation = "destination-out";
-    ctx.lineWidth = editor.lineWidthValue;
-    ctx.beginPath?.();
-    ctx.moveTo?.(e.offsetX, e.offsetY);
+    this.applyStroke(ctx, editor);
+    ctx.beginPath();
+    ctx.moveTo(e.offsetX, e.offsetY);
     ctx.clearRect(
       e.offsetX - editor.lineWidthValue / 2,
       e.offsetY - editor.lineWidthValue / 2,
@@ -16,24 +16,23 @@ export class EraserTool implements Tool {
     );
   }
 
-    onPointerMove(e: PointerEvent, editor: Editor) {
-      if (e.buttons !== 1) return;
-      const ctx = editor.ctx;
-      ctx.lineWidth = editor.lineWidthValue;
-      ctx.lineTo?.(e.offsetX, e.offsetY);
-      ctx.stroke?.();
-      ctx.clearRect(
-        e.offsetX - editor.lineWidthValue / 2,
-        e.offsetY - editor.lineWidthValue / 2,
-        editor.lineWidthValue,
-        editor.lineWidthValue,
-      );
-    }
+  onPointerMove(e: PointerEvent, editor: Editor) {
+    if (e.buttons !== 1) return;
+    const ctx = editor.ctx;
+    this.applyStroke(ctx, editor);
+    ctx.lineTo(e.offsetX, e.offsetY);
+    ctx.stroke();
+    ctx.clearRect(
+      e.offsetX - editor.lineWidthValue / 2,
+      e.offsetY - editor.lineWidthValue / 2,
+      editor.lineWidthValue,
+      editor.lineWidthValue,
+    );
+  }
 
   onPointerUp(_e: PointerEvent, editor: Editor) {
     const ctx = editor.ctx;
-    ctx.closePath?.();
+    ctx.closePath();
     ctx.globalCompositeOperation = "source-over";
   }
-
 }


### PR DESCRIPTION
## Summary
- refactor eraser tool to extend `DrawingTool` and drop optional chaining

## Testing
- `npm test` *(fails: Expected 4 arguments, but got 3; and parsing errors in src/editor.ts)*
- `npm run lint` *(fails: parsing error in src/editor.ts and @typescript-eslint/no-explicit-any warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689d84db15508328b2626ede34a096b7