### PR TITLE
ci: build project before linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,6 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
       - run: npm ci
+      - run: npm run build
       - run: npm run lint
       - run: npm test


### PR DESCRIPTION
## Summary
- run project build during CI

## Testing
- `npm test` *(fails: TS errors in tests and editor)*
- `npm run lint` *(fails: parsing errors and no-explicit-any violations)*

------
https://chatgpt.com/codex/tasks/task_e_689d7beb0f5c8328b4cca8c411520ead