### PR TITLE
chore: pin pages actions to exact versions

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,14 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.0
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v5.0.0
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v3.0.0
         with:
           # Upload entire repository
           path: '.'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v4.0.0


### PR DESCRIPTION
## Summary
- chore: pin GitHub Pages workflow actions to exact versions

## Testing
- `npm test` *(fails: TS2554: Expected 4 arguments, but got 3)*

------
https://chatgpt.com/codex/tasks/task_e_689d7be9e4808328b36d2f17e4a8e9cd