### PR TITLE
Implement editor initialization and text tool integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "lint": "eslint . --ext .ts",
-
+    "test": "jest"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.0",
@@ -22,13 +22,14 @@
     "ts-jest": "^29.2.3",
     "jest-environment-jsdom": "^29.7.0"
   },
-    "jest": {
-      "preset": "ts-jest",
-      "testEnvironment": "jsdom",
-      "globals": {
-        "ts-jest": {
-          "useESM": true
-        }
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "jsdom",
+    "globals": {
+      "ts-jest": {
+        "useESM": true
       }
     }
   }
+}
+

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -14,7 +14,7 @@ export class Editor {
     canvas: HTMLCanvasElement,
     colorPicker: HTMLInputElement,
     lineWidth: HTMLInputElement,
-
+    fillMode: HTMLInputElement,
   ) {
     this.canvas = canvas;
     const ctx = canvas.getContext("2d");

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -12,11 +12,35 @@ export interface EditorHandle {
   destroy: () => void;
 }
 
-
+/**
+ * Initialize the editor and wire DOM controls to it.
+ * Returns the editor instance together with a destroy function
+ * that removes all registered event listeners.
+ */
+export function initEditor(): EditorHandle {
+  // Query required DOM elements
   const canvas = document.getElementById("canvas") as HTMLCanvasElement;
   const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
   const lineWidth = document.getElementById("lineWidth") as HTMLInputElement;
+  const fillMode = document.getElementById("fillMode") as HTMLInputElement;
 
+  const pencilBtn = document.getElementById("pencil");
+  const eraserBtn = document.getElementById("eraser");
+  const rectBtn = document.getElementById("rectangle");
+  const lineBtn = document.getElementById("line");
+  const circleBtn = document.getElementById("circle");
+  const textBtn = document.getElementById("text");
+  const undoBtn = document.getElementById("undo");
+  const redoBtn = document.getElementById("redo");
+  const saveBtn = document.getElementById("save");
+  const imageLoader = document.getElementById("imageLoader") as HTMLInputElement | null;
+
+  // Instantiate editor and shortcuts
+  const editor = new Editor(canvas, colorPicker, lineWidth, fillMode);
+  const shortcuts = new Shortcuts(editor);
+
+  // Default tool
+  editor.setTool(new PencilTool());
 
   // Tool selection handlers
   const pencilHandler = () => editor.setTool(new PencilTool());
@@ -25,6 +49,7 @@ export interface EditorHandle {
   const lineHandler = () => editor.setTool(new LineTool());
   const circleHandler = () => editor.setTool(new CircleTool());
   const textHandler = () => editor.setTool(new TextTool());
+
   pencilBtn?.addEventListener("click", pencilHandler);
   eraserBtn?.addEventListener("click", eraserHandler);
   rectBtn?.addEventListener("click", rectHandler);
@@ -32,6 +57,11 @@ export interface EditorHandle {
   circleBtn?.addEventListener("click", circleHandler);
   textBtn?.addEventListener("click", textHandler);
 
+  // Undo/redo handlers
+  const undoHandler = () => editor.undo();
+  const redoHandler = () => editor.redo();
+  undoBtn?.addEventListener("click", undoHandler);
+  redoBtn?.addEventListener("click", redoHandler);
 
   // Save handler
   const saveHandler = () => {
@@ -43,5 +73,45 @@ export interface EditorHandle {
   };
   saveBtn?.addEventListener("click", saveHandler);
 
+  // Image loader handler
+  const loadHandler = () => {
+    const file = imageLoader?.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        editor.ctx.drawImage(
+          img,
+          0,
+          0,
+          canvas.width,
+          canvas.height,
+        );
+      };
+      img.src = reader.result as string;
+    };
+    reader.readAsDataURL(file);
+  };
+  imageLoader?.addEventListener("change", loadHandler);
+
+  // Destroy function to remove listeners
+  const destroy = () => {
+    pencilBtn?.removeEventListener("click", pencilHandler);
+    eraserBtn?.removeEventListener("click", eraserHandler);
+    rectBtn?.removeEventListener("click", rectHandler);
+    lineBtn?.removeEventListener("click", lineHandler);
+    circleBtn?.removeEventListener("click", circleHandler);
+    textBtn?.removeEventListener("click", textHandler);
+    undoBtn?.removeEventListener("click", undoHandler);
+    redoBtn?.removeEventListener("click", redoHandler);
+    saveBtn?.removeEventListener("click", saveHandler);
+    imageLoader?.removeEventListener("change", loadHandler);
+
+    shortcuts.destroy();
+    editor.destroy();
+  };
+
+  return { editor, destroy };
 }
 

--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -2,7 +2,27 @@ import { Editor } from "../core/Editor";
 import { Tool } from "./Tool";
 
 /**
+ * Tool allowing users to add text to the canvas by typing into a
+ * temporarily created textarea overlay. The text is committed on Enter
+ * and cancelled on Escape or blur.
+ */
+export class TextTool implements Tool {
+  private textarea: HTMLTextAreaElement | null = null;
+  private blurListener: (() => void) | null = null;
+  private keydownListener: ((e: KeyboardEvent) => void) | null = null;
 
+  onPointerDown(e: PointerEvent, editor: Editor): void {
+    this.cleanup();
+
+    const textarea = document.createElement("textarea");
+    textarea.style.position = "absolute";
+    textarea.style.left = `${e.offsetX}px`;
+    textarea.style.top = `${e.offsetY}px`;
+    textarea.style.color = editor.strokeStyle;
+    textarea.style.fontSize = `${editor.lineWidthValue * 4}px`;
+
+    document.body.appendChild(textarea);
+    textarea.focus();
 
     const commit = () => {
       if (!this.textarea) return;
@@ -20,7 +40,7 @@ import { Tool } from "./Tool";
       this.cleanup();
     };
 
-
+    this.blurListener = commit;
     this.keydownListener = (ev: KeyboardEvent) => {
       if (ev.key === "Enter") {
         ev.preventDefault();
@@ -31,10 +51,14 @@ import { Tool } from "./Tool";
       }
     };
 
+    textarea.addEventListener("blur", this.blurListener);
+    textarea.addEventListener("keydown", this.keydownListener);
+
+    this.textarea = textarea;
   }
 
   onPointerMove(_e: PointerEvent, _editor: Editor): void {
-    // No operation
+    // No-op for text tool
   }
 
   onPointerUp(_e: PointerEvent, _editor: Editor): void {


### PR DESCRIPTION
## Summary
- add `initEditor` to bootstrap canvas and toolbar controls
- implement `TextTool` for on-canvas text input
- wire up editor constructor to accept `fillMode`
- provide working package.json with test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fc7a0584883289fd9df5ce6649458