### PR TITLE
Wire fill mode input into Editor constructor

### DIFF
--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -14,7 +14,7 @@ export class Editor {
     canvas: HTMLCanvasElement,
     colorPicker: HTMLInputElement,
     lineWidth: HTMLInputElement,
-
+    fillMode: HTMLInputElement,
   ) {
     this.canvas = canvas;
     const ctx = canvas.getContext("2d");

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -12,11 +12,26 @@ export interface EditorHandle {
   destroy: () => void;
 }
 
-
+export function initEditor(): EditorHandle {
   const canvas = document.getElementById("canvas") as HTMLCanvasElement;
   const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
   const lineWidth = document.getElementById("lineWidth") as HTMLInputElement;
+  const fillMode = document.getElementById("fillMode") as HTMLInputElement;
 
+  const pencilBtn = document.getElementById("pencil") as HTMLButtonElement | null;
+  const eraserBtn = document.getElementById("eraser") as HTMLButtonElement | null;
+  const rectBtn = document.getElementById("rectangle") as HTMLButtonElement | null;
+  const lineBtn = document.getElementById("line") as HTMLButtonElement | null;
+  const circleBtn = document.getElementById("circle") as HTMLButtonElement | null;
+  const textBtn = document.getElementById("text") as HTMLButtonElement | null;
+  const undoBtn = document.getElementById("undo") as HTMLButtonElement | null;
+  const redoBtn = document.getElementById("redo") as HTMLButtonElement | null;
+  const imageLoader = document.getElementById("imageLoader") as HTMLInputElement | null;
+  const saveBtn = document.getElementById("save") as HTMLButtonElement | null;
+
+  const editor = new Editor(canvas, colorPicker, lineWidth, fillMode);
+  editor.setTool(new PencilTool());
+  const shortcuts = new Shortcuts(editor);
 
   // Tool selection handlers
   const pencilHandler = () => editor.setTool(new PencilTool());
@@ -32,6 +47,27 @@ export interface EditorHandle {
   circleBtn?.addEventListener("click", circleHandler);
   textBtn?.addEventListener("click", textHandler);
 
+  // Undo/redo handlers
+  const undoHandler = () => editor.undo();
+  const redoHandler = () => editor.redo();
+  undoBtn?.addEventListener("click", undoHandler);
+  redoBtn?.addEventListener("click", redoHandler);
+
+  // Image loading handler
+  const imageLoaderHandler = () => {
+    const file = imageLoader?.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        editor.ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+      };
+      img.src = reader.result as string;
+    };
+    reader.readAsDataURL(file);
+  };
+  imageLoader?.addEventListener("change", imageLoaderHandler);
 
   // Save handler
   const saveHandler = () => {
@@ -43,5 +79,22 @@ export interface EditorHandle {
   };
   saveBtn?.addEventListener("click", saveHandler);
 
+  return {
+    editor,
+    destroy: () => {
+      pencilBtn?.removeEventListener("click", pencilHandler);
+      eraserBtn?.removeEventListener("click", eraserHandler);
+      rectBtn?.removeEventListener("click", rectHandler);
+      lineBtn?.removeEventListener("click", lineHandler);
+      circleBtn?.removeEventListener("click", circleHandler);
+      textBtn?.removeEventListener("click", textHandler);
+      undoBtn?.removeEventListener("click", undoHandler);
+      redoBtn?.removeEventListener("click", redoHandler);
+      imageLoader?.removeEventListener("change", imageLoaderHandler);
+      saveBtn?.removeEventListener("click", saveHandler);
+      shortcuts.destroy();
+      editor.destroy();
+    },
+  };
 }
 


### PR DESCRIPTION
## Summary
- require `fillMode` checkbox when constructing `Editor`
- gather and pass the `fillMode` element from `initEditor`

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fc79f18f48328b87c5b3fafa7fde5