### PR TITLE
Add fill mode to tests and hook up save & image handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node dist/index.js",
     "lint": "eslint . --ext .ts",
     "format": "prettier --write .",
-
+    "test": "jest"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.0",

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -12,16 +12,43 @@ export function initEditor(): EditorHandle {
   const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
   const lineWidth = document.getElementById("lineWidth") as HTMLInputElement;
   const fillMode = document.getElementById("fillMode") as HTMLInputElement;
+  const saveBtn = document.getElementById("save") as HTMLButtonElement | null;
+  const imageLoader = document.getElementById("imageLoader") as HTMLInputElement | null;
 
   const editor = new Editor(canvas, colorPicker, lineWidth, fillMode);
   editor.setTool(new PencilTool());
   const shortcuts = new Shortcuts(editor);
+
+  const onSave = () => {
+    const anchor = document.createElement("a");
+    anchor.href = canvas.toDataURL("image/png");
+    anchor.download = "canvas.png";
+    anchor.click();
+  };
+  saveBtn?.addEventListener("click", onSave);
+
+  const onImageLoad = () => {
+    const file = imageLoader?.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        editor.ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+      };
+      img.src = reader.result as string;
+    };
+    reader.readAsDataURL(file);
+  };
+  imageLoader?.addEventListener("change", onImageLoad);
 
   return {
     editor,
     destroy() {
       shortcuts.destroy();
       editor.destroy();
+      saveBtn?.removeEventListener("click", onSave);
+      imageLoader?.removeEventListener("change", onImageLoad);
     },
   };
 }

--- a/src/tools/DrawingTool.ts
+++ b/src/tools/DrawingTool.ts
@@ -7,7 +7,7 @@ import { Tool } from "./Tool";
  * rendering context. Concrete tools must implement the pointer handlers.
  */
 export abstract class DrawingTool implements Tool {
-
+  protected applyStroke(ctx: CanvasRenderingContext2D, editor: Editor) {
     ctx.lineWidth = editor.lineWidthValue;
     ctx.strokeStyle = editor.strokeStyle;
     ctx.fillStyle = editor.fillStyle;
@@ -17,3 +17,4 @@ export abstract class DrawingTool implements Tool {
   abstract onPointerMove(e: PointerEvent, editor: Editor): void;
   abstract onPointerUp(e: PointerEvent, editor: Editor): void;
 }
+

--- a/tests/eraserTool.test.ts
+++ b/tests/eraserTool.test.ts
@@ -10,6 +10,7 @@ describe("EraserTool", () => {
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="10" />
+      <input id="fillMode" type="checkbox" />
     `;
     const canvas = document.getElementById("canvas") as HTMLCanvasElement;
     ctx = {
@@ -31,6 +32,7 @@ describe("EraserTool", () => {
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
+      document.getElementById("fillMode") as HTMLInputElement,
     );
   });
 

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -10,11 +10,19 @@ describe("image operations", () => {
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
       <input id="imageLoader" type="file" />
       <button id="save"></button>
     `;
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
-    ctx = { drawImage: jest.fn(), scale: jest.fn() };
+    ctx = {
+      drawImage: jest.fn(),
+      scale: jest.fn(),
+      setTransform: jest.fn(),
+      getImageData: jest.fn(),
+      putImageData: jest.fn(),
+      clearRect: jest.fn(),
+    };
     canvas.getContext = jest
       .fn()
       .mockReturnValue(ctx as CanvasRenderingContext2D);

--- a/tests/lineTool.test.ts
+++ b/tests/lineTool.test.ts
@@ -10,6 +10,7 @@ describe("LineTool", () => {
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
     `;
     const canvas = document.getElementById("canvas") as HTMLCanvasElement;
     const imageData = {} as ImageData;
@@ -22,6 +23,7 @@ describe("LineTool", () => {
       stroke: jest.fn(),
       closePath: jest.fn(),
       scale: jest.fn(),
+      setTransform: jest.fn(),
     };
     canvas.getContext = jest
       .fn()
@@ -30,6 +32,7 @@ describe("LineTool", () => {
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
+      document.getElementById("fillMode") as HTMLInputElement,
     );
   });
 

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -6,11 +6,18 @@ describe("save button", () => {
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
       <button id="save"></button>
     `;
 
     const canvas = document.getElementById("canvas") as HTMLCanvasElement;
-    const ctx = { scale: jest.fn(), getImageData: jest.fn(), putImageData: jest.fn(), clearRect: jest.fn() } as any;
+    const ctx = {
+      scale: jest.fn(),
+      setTransform: jest.fn(),
+      getImageData: jest.fn(),
+      putImageData: jest.fn(),
+      clearRect: jest.fn(),
+    } as any;
     canvas.getContext = jest.fn().mockReturnValue(ctx);
     canvas.toDataURL = jest.fn().mockReturnValue("data:image/png;base64,TEST");
     canvas.getBoundingClientRect = () => ({

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -12,6 +12,7 @@ describe("keyboard shortcuts", () => {
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
     `;
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
     ctx = {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -14,6 +14,7 @@ describe("additional tools", () => {
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
     `;
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
     ctx = {
@@ -25,6 +26,9 @@ describe("additional tools", () => {
       fillText: jest.fn(),
       closePath: jest.fn(),
       scale: jest.fn(),
+      setTransform: jest.fn(),
+      getImageData: jest.fn().mockReturnValue({}),
+      putImageData: jest.fn(),
     };
     canvas.getContext = jest
       .fn()
@@ -33,6 +37,7 @@ describe("additional tools", () => {
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
+      document.getElementById("fillMode") as HTMLInputElement,
     );
   });
 


### PR DESCRIPTION
## Summary
- add missing `fillMode` checkbox to DOM setups in tests
- wire up save button and image loader in `initEditor`
- restore `DrawingTool` helper and enable Jest test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d3f98a4a88328b6feb1b4ca07f7ff