### PR TITLE
Ensure continuous drawing on pointer move

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "lint": "eslint . --ext .ts",
-
+    "test": "jest"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.0",

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -37,6 +37,7 @@ export class Editor {
   }
 
   private handlePointerDown = (e: PointerEvent) => {
+    this.canvas.setPointerCapture(e.pointerId);
     this.saveState();
     this.currentTool?.onPointerDown(e, this);
   };

--- a/style.css
+++ b/style.css
@@ -22,4 +22,5 @@ body {
   width: 100%;
   height: 100%;
   flex: 1;
+  touch-action: none;
 }


### PR DESCRIPTION
## Summary
- Capture pointer input on canvas to continue strokes beyond its bounds
- Prevent touch scrolling with `touch-action: none` on the drawing surface
- Add missing Jest test script to package.json

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: multiple TypeScript errors and failing suites)*
- `npm run build` *(fails: TypeScript compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_689ff0abfb68832899969bf0ee7c9012