### PR TITLE
fix: restore canvas before final shape

### DIFF
--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -33,8 +33,11 @@ export class CircleTool extends DrawingTool {
   }
 
   onPointerUp(e: PointerEvent, editor: Editor): void {
+    const ctx = editor.ctx as any;
+    if (this.imageData) {
+      ctx.putImageData?.(this.imageData, 0, 0);
+    }
     this.applyStroke(editor.ctx, editor);
-    const ctx = editor.ctx;
 
     const dx = e.offsetX - this.startX;
     const dy = e.offsetY - this.startY;

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -28,8 +28,11 @@ export class LineTool extends DrawingTool {
   }
 
   onPointerUp(e: PointerEvent, editor: Editor): void {
+    const ctx = editor.ctx as any;
+    if (this.imageData) {
+      ctx.putImageData?.(this.imageData, 0, 0);
+    }
     this.applyStroke(editor.ctx, editor);
-    const ctx = editor.ctx;
 
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);


### PR DESCRIPTION
## Summary
- avoid double drawing by restoring canvas on pointer release for line tool
- avoid double drawing by restoring canvas on pointer release for circle tool

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ff0da96dc832897596a2ef5d1874b