### PR TITLE
Verify color rendering for drawing tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "lint": "eslint . --ext .ts",
-
+    "test": "jest"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.0",

--- a/tests/colorRendering.test.ts
+++ b/tests/colorRendering.test.ts
@@ -1,0 +1,94 @@
+import { Editor } from "../src/core/Editor";
+import { PencilTool } from "../src/tools/PencilTool";
+import { RectangleTool } from "../src/tools/RectangleTool";
+
+describe("color rendering", () => {
+  let canvas: HTMLCanvasElement;
+  let ctx: Partial<CanvasRenderingContext2D> & {
+    strokeStyle: string;
+    fillStyle: string;
+    lineWidth: number;
+  };
+  let editor: Editor;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <canvas id="canvas"></canvas>
+      <input id="colorPicker" value="#111111" />
+      <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
+    `;
+
+    canvas = document.getElementById("canvas") as HTMLCanvasElement;
+
+    const mockImage = {
+      data: new Uint8ClampedArray(),
+      width: 0,
+      height: 0,
+    } as ImageData;
+
+    ctx = {
+      beginPath: jest.fn(),
+      moveTo: jest.fn(),
+      lineTo: jest.fn(),
+      stroke: jest.fn(),
+      closePath: jest.fn(),
+      strokeRect: jest.fn(),
+      fillRect: jest.fn(),
+      getImageData: jest.fn(() => mockImage),
+      putImageData: jest.fn(),
+      arc: jest.fn(),
+      fill: jest.fn(),
+      strokeStyle: "",
+      fillStyle: "",
+      lineWidth: 0,
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+    };
+
+    canvas.getContext = jest.fn().mockReturnValue(ctx);
+    canvas.getBoundingClientRect = () => ({
+      width: 0,
+      height: 0,
+      left: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+
+    editor = new Editor(
+      canvas,
+      document.getElementById("colorPicker") as HTMLInputElement,
+      document.getElementById("lineWidth") as HTMLInputElement,
+      document.getElementById("fillMode") as HTMLInputElement,
+    );
+  });
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  it("uses the selected color for strokes and fills", () => {
+    const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
+
+    const pencil = new PencilTool();
+    pencil.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+    expect(ctx.strokeStyle).toBe("#111111");
+
+    colorPicker.value = "#ff0000";
+    pencil.onPointerDown({ offsetX: 1, offsetY: 1 } as PointerEvent, editor);
+    expect(ctx.strokeStyle).toBe("#ff0000");
+
+    const fillMode = document.getElementById("fillMode") as HTMLInputElement;
+    fillMode.checked = true;
+    colorPicker.value = "#00ff00";
+    const rect = new RectangleTool();
+    rect.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+    rect.onPointerUp({ offsetX: 2, offsetY: 2 } as PointerEvent, editor);
+    expect(ctx.strokeStyle).toBe("#00ff00");
+    expect(ctx.fillStyle).toBe("#00ff00");
+  });
+});


### PR DESCRIPTION
## Summary
- add test ensuring drawing tools pick up current color from the color picker
- add npm `test` script to enable running Jest tests

## Testing
- `npm test` *(fails: Module '../src/editor' has no exported member 'initEditor', Module '../src/tools/TextTool' has no exported member 'TextTool')*
- `npm run lint` *(fails: unexpected any / parsing error in existing files)*
- `npx jest tests/colorRendering.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689ff118fd78832885eac338654855d2