### PR TITLE
Implement image resizing on load and restore editor tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A simple Photoshop-like web application built with HTML5 Canvas, CSS, and JavaSc
 - Color picker for stroke selection
 - Adjustable line width
 - Undo/redo support
+- Import an image with the canvas automatically resized to the image's dimensions
 
 ### Keyboard Shortcuts
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "lint": "eslint . --ext .ts",
-
+    "test": "jest"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.0",

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -54,8 +54,8 @@ export class Editor {
     const rect = this.canvas.getBoundingClientRect();
     this.canvas.width = rect.width * dpr;
     this.canvas.height = rect.height * dpr;
-    (this.ctx as any).setTransform?.(1, 0, 0, 1, 0, 0);
-    (this.ctx as any).scale?.(dpr, dpr);
+    this.ctx.setTransform(1, 0, 0, 1, 0, 0);
+    this.ctx.scale(dpr, dpr);
   }
 
   private handleResize = () => {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -12,17 +12,93 @@ export interface EditorHandle {
   destroy: () => void;
 }
 
+/**
+ * Initialise the editor and wire all toolbar controls.
+ */
+export function initEditor(): EditorHandle {
   const canvas = document.getElementById("canvas") as HTMLCanvasElement;
   const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
   const lineWidth = document.getElementById("lineWidth") as HTMLInputElement;
   const fillMode = document.getElementById("fillMode") as HTMLInputElement;
-  const saveBtn = document.getElementById("save") as HTMLButtonElement | null;
-  const imageLoader = document.getElementById("imageLoader") as HTMLInputElement | null;
 
+  const editor = new Editor(canvas, colorPicker, lineWidth, fillMode);
+  const shortcuts = new Shortcuts(editor);
 
-
+  const cleanups: Array<() => void> = [];
+  const bind = <K extends keyof HTMLElementEventMap>(
+    el: HTMLElement | null,
+    type: K,
+    handler: (ev: HTMLElementEventMap[K]) => void,
+  ) => {
+    if (!el) return;
+    el.addEventListener(type, handler);
+    cleanups.push(() => el.removeEventListener(type, handler));
   };
-  saveBtn?.addEventListener("click", saveHandler);
 
+  // Tool buttons
+  bind(document.getElementById("pencil"), "click", () =>
+    editor.setTool(new PencilTool()),
+  );
+  bind(document.getElementById("eraser"), "click", () =>
+    editor.setTool(new EraserTool()),
+  );
+  bind(document.getElementById("rectangle"), "click", () =>
+    editor.setTool(new RectangleTool()),
+  );
+  bind(document.getElementById("line"), "click", () =>
+    editor.setTool(new LineTool()),
+  );
+  bind(document.getElementById("circle"), "click", () =>
+    editor.setTool(new CircleTool()),
+  );
+  bind(document.getElementById("text"), "click", () =>
+    editor.setTool(new TextTool()),
+  );
+
+  // Undo/redo
+  bind(document.getElementById("undo"), "click", () => editor.undo());
+  bind(document.getElementById("redo"), "click", () => editor.redo());
+
+  // Save to image
+  bind(document.getElementById("save"), "click", () => {
+    const data = canvas.toDataURL("image/png");
+    const link = document.createElement("a");
+    link.href = data;
+    link.download = "canvas.png";
+    link.click();
+  });
+
+  // Load image from file input and resize canvas to image dimensions
+  const loader = document.getElementById("imageLoader") as
+    | HTMLInputElement
+    | null;
+  bind(loader, "change", () => {
+    const file = loader?.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        const dpr = window.devicePixelRatio || 1;
+        canvas.style.width = `${img.width}px`;
+        canvas.style.height = `${img.height}px`;
+          canvas.width = img.width * dpr;
+          canvas.height = img.height * dpr;
+          editor.ctx.setTransform(1, 0, 0, 1, 0, 0);
+          editor.ctx.scale(dpr, dpr);
+          editor.ctx.drawImage(img, 0, 0, img.width, img.height);
+      };
+      img.src = reader.result as string;
+    };
+    reader.readAsDataURL(file);
+  });
+
+  const destroy = () => {
+    cleanups.forEach((fn) => fn());
+    shortcuts.destroy();
+    editor.destroy();
+  };
+
+  return { editor, destroy };
 }
 

--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -9,17 +9,26 @@ export class CircleTool extends DrawingTool {
   onPointerDown(e: PointerEvent, editor: Editor): void {
     this.startX = e.offsetX;
     this.startY = e.offsetY;
-    const ctx = editor.ctx as any;
-    this.imageData = ctx.getImageData
-      ? ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height)
-      : null;
+    const ctx = editor.ctx;
+    try {
+      this.imageData = ctx.getImageData(
+        0,
+        0,
+        editor.canvas.width,
+        editor.canvas.height,
+      );
+    } catch {
+      this.imageData = null;
+    }
   }
 
   onPointerMove(e: PointerEvent, editor: Editor): void {
     if (e.buttons !== 1 || !this.imageData) return;
-    const ctx = editor.ctx as any;
-    ctx.putImageData?.(this.imageData, 0, 0);
-    this.applyStroke(editor.ctx, editor);
+    const ctx = editor.ctx;
+    if (this.imageData) {
+      ctx.putImageData(this.imageData, 0, 0);
+    }
+    this.applyStroke(ctx, editor);
     const dx = e.offsetX - this.startX;
     const dy = e.offsetY - this.startY;
     const radius = Math.sqrt(dx * dx + dy * dy);

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -9,17 +9,26 @@ export class LineTool extends DrawingTool {
   onPointerDown(e: PointerEvent, editor: Editor): void {
     this.startX = e.offsetX;
     this.startY = e.offsetY;
-    const ctx = editor.ctx as any;
-    this.imageData = ctx.getImageData
-      ? ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height)
-      : null;
+    const ctx = editor.ctx;
+    try {
+      this.imageData = ctx.getImageData(
+        0,
+        0,
+        editor.canvas.width,
+        editor.canvas.height,
+      );
+    } catch {
+      this.imageData = null;
+    }
   }
 
   onPointerMove(e: PointerEvent, editor: Editor): void {
     if (e.buttons !== 1 || !this.imageData) return;
-    const ctx = editor.ctx as any;
-    ctx.putImageData?.(this.imageData, 0, 0);
-    this.applyStroke(editor.ctx, editor);
+    const ctx = editor.ctx;
+    if (this.imageData) {
+      ctx.putImageData(this.imageData, 0, 0);
+    }
+    this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
     ctx.lineTo(e.offsetX, e.offsetY);

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -15,7 +15,11 @@ describe("image operations", () => {
       <button id="save"></button>
     `;
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
-
+    ctx = {
+      drawImage: jest.fn(),
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+    };
     canvas.getContext = jest
       .fn()
       .mockReturnValue(ctx as CanvasRenderingContext2D);
@@ -30,7 +34,8 @@ describe("image operations", () => {
       onload: () => void = () => {};
       readAsDataURL = readSpy;
     }
-    (global as any).FileReader = MockFileReader;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (global as any).FileReader = MockFileReader;
 
     class MockImage {
       onload: () => void = () => {};
@@ -38,11 +43,13 @@ describe("image operations", () => {
         setTimeout(() => this.onload(), 0);
       }
     }
-    (global as any).Image = MockImage;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (global as any).Image = MockImage;
 
     handle = initEditor();
 
-    (global as any).readSpy = readSpy;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (global as any).readSpy = readSpy;
   });
 
   afterEach(() => {
@@ -55,13 +62,15 @@ describe("image operations", () => {
     Object.defineProperty(loader, "files", { value: [file], configurable: true });
     loader.dispatchEvent(new Event("change"));
     await new Promise((r) => setTimeout(r, 0));
-    expect((global as any).readSpy).toHaveBeenCalled();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((global as any).readSpy).toHaveBeenCalled();
     expect(ctx.drawImage).toHaveBeenCalled();
   });
 
   it("saves the canvas as an image", () => {
     const click = jest.fn();
-    const anchor = { href: "", download: "", click } as any;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const anchor = { href: "", download: "", click } as any;
     jest.spyOn(document, "createElement").mockReturnValue(anchor);
     const save = document.getElementById("save") as HTMLButtonElement;
     save.click();

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -11,11 +11,11 @@ describe("save button", () => {
     `;
 
     const canvas = document.getElementById("canvas") as HTMLCanvasElement;
-    const ctx = {
-      scale: jest.fn(),
-
-    } as any;
-    canvas.getContext = jest.fn().mockReturnValue(ctx);
+      const ctx: Partial<CanvasRenderingContext2D> = {
+        scale: jest.fn(),
+        setTransform: jest.fn(),
+      };
+      canvas.getContext = jest.fn().mockReturnValue(ctx as CanvasRenderingContext2D);
     canvas.toDataURL = jest.fn().mockReturnValue("data:image/png;base64,TEST");
     canvas.getBoundingClientRect = () => ({
       width: 100,
@@ -30,7 +30,8 @@ describe("save button", () => {
     });
 
     const click = jest.fn();
-    const anchor = { href: "", download: "", click } as any;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const anchor = { href: "", download: "", click } as any;
     jest.spyOn(document, "createElement").mockReturnValue(anchor);
 
     const handle = initEditor();


### PR DESCRIPTION
## Summary
- initialize editor with full toolbar bindings and automatic canvas resize when loading images
- reintroduce TextTool and clean up drawing tools to avoid `any` usage
- document image import feature and add Jest test script

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ff1d7a8f88328add8aa4687864293