### PR TITLE
Add basic multi-layer canvas support

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,15 @@
       <button id="redo">Redo</button>
       <button id="save">Save</button>
     </div>
-    <canvas id="canvas"></canvas>
+    <div id="canvasContainer" style="position: relative;">
+      <canvas id="layer1" width="800" height="600"></canvas>
+      <canvas
+        id="layer2"
+        width="800"
+        height="600"
+        style="position: absolute; top: 0; left: 0;"
+      ></canvas>
+    </div>
     <script type="module" src="dist/index.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "lint": "eslint . --ext .ts",
-
+    "test": "jest"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.0",

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -12,17 +12,102 @@ export interface EditorHandle {
   destroy: () => void;
 }
 
-  const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+/**
+ * Initialize an editor on a specific canvas element.
+ * @param canvasId The id of the canvas to enhance. Defaults to `canvas` so
+ * existing tests that assume a single canvas continue to work.
+ */
+export function initEditor(canvasId = "canvas"): EditorHandle {
+  const canvas = document.getElementById(canvasId) as HTMLCanvasElement;
+  if (!canvas) {
+    throw new Error(`Canvas with id "${canvasId}" not found`);
+  }
+
   const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
   const lineWidth = document.getElementById("lineWidth") as HTMLInputElement;
   const fillMode = document.getElementById("fillMode") as HTMLInputElement;
   const saveBtn = document.getElementById("save") as HTMLButtonElement | null;
   const imageLoader = document.getElementById("imageLoader") as HTMLInputElement | null;
 
+  const editor = new Editor(canvas, colorPicker, lineWidth, fillMode);
+  const shortcuts = new Shortcuts(editor);
 
+  // --- Tool Buttons --------------------------------------------------------
+  const pencilBtn = document.getElementById("pencil") as HTMLButtonElement | null;
+  const eraserBtn = document.getElementById("eraser") as HTMLButtonElement | null;
+  const rectangleBtn = document.getElementById("rectangle") as HTMLButtonElement | null;
+  const lineBtn = document.getElementById("line") as HTMLButtonElement | null;
+  const circleBtn = document.getElementById("circle") as HTMLButtonElement | null;
+  const textBtn = document.getElementById("text") as HTMLButtonElement | null;
+  const undoBtn = document.getElementById("undo") as HTMLButtonElement | null;
+  const redoBtn = document.getElementById("redo") as HTMLButtonElement | null;
 
+  const setPencil = () => editor.setTool(new PencilTool());
+  const setEraser = () => editor.setTool(new EraserTool());
+  const setRectangle = () => editor.setTool(new RectangleTool());
+  const setLine = () => editor.setTool(new LineTool());
+  const setCircle = () => editor.setTool(new CircleTool());
+  const setText = () => editor.setTool(new TextTool());
+  const undo = () => editor.undo();
+  const redo = () => editor.redo();
+
+  pencilBtn?.addEventListener("click", setPencil);
+  eraserBtn?.addEventListener("click", setEraser);
+  rectangleBtn?.addEventListener("click", setRectangle);
+  lineBtn?.addEventListener("click", setLine);
+  circleBtn?.addEventListener("click", setCircle);
+  textBtn?.addEventListener("click", setText);
+  undoBtn?.addEventListener("click", undo);
+  redoBtn?.addEventListener("click", redo);
+
+  // --- Image Loading -------------------------------------------------------
+  const imageHandler = (e: Event) => {
+    const target = e.target as HTMLInputElement;
+    const file = target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        editor.ctx.drawImage(
+          img,
+          0,
+          0,
+          canvas.clientWidth,
+          canvas.clientHeight,
+        );
+      };
+      img.src = reader.result as string;
+    };
+    reader.readAsDataURL(file);
+  };
+  imageLoader?.addEventListener("change", imageHandler);
+
+  // --- Saving --------------------------------------------------------------
+  const saveHandler = () => {
+    const data = canvas.toDataURL("image/png");
+    const a = document.createElement("a");
+    a.href = data;
+    a.download = "canvas.png";
+    a.click();
   };
   saveBtn?.addEventListener("click", saveHandler);
 
+  const destroy = () => {
+    pencilBtn?.removeEventListener("click", setPencil);
+    eraserBtn?.removeEventListener("click", setEraser);
+    rectangleBtn?.removeEventListener("click", setRectangle);
+    lineBtn?.removeEventListener("click", setLine);
+    circleBtn?.removeEventListener("click", setCircle);
+    textBtn?.removeEventListener("click", setText);
+    undoBtn?.removeEventListener("click", undo);
+    redoBtn?.removeEventListener("click", redo);
+    saveBtn?.removeEventListener("click", saveHandler);
+    imageLoader?.removeEventListener("change", imageHandler);
+    shortcuts.destroy();
+    editor.destroy();
+  };
+
+  return { editor, destroy };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import { initEditor } from "./editor";
 
-const handle = initEditor();
-window.addEventListener("beforeunload", () => handle.destroy());
+const handles = [initEditor("layer1"), initEditor("layer2")];
+window.addEventListener("beforeunload", () =>
+  handles.forEach((h) => h.destroy()),
+);
 

--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -2,7 +2,13 @@ import { Editor } from "../core/Editor";
 import { Tool } from "./Tool";
 
 /**
-
+ * Tool for placing text on the canvas. A textarea is temporarily created to
+ * gather input and then rendered to the canvas when committed.
+ */
+export class TextTool implements Tool {
+  private textarea: HTMLTextAreaElement | null = null;
+  private blurListener: (() => void) | null = null;
+  private keydownListener: ((e: KeyboardEvent) => void) | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
     this.cleanup();
@@ -11,7 +17,10 @@ import { Tool } from "./Tool";
     textarea.style.position = "absolute";
     textarea.style.left = `${e.offsetX}px`;
     textarea.style.top = `${e.offsetY}px`;
-
+    textarea.style.color = this.hexToRgb(editor.strokeStyle);
+    textarea.style.fontSize = `${editor.lineWidthValue * 4}px`;
+    document.body.appendChild(textarea);
+    textarea.focus();
 
     const commit = () => {
       if (!this.textarea) return;
@@ -20,7 +29,7 @@ import { Tool } from "./Tool";
         const ctx = editor.ctx;
         ctx.fillStyle = editor.strokeStyle;
         ctx.font = `${editor.lineWidthValue * 4}px sans-serif`;
-        ctx.fillText(text, x, y);
+        ctx.fillText(text, e.offsetX, e.offsetY);
       }
       this.cleanup();
     };
@@ -30,6 +39,7 @@ import { Tool } from "./Tool";
     };
 
     this.blurListener = commit;
+    textarea.addEventListener("blur", this.blurListener);
 
     this.keydownListener = (ev: KeyboardEvent) => {
       if (ev.key === "Enter") {
@@ -42,12 +52,11 @@ import { Tool } from "./Tool";
     };
     textarea.addEventListener("keydown", this.keydownListener);
 
-
     this.textarea = textarea;
   }
 
   onPointerMove(_e: PointerEvent, _editor: Editor): void {
-    // No-op for text tool
+    // Text tool does not draw during pointer move
   }
 
   onPointerUp(_e: PointerEvent, _editor: Editor): void {
@@ -62,14 +71,12 @@ import { Tool } from "./Tool";
 
   private cleanup(): void {
     if (!this.textarea) return;
-
     if (this.blurListener) {
       this.textarea.removeEventListener("blur", this.blurListener);
     }
     if (this.keydownListener) {
       this.textarea.removeEventListener("keydown", this.keydownListener);
     }
-
     this.textarea.remove();
     this.textarea = null;
     this.blurListener = null;

--- a/style.css
+++ b/style.css
@@ -16,10 +16,21 @@ body {
   margin: 10px;
 }
 
-#canvas {
+#canvasContainer {
+  position: relative;
+  flex: 1;
+}
+
+#canvasContainer canvas {
   border: 1px solid #000;
   cursor: crosshair;
   width: 100%;
   height: 100%;
-  flex: 1;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+#canvasContainer canvas:first-child {
+  position: relative;
 }

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -2,7 +2,11 @@ import { initEditor, EditorHandle } from "../src/editor";
 
 describe("image operations", () => {
   let canvas: HTMLCanvasElement;
-  let ctx: Partial<CanvasRenderingContext2D>;
+  let ctx: Partial<CanvasRenderingContext2D> = {
+    drawImage: jest.fn(),
+    setTransform: jest.fn(),
+    scale: jest.fn(),
+  };
   let handle: EditorHandle;
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- Stack two canvases in `index.html` and style them for layered drawing
- Rebuild `initEditor` to handle configurable canvas targets and wire up tools, image loading, save, and cleanup
- Instantiate editors for both layers and restore TextTool implementation

## Testing
- `npm test`
- `npm run build`
- `npm run lint` *(fails: Unexpected any, unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_689ff1ed8a7c83289ed50a8e326df8cd