### PR TITLE
Enable layer-aware undo/redo with dynamic button states

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "lint": "eslint . --ext .ts",
-
+    "test": "jest"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.0",

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -9,12 +9,14 @@ export class Editor {
   colorPicker: HTMLInputElement;
   lineWidth: HTMLInputElement;
   fillMode: HTMLInputElement;
+  private onChange?: () => void;
 
   constructor(
     canvas: HTMLCanvasElement,
     colorPicker: HTMLInputElement,
     lineWidth: HTMLInputElement,
     fillMode: HTMLInputElement,
+    onChange?: () => void,
   ) {
     this.canvas = canvas;
     const ctx = canvas.getContext("2d");
@@ -23,6 +25,7 @@ export class Editor {
     this.colorPicker = colorPicker;
     this.lineWidth = lineWidth;
     this.fillMode = fillMode;
+    this.onChange = onChange;
     this.adjustForPixelRatio();
     window.addEventListener("resize", this.handleResize);
 
@@ -80,6 +83,7 @@ export class Editor {
     );
     if (this.undoStack.length > 50) this.undoStack.shift();
     this.redoStack.length = 0;
+    this.onChange?.();
   }
 
   private restoreState(stack: ImageData[], opposite: ImageData[]) {
@@ -90,6 +94,7 @@ export class Editor {
     const imageData = stack.pop()!;
     this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
     this.ctx.putImageData(imageData, 0, 0);
+    this.onChange?.();
   }
 
   undo() {
@@ -98,6 +103,14 @@ export class Editor {
 
   redo() {
     this.restoreState(this.redoStack, this.undoStack);
+  }
+
+  get canUndo() {
+    return this.undoStack.length > 0;
+  }
+
+  get canRedo() {
+    return this.redoStack.length > 0;
   }
 
   get strokeStyle() {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -6,23 +6,156 @@ import { RectangleTool } from "./tools/RectangleTool";
 import { LineTool } from "./tools/LineTool";
 import { CircleTool } from "./tools/CircleTool";
 import { TextTool } from "./tools/TextTool";
+import type { Tool } from "./tools/Tool";
 
 export interface EditorHandle {
   editor: Editor;
+  activateLayer: (index: number) => void;
   destroy: () => void;
 }
 
-  const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+/**
+ * Initialize the editor application.
+ *
+ * The editor supports multiple layers – each canvas element on the page
+ * represents a separate layer with its own {@link Editor} instance and
+ * independent undo/redo stacks. The returned handle exposes the currently
+ * active editor and allows switching layers programmatically.
+ */
+export function initEditor(): EditorHandle {
+  const canvases = Array.from(
+    document.querySelectorAll<HTMLCanvasElement>("canvas"),
+  );
+  if (!canvases.length) {
+    throw new Error("No canvas elements found");
+  }
+
   const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
   const lineWidth = document.getElementById("lineWidth") as HTMLInputElement;
   const fillMode = document.getElementById("fillMode") as HTMLInputElement;
+  const undoBtn = document.getElementById("undo") as HTMLButtonElement | null;
+  const redoBtn = document.getElementById("redo") as HTMLButtonElement | null;
   const saveBtn = document.getElementById("save") as HTMLButtonElement | null;
-  const imageLoader = document.getElementById("imageLoader") as HTMLInputElement | null;
+  const imageLoader = document.getElementById("imageLoader") as
+    | HTMLInputElement
+    | null;
 
+  // Current active editor index
+  let active = 0;
 
+  // Editors for each canvas/layer
+  const editors = canvases.map(
+    (c) =>
+      new Editor(c, colorPicker, lineWidth, fillMode, updateUndoRedoButtons),
+  );
 
+  // Active editor reference
+  let editor = editors[active];
+
+  // Keyboard shortcuts bound to the active editor
+  let shortcuts = new Shortcuts(editor);
+
+  function updateUndoRedoButtons() {
+    if (undoBtn) undoBtn.disabled = !editor.canUndo;
+    if (redoBtn) redoBtn.disabled = !editor.canRedo;
+  }
+
+  // -- Toolbar bindings ----------------------------------------------------
+  const toolDefs: Array<[string, () => Tool]> = [
+    ["pencil", () => new PencilTool()],
+    ["eraser", () => new EraserTool()],
+    ["rectangle", () => new RectangleTool()],
+    ["line", () => new LineTool()],
+    ["circle", () => new CircleTool()],
+    ["text", () => new TextTool()],
+  ];
+
+  const listeners: Array<() => void> = [];
+
+  toolDefs.forEach(([id, factory]) => {
+    const btn = document.getElementById(id);
+    if (!btn) return;
+    const handler = () => editor.setTool(factory());
+    btn.addEventListener("click", handler);
+    listeners.push(() => btn.removeEventListener("click", handler));
+  });
+
+  if (undoBtn) {
+    const handler = () => {
+      editor.undo();
+      updateUndoRedoButtons();
+    };
+    undoBtn.addEventListener("click", handler);
+    listeners.push(() => undoBtn.removeEventListener("click", handler));
+  }
+
+  if (redoBtn) {
+    const handler = () => {
+      editor.redo();
+      updateUndoRedoButtons();
+    };
+    redoBtn.addEventListener("click", handler);
+    listeners.push(() => redoBtn.removeEventListener("click", handler));
+  }
+
+  if (saveBtn) {
+    const handler = () => {
+      const data = editor.canvas.toDataURL("image/png");
+      const anchor = document.createElement("a");
+      anchor.href = data;
+      anchor.download = "canvas.png";
+      anchor.click();
+    };
+    saveBtn.addEventListener("click", handler);
+    listeners.push(() => saveBtn.removeEventListener("click", handler));
+  }
+
+  if (imageLoader) {
+    const handler = () => {
+      const file = imageLoader.files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        const img = new Image();
+        img.onload = () => {
+          editor.ctx.drawImage(
+            img,
+            0,
+            0,
+            editor.canvas.width,
+            editor.canvas.height,
+          );
+          updateUndoRedoButtons();
+        };
+        img.src = reader.result as string;
+      };
+      reader.readAsDataURL(file);
+    };
+    imageLoader.addEventListener("change", handler);
+    listeners.push(() => imageLoader.removeEventListener("change", handler));
+  }
+
+  // Initial button state
+  updateUndoRedoButtons();
+
+  const handle: EditorHandle = {
+    editor,
+    activateLayer(index: number) {
+      if (index < 0 || index >= editors.length || index === active) return;
+      shortcuts.destroy();
+      active = index;
+      editor = editors[active];
+      this.editor = editor;
+      shortcuts = new Shortcuts(editor);
+      updateUndoRedoButtons();
+    },
+    destroy() {
+      shortcuts.destroy();
+      editors.forEach((e) => e.destroy());
+      listeners.forEach((off) => off());
+    },
   };
-  saveBtn?.addEventListener("click", saveHandler);
 
+  return handle;
 }
 

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -16,6 +16,11 @@ describe("image operations", () => {
     `;
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
 
+    ctx = {
+      drawImage: jest.fn(),
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+    };
     canvas.getContext = jest
       .fn()
       .mockReturnValue(ctx as CanvasRenderingContext2D);

--- a/tests/layers.test.ts
+++ b/tests/layers.test.ts
@@ -1,0 +1,105 @@
+import { initEditor, EditorHandle } from "../src/editor";
+
+describe("layer-specific undo/redo", () => {
+  let handle: EditorHandle;
+  let canvas1: HTMLCanvasElement;
+  let canvas2: HTMLCanvasElement;
+  let ctx1: Partial<CanvasRenderingContext2D>;
+  let ctx2: Partial<CanvasRenderingContext2D>;
+  let undoBtn: HTMLButtonElement;
+  let redoBtn: HTMLButtonElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <canvas id="c1"></canvas>
+      <canvas id="c2"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
+      <button id="pencil"></button>
+      <button id="undo"></button>
+      <button id="redo"></button>
+    `;
+
+    canvas1 = document.getElementById("c1") as HTMLCanvasElement;
+    canvas2 = document.getElementById("c2") as HTMLCanvasElement;
+
+    const rect = {
+      width: 100,
+      height: 100,
+      top: 0,
+      left: 0,
+      bottom: 100,
+      right: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    };
+
+    ctx1 = {
+      clearRect: jest.fn(),
+      putImageData: jest.fn(),
+      getImageData: jest
+        .fn()
+        .mockReturnValue({
+          data: new Uint8ClampedArray(),
+          width: 1,
+          height: 1,
+        } as ImageData),
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+    };
+    ctx2 = {
+      clearRect: jest.fn(),
+      putImageData: jest.fn(),
+      getImageData: jest
+        .fn()
+        .mockReturnValue({
+          data: new Uint8ClampedArray(),
+          width: 1,
+          height: 1,
+        } as ImageData),
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+    };
+
+    canvas1.getContext = jest.fn().mockReturnValue(ctx1 as any);
+    canvas2.getContext = jest.fn().mockReturnValue(ctx2 as any);
+    canvas1.getBoundingClientRect = canvas2.getBoundingClientRect = () => rect;
+
+    handle = initEditor();
+    undoBtn = document.getElementById("undo") as HTMLButtonElement;
+    redoBtn = document.getElementById("redo") as HTMLButtonElement;
+  });
+
+  afterEach(() => handle.destroy());
+
+  it("targets the active layer and toggles button states", () => {
+    // initially disabled
+    expect(undoBtn.disabled).toBe(true);
+    expect(redoBtn.disabled).toBe(true);
+
+    // add state to first layer
+    handle.editor.saveState();
+    expect(undoBtn.disabled).toBe(false);
+
+    // switch to second layer – no history yet
+    handle.activateLayer(1);
+    expect(undoBtn.disabled).toBe(true);
+
+    // add state to second layer and undo
+    handle.editor.saveState();
+    expect(undoBtn.disabled).toBe(false);
+    undoBtn.click();
+    expect(ctx2.putImageData).toHaveBeenCalled();
+    expect(ctx1.putImageData).not.toHaveBeenCalled();
+    expect(undoBtn.disabled).toBe(true);
+    expect(redoBtn.disabled).toBe(false);
+
+    // switch back to first layer – its undo stack still has entries
+    handle.activateLayer(0);
+    expect(undoBtn.disabled).toBe(false);
+    expect(redoBtn.disabled).toBe(true);
+  });
+});
+

--- a/tests/toolbar.test.ts
+++ b/tests/toolbar.test.ts
@@ -79,9 +79,16 @@ describe("toolbar controls", () => {
   it("triggers undo and redo when buttons are clicked", () => {
     const undo = jest.spyOn(handle.editor, "undo").mockImplementation(() => {});
     const redo = jest.spyOn(handle.editor, "redo").mockImplementation(() => {});
-    (document.getElementById("undo") as HTMLButtonElement).click();
+    const undoBtn = document.getElementById("undo") as HTMLButtonElement;
+    const redoBtn = document.getElementById("redo") as HTMLButtonElement;
+    // ensure buttons are enabled for the test
+    undoBtn.disabled = false;
+    redoBtn.disabled = false;
+    undoBtn.click();
     expect(undo).toHaveBeenCalled();
-    (document.getElementById("redo") as HTMLButtonElement).click();
+    // undo click will toggle button states; re-enable redo for this test
+    redoBtn.disabled = false;
+    redoBtn.click();
     expect(redo).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- expose undo/redo availability and state-change callback in Editor
- handle multiple canvas layers, routing undo/redo to active editor and toggling buttons
- add tests for layer-specific undo/redo and update toolbar tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ff23317d48328a1e049f15608791f