### PR TITLE
feat: merge canvas layers when exporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "lint": "eslint . --ext .ts",
-
+    "lint": "eslint . --ext .ts"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.0",

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -12,17 +12,100 @@ export interface EditorHandle {
   destroy: () => void;
 }
 
+export function initEditor(): EditorHandle {
   const canvas = document.getElementById("canvas") as HTMLCanvasElement;
   const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
   const lineWidth = document.getElementById("lineWidth") as HTMLInputElement;
   const fillMode = document.getElementById("fillMode") as HTMLInputElement;
   const saveBtn = document.getElementById("save") as HTMLButtonElement | null;
   const imageLoader = document.getElementById("imageLoader") as HTMLInputElement | null;
+  const undoBtn = document.getElementById("undo") as HTMLButtonElement | null;
+  const redoBtn = document.getElementById("redo") as HTMLButtonElement | null;
 
+  const editor = new Editor(canvas, colorPicker, lineWidth, fillMode);
+  const shortcuts = new Shortcuts(editor);
 
+  const pencilHandler = () => editor.setTool(new PencilTool());
+  const eraserHandler = () => editor.setTool(new EraserTool());
+  const rectangleHandler = () => editor.setTool(new RectangleTool());
+  const lineHandler = () => editor.setTool(new LineTool());
+  const circleHandler = () => editor.setTool(new CircleTool());
+  const textHandler = () => editor.setTool(new TextTool());
 
+  document.getElementById("pencil")?.addEventListener("click", pencilHandler);
+  document.getElementById("eraser")?.addEventListener("click", eraserHandler);
+  document.getElementById("rectangle")?.addEventListener("click", rectangleHandler);
+  document.getElementById("line")?.addEventListener("click", lineHandler);
+  document.getElementById("circle")?.addEventListener("click", circleHandler);
+  document.getElementById("text")?.addEventListener("click", textHandler);
+
+  const undoHandler = () => editor.undo();
+  const redoHandler = () => editor.redo();
+  undoBtn?.addEventListener("click", undoHandler);
+  redoBtn?.addEventListener("click", redoHandler);
+
+  const imageHandler = () => {
+    const file = imageLoader?.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        editor.ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+      };
+      img.src = reader.result as string;
+    };
+    reader.readAsDataURL(file);
+  };
+  imageLoader?.addEventListener("change", imageHandler);
+
+  const saveHandler = () => {
+    const canvases = Array.from(document.querySelectorAll("canvas"));
+    let exportCanvas = canvases[0];
+    if (canvases.length > 1) {
+      const temp = document.createElement("canvas");
+      temp.width = exportCanvas.width;
+      temp.height = exportCanvas.height;
+      const tempCtx = temp.getContext("2d")!;
+      canvases.forEach((c) => {
+        const opacity = parseFloat(c.style.opacity || "1");
+        tempCtx.globalAlpha = opacity;
+        tempCtx.drawImage(c, 0, 0);
+      });
+      exportCanvas = temp;
+    }
+    const data = exportCanvas.toDataURL("image/png");
+    const a = document.createElement("a");
+    a.href = data;
+    a.download = "canvas.png";
+    a.click();
   };
   saveBtn?.addEventListener("click", saveHandler);
 
+  return {
+    editor,
+    destroy: () => {
+      document
+        .getElementById("pencil")
+        ?.removeEventListener("click", pencilHandler);
+      document
+        .getElementById("eraser")
+        ?.removeEventListener("click", eraserHandler);
+      document
+        .getElementById("rectangle")
+        ?.removeEventListener("click", rectangleHandler);
+      document.getElementById("line")?.removeEventListener("click", lineHandler);
+      document
+        .getElementById("circle")
+        ?.removeEventListener("click", circleHandler);
+      document.getElementById("text")?.removeEventListener("click", textHandler);
+      undoBtn?.removeEventListener("click", undoHandler);
+      redoBtn?.removeEventListener("click", redoHandler);
+      saveBtn?.removeEventListener("click", saveHandler);
+      imageLoader?.removeEventListener("change", imageHandler);
+      shortcuts.destroy();
+      editor.destroy();
+    },
+  };
 }
 

--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -1,17 +1,25 @@
-import { Editor } from "../core/Editor";
+import type { Editor } from "../core/Editor";
 import { Tool } from "./Tool";
 
-/**
-
+export class TextTool implements Tool {
+  private textarea: HTMLTextAreaElement | null = null;
+  private blurListener: (() => void) | null = null;
+  private keydownListener: ((e: KeyboardEvent) => void) | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
     this.cleanup();
 
+    const x = e.offsetX;
+    const y = e.offsetY;
+
     const textarea = document.createElement("textarea");
     textarea.style.position = "absolute";
-    textarea.style.left = `${e.offsetX}px`;
-    textarea.style.top = `${e.offsetY}px`;
-
+    textarea.style.left = `${x}px`;
+    textarea.style.top = `${y}px`;
+    textarea.style.color = this.hexToRgb(editor.strokeStyle);
+    textarea.style.fontSize = `${editor.lineWidthValue * 4}px`;
+    document.body.appendChild(textarea);
+    textarea.focus();
 
     const commit = () => {
       if (!this.textarea) return;
@@ -30,6 +38,7 @@ import { Tool } from "./Tool";
     };
 
     this.blurListener = commit;
+    textarea.addEventListener("blur", this.blurListener);
 
     this.keydownListener = (ev: KeyboardEvent) => {
       if (ev.key === "Enter") {
@@ -42,12 +51,11 @@ import { Tool } from "./Tool";
     };
     textarea.addEventListener("keydown", this.keydownListener);
 
-
     this.textarea = textarea;
   }
 
   onPointerMove(_e: PointerEvent, _editor: Editor): void {
-    // No-op for text tool
+    // No-op
   }
 
   onPointerUp(_e: PointerEvent, _editor: Editor): void {
@@ -62,14 +70,12 @@ import { Tool } from "./Tool";
 
   private cleanup(): void {
     if (!this.textarea) return;
-
     if (this.blurListener) {
       this.textarea.removeEventListener("blur", this.blurListener);
     }
     if (this.keydownListener) {
       this.textarea.removeEventListener("keydown", this.keydownListener);
     }
-
     this.textarea.remove();
     this.textarea = null;
     this.blurListener = null;

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -16,6 +16,12 @@ describe("image operations", () => {
     `;
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
 
+    ctx = {
+      drawImage: jest.fn(),
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+    };
+
     canvas.getContext = jest
       .fn()
       .mockReturnValue(ctx as CanvasRenderingContext2D);

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -31,12 +31,82 @@ describe("save button", () => {
 
     const click = jest.fn();
     const anchor = { href: "", download: "", click } as any;
-    jest.spyOn(document, "createElement").mockReturnValue(anchor);
+    const realCreate = document.createElement.bind(document);
+    jest
+      .spyOn(document, "createElement")
+      .mockImplementation((tag: string) =>
+        tag === "a" ? anchor : realCreate(tag),
+      );
 
     const handle = initEditor();
 
     (document.getElementById("save") as HTMLButtonElement).click();
     expect(canvas.toDataURL).toHaveBeenCalledWith("image/png");
+    expect(click).toHaveBeenCalled();
+
+    handle.destroy();
+  });
+
+  it("merges multiple layers before saving", () => {
+    document.body.innerHTML = `
+      <canvas id="canvas" width="100" height="100"></canvas>
+      <canvas id="overlay" width="100" height="100" style="opacity:0.5"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
+      <button id="save"></button>
+    `;
+
+    const base = document.getElementById("canvas") as HTMLCanvasElement;
+    const overlay = document.getElementById("overlay") as HTMLCanvasElement;
+    const ctx = { scale: jest.fn() } as any;
+    base.getContext = jest.fn().mockReturnValue(ctx);
+    base.toDataURL = jest.fn();
+    base.getBoundingClientRect = () => ({
+      width: 100,
+      height: 100,
+      top: 0,
+      left: 0,
+      bottom: 0,
+      right: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+
+    const calls: { alpha: number; canvas: HTMLCanvasElement }[] = [];
+    const tempCtx: any = {
+      globalAlpha: 1,
+      drawImage: jest.fn((c: HTMLCanvasElement) => {
+        calls.push({ alpha: tempCtx.globalAlpha, canvas: c });
+      }),
+    };
+    const tempCanvas: any = {
+      width: 0,
+      height: 0,
+      getContext: jest.fn(() => tempCtx),
+      toDataURL: jest.fn().mockReturnValue("data:image/png;base64,MERGED"),
+    };
+
+    const click = jest.fn();
+    const anchor = { href: "", download: "", click } as any;
+    const realCreate = document.createElement.bind(document);
+    jest.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      if (tag === "a") return anchor;
+      if (tag === "canvas") return tempCanvas;
+      return realCreate(tag);
+    });
+
+    const handle = initEditor();
+
+    (document.getElementById("save") as HTMLButtonElement).click();
+
+    expect(base.toDataURL).not.toHaveBeenCalled();
+    expect(tempCanvas.toDataURL).toHaveBeenCalledWith("image/png");
+    expect(calls).toEqual([
+      { alpha: 1, canvas: base },
+      { alpha: 0.5, canvas: overlay },
+    ]);
     expect(click).toHaveBeenCalled();
 
     handle.destroy();


### PR DESCRIPTION
## Summary
- combine multiple canvas layers onto a temporary canvas when saving
- add tests for merged export
- restore TextTool implementation

## Testing
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_689ff25f75588328b5b4a8c8166fae35