### PR TITLE
Improve accessibility with focus outlines and tool cursor indicators

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,16 +8,16 @@
   </head>
   <body>
     <div id="toolbar">
-      <input type="color" id="colorPicker" value="#000000" />
-      <input type="range" id="lineWidth" min="1" max="50" value="5" />
-      <input type="checkbox" id="fillMode" />
+      <input type="color" id="colorPicker" value="#000000" aria-label="Select color" />
+      <input type="range" id="lineWidth" min="1" max="50" value="5" aria-label="Line width" />
+      <input type="checkbox" id="fillMode" aria-label="Fill shapes" />
       <button id="pencil">Pencil</button>
       <button id="eraser">Eraser</button>
       <button id="rectangle">Rectangle</button>
       <button id="line">Line</button>
       <button id="circle">Circle</button>
       <button id="text">Text</button>
-      <input type="file" id="imageLoader" accept="image/*" />
+      <input type="file" id="imageLoader" accept="image/*" aria-label="Load image" />
       <button id="undo">Undo</button>
       <button id="redo">Redo</button>
       <button id="save">Save</button>

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -34,6 +34,7 @@ export class Editor {
   setTool(tool: Tool) {
     this.currentTool?.destroy?.();
     this.currentTool = tool;
+    this.canvas.style.cursor = tool.cursor || "crosshair";
   }
 
   private handlePointerDown = (e: PointerEvent) => {

--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -2,16 +2,27 @@ import { Editor } from "../core/Editor";
 import { Tool } from "./Tool";
 
 /**
-
+ * Tool for placing text on the canvas via a temporary textarea overlay.
+ */
+export class TextTool implements Tool {
+  cursor = "text";
+  private textarea: HTMLTextAreaElement | null = null;
+  private blurListener: (() => void) | null = null;
+  private keydownListener: ((ev: KeyboardEvent) => void) | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
     this.cleanup();
 
+    const x = e.offsetX;
+    const y = e.offsetY;
     const textarea = document.createElement("textarea");
     textarea.style.position = "absolute";
-    textarea.style.left = `${e.offsetX}px`;
-    textarea.style.top = `${e.offsetY}px`;
-
+    textarea.style.left = `${x}px`;
+    textarea.style.top = `${y}px`;
+    textarea.style.color = this.hexToRgb(editor.strokeStyle);
+    textarea.style.fontSize = `${editor.lineWidthValue * 4}px`;
+    document.body.appendChild(textarea);
+    textarea.focus();
 
     const commit = () => {
       if (!this.textarea) return;
@@ -30,6 +41,7 @@ import { Tool } from "./Tool";
     };
 
     this.blurListener = commit;
+    textarea.addEventListener("blur", commit);
 
     this.keydownListener = (ev: KeyboardEvent) => {
       if (ev.key === "Enter") {
@@ -41,7 +53,6 @@ import { Tool } from "./Tool";
       }
     };
     textarea.addEventListener("keydown", this.keydownListener);
-
 
     this.textarea = textarea;
   }
@@ -84,4 +95,3 @@ import { Tool } from "./Tool";
     return `rgb(${r}, ${g}, ${b})`;
   }
 }
-

--- a/src/tools/Tool.ts
+++ b/src/tools/Tool.ts
@@ -1,6 +1,7 @@
 import { Editor } from "../core/Editor";
 
 export interface Tool {
+  cursor?: string;
   onPointerDown(e: PointerEvent, editor: Editor): void;
   onPointerMove(e: PointerEvent, editor: Editor): void;
   onPointerUp(e: PointerEvent, editor: Editor): void;

--- a/style.css
+++ b/style.css
@@ -1,3 +1,8 @@
+button:focus-visible, input:focus-visible {
+  outline: 2px solid #1e90ff;
+  outline-offset: 2px;
+}
+
 html,
 body {
   height: 100%;
@@ -18,7 +23,6 @@ body {
 
 #canvas {
   border: 1px solid #000;
-  cursor: crosshair;
   width: 100%;
   height: 100%;
   flex: 1;


### PR DESCRIPTION
## Summary
- add visible focus outlines for toolbar controls
- label unlabeled inputs for screen readers
- show crosshair cursor for drawing tools and text cursor for text tool

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npx jest` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ff2935a288328971697dd68e0e9f3