### PR TITLE
Document touch drawing support and disable default gestures

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A simple Photoshop-like web application built with HTML5 Canvas, CSS, and JavaSc
 - Color picker for stroke selection
 - Adjustable line width
 - Undo/redo support
+- Touch and stylus input for drawing
 
 ### Keyboard Shortcuts
 
@@ -29,6 +30,9 @@ A simple Photoshop-like web application built with HTML5 Canvas, CSS, and JavaSc
 
 ## Usage
 
+Draw on the canvas using a mouse, a single finger, or a stylus. Pointer events
+enable touch input, but multi-touch gestures such as pinch-to-zoom or panning
+are handled by the browser and are not yet supported by the app.
 
 ## Installing Dependencies
 

--- a/style.css
+++ b/style.css
@@ -19,6 +19,7 @@ body {
 #canvas {
   border: 1px solid #000;
   cursor: crosshair;
+  touch-action: none;
   width: 100%;
   height: 100%;
   flex: 1;


### PR DESCRIPTION
## Summary
- Disable default browser touch gestures on the canvas with `touch-action: none`
- Document that users can draw with a single finger or stylus while multi-touch is not yet supported

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ff24099788328808b1c1aaa113d76