### PR TITLE
fix canvas style block

### DIFF
--- a/style.css
+++ b/style.css
@@ -33,7 +33,7 @@ body {
   outline: 2px solid #007bff;
 }
 
-
+canvas {
   flex: 1;
   display: block;
 }


### PR DESCRIPTION
## Summary
- wrap stray flex and display declarations inside canvas selector

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx jest tests/toolbar.test.ts` *(fails: SyntaxError in src/tools/TextTool.ts: unexpected token)*
- `node -e "..."` to verify toolbar and canvas computed styles (flex and display)

------
https://chatgpt.com/codex/tasks/task_e_68a009e099f083288372c733076a029f