### PR TITLE
fix: add preview for circle tool

### DIFF
--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -9,11 +9,16 @@ export class CircleTool extends DrawingTool {
   onPointerDown(e: PointerEvent, editor: Editor): void {
     this.startX = e.offsetX;
     this.startY = e.offsetY;
-
+    this.applyStroke(editor.ctx, editor);
+    const ctx = editor.ctx;
+    this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
   }
 
   onPointerMove(e: PointerEvent, editor: Editor): void {
     if (e.buttons !== 1 || !this.imageData) return;
+    const ctx = editor.ctx;
+    ctx.putImageData(this.imageData, 0, 0);
+    this.applyStroke(editor.ctx, editor);
 
     const dx = e.offsetX - this.startX;
     const dy = e.offsetY - this.startY;
@@ -28,10 +33,11 @@ export class CircleTool extends DrawingTool {
   }
 
   onPointerUp(e: PointerEvent, editor: Editor): void {
-    const ctx = editor.ctx as any;
+    const ctx = editor.ctx;
     if (this.imageData) {
-      ctx.putImageData?.(this.imageData, 0, 0);
+      ctx.putImageData(this.imageData, 0, 0);
     }
+
     this.applyStroke(editor.ctx, editor);
 
     const dx = e.offsetX - this.startX;


### PR DESCRIPTION
## Summary
- capture image data when starting a circle
- redraw preview circle during pointer move with optional fill
- restore image data and draw final circle on pointer up

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a009e486008328a36be8a6befa7ab2