### PR TITLE
Fix line tool preview to restore image data

### DIFF
--- a/dist/tools/LineTool.js
+++ b/dist/tools/LineTool.js
@@ -7,19 +7,19 @@ export class LineTool extends DrawingTool {
         this.imageData = null;
     }
     onPointerDown(e, editor) {
+        const ctx = editor.ctx;
         this.startX = e.offsetX;
         this.startY = e.offsetY;
-        const ctx = editor.ctx;
         this.imageData = ctx.getImageData
             ? ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height)
             : null;
     }
     onPointerMove(e, editor) {
+        const ctx = editor.ctx;
         if (e.buttons !== 1 || !this.imageData)
             return;
-        const ctx = editor.ctx;
         ctx.putImageData?.(this.imageData, 0, 0);
-        this.applyStroke(editor.ctx, editor);
+        this.applyStroke(ctx, editor);
         ctx.beginPath();
         ctx.moveTo(this.startX, this.startY);
         ctx.lineTo(e.offsetX, e.offsetY);
@@ -27,8 +27,11 @@ export class LineTool extends DrawingTool {
         ctx.closePath();
     }
     onPointerUp(e, editor) {
-        this.applyStroke(editor.ctx, editor);
         const ctx = editor.ctx;
+        if (this.imageData) {
+            ctx.putImageData?.(this.imageData, 0, 0);
+        }
+        this.applyStroke(ctx, editor);
         ctx.beginPath();
         ctx.moveTo(this.startX, this.startY);
         ctx.lineTo(e.offsetX, e.offsetY);

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -7,14 +7,20 @@ export class LineTool extends DrawingTool {
   private imageData: ImageData | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
+    const ctx = editor.ctx;
     this.startX = e.offsetX;
     this.startY = e.offsetY;
-
+    this.imageData = ctx.getImageData
+      ? ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height)
+      : null;
   }
 
   onPointerMove(e: PointerEvent, editor: Editor): void {
+    const ctx = editor.ctx;
     if (e.buttons !== 1 || !this.imageData) return;
 
+    ctx.putImageData?.(this.imageData, 0, 0);
+    this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
     ctx.lineTo(e.offsetX, e.offsetY);
@@ -23,12 +29,11 @@ export class LineTool extends DrawingTool {
   }
 
   onPointerUp(e: PointerEvent, editor: Editor): void {
-    const ctx = editor.ctx as any;
+    const ctx = editor.ctx;
     if (this.imageData) {
       ctx.putImageData?.(this.imageData, 0, 0);
     }
-    this.applyStroke(editor.ctx, editor);
-
+    this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
     ctx.lineTo(e.offsetX, e.offsetY);


### PR DESCRIPTION
## Summary
- Save canvas state and start coordinates on line tool pointer down
- Restore and preview line during move
- Restore image and draw final stroke on release

## Testing
- `npx jest` *(fails: SyntaxError in TextTool and various initEditor issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a009e39a248328b29bbc8e3097dc67