### PR TITLE
Add keyboard shortcut handling

### DIFF
--- a/src/core/Shortcuts.ts
+++ b/src/core/Shortcuts.ts
@@ -14,7 +14,8 @@ export class Shortcuts {
   private readonly handler: (e: KeyboardEvent) => void;
   private editor: Editor;
 
-
+  constructor(editor: Editor) {
+    this.editor = editor;
     this.handler = (e: KeyboardEvent) => this.onKeyDown(e);
     document.addEventListener("keydown", this.handler);
   }
@@ -24,13 +25,12 @@ export class Shortcuts {
   }
 
   private onKeyDown(e: KeyboardEvent) {
-    const editor = this.getEditor();
     if (e.ctrlKey || e.metaKey) {
       if (e.key.toLowerCase() === "z") {
         if (e.shiftKey) {
-          editor.redo();
+          this.editor.redo();
         } else {
-          editor.undo();
+          this.editor.undo();
         }
         e.preventDefault();
       }
@@ -39,7 +39,28 @@ export class Shortcuts {
 
     switch (e.key.toLowerCase()) {
       case "p":
-
+        this.editor.setTool(new PencilTool());
+        this.activate("pencil");
+        break;
+      case "r":
+        this.editor.setTool(new RectangleTool());
+        this.activate("rectangle");
+        break;
+      case "l":
+        this.editor.setTool(new LineTool());
+        this.activate("line");
+        break;
+      case "c":
+        this.editor.setTool(new CircleTool());
+        this.activate("circle");
+        break;
+      case "t":
+        this.editor.setTool(new TextTool());
+        this.activate("text");
+        break;
+      case "e":
+        this.editor.setTool(new EraserTool());
+        this.activate("eraser");
         break;
     }
   }


### PR DESCRIPTION
## Summary
- Add Shortcuts constructor to register keydown listener
- Handle tool and undo/redo shortcuts directly on current editor
- Ensure listener removed on destroy

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a009e28d108328ae175967eeda1646