### PR TITLE
Implement keyboard shortcuts handler

### DIFF
--- a/src/core/Shortcuts.ts
+++ b/src/core/Shortcuts.ts
@@ -14,7 +14,13 @@ export class Shortcuts {
   private readonly handler: (e: KeyboardEvent) => void;
   private editor: Editor;
 
-
+  /**
+   * Create a shortcuts manager bound to an editor instance.
+   * The manager listens to keydown events on the document and
+   * delegates them to {@link onKeyDown}.
+   */
+  constructor(initial: Editor) {
+    this.editor = initial;
     this.handler = (e: KeyboardEvent) => this.onKeyDown(e);
     document.addEventListener("keydown", this.handler);
   }
@@ -24,22 +30,46 @@ export class Shortcuts {
   }
 
   private onKeyDown(e: KeyboardEvent) {
-    const editor = this.getEditor();
+    const editor = this.editor;
+
+    // Undo / redo shortcuts (Ctrl/Cmd + Z / Ctrl/Cmd + Shift + Z)
     if (e.ctrlKey || e.metaKey) {
       if (e.key.toLowerCase() === "z") {
+        e.preventDefault();
         if (e.shiftKey) {
           editor.redo();
         } else {
           editor.undo();
         }
-        e.preventDefault();
       }
       return;
     }
 
+    // Tool switching via letter keys
     switch (e.key.toLowerCase()) {
       case "p":
-
+        editor.setTool(new PencilTool());
+        this.activate("pencil");
+        break;
+      case "e":
+        editor.setTool(new EraserTool());
+        this.activate("eraser");
+        break;
+      case "r":
+        editor.setTool(new RectangleTool());
+        this.activate("rectangle");
+        break;
+      case "l":
+        editor.setTool(new LineTool());
+        this.activate("line");
+        break;
+      case "c":
+        editor.setTool(new CircleTool());
+        this.activate("circle");
+        break;
+      case "t":
+        editor.setTool(new TextTool());
+        this.activate("text");
         break;
     }
   }


### PR DESCRIPTION
## Summary
- add Shortcuts constructor to hook keyboard events to the initial editor
- map letter keys to tool changes and add undo/redo handling
- allow switching editors and retain cleanup via destroy

## Testing
- `npx jest` *(fails: Jest encountered an unexpected token in TextTool.ts and multiple suites fail; test summary: 11 failed, 4 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a00b44405883289ca893941d5cf614