### PR TITLE
Implement line tool preview and final drawing

### DIFF
--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -9,12 +9,20 @@ export class LineTool extends DrawingTool {
   onPointerDown(e: PointerEvent, editor: Editor): void {
     this.startX = e.offsetX;
     this.startY = e.offsetY;
-
+    this.imageData = editor.ctx.getImageData(
+      0,
+      0,
+      editor.canvas.width,
+      editor.canvas.height,
+    );
   }
 
   onPointerMove(e: PointerEvent, editor: Editor): void {
     if (e.buttons !== 1 || !this.imageData) return;
 
+    const ctx = editor.ctx;
+    ctx.putImageData(this.imageData, 0, 0);
+    this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
     ctx.lineTo(e.offsetX, e.offsetY);
@@ -23,12 +31,11 @@ export class LineTool extends DrawingTool {
   }
 
   onPointerUp(e: PointerEvent, editor: Editor): void {
-    const ctx = editor.ctx as any;
+    const ctx = editor.ctx;
     if (this.imageData) {
-      ctx.putImageData?.(this.imageData, 0, 0);
+      ctx.putImageData(this.imageData, 0, 0);
     }
-    this.applyStroke(editor.ctx, editor);
-
+    this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
     ctx.lineTo(e.offsetX, e.offsetY);


### PR DESCRIPTION
## Summary
- store starting coordinates and canvas snapshot when line drawing begins
- preview line on move using saved image and stroke settings
- finalize line on pointer up and reset preview image

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx jest` *(fails: Jest encountered an unexpected token in TextTool.ts, multiple suites failing)*

------
https://chatgpt.com/codex/tasks/task_e_68a00b44ca7c83289422fb00cafbdbd6