### PR TITLE
Add circle tool drawing preview and completion

### DIFF
--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -9,11 +9,17 @@ export class CircleTool extends DrawingTool {
   onPointerDown(e: PointerEvent, editor: Editor): void {
     this.startX = e.offsetX;
     this.startY = e.offsetY;
-
+    this.applyStroke(editor.ctx, editor);
+    const ctx = editor.ctx;
+    this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
   }
 
   onPointerMove(e: PointerEvent, editor: Editor): void {
     if (e.buttons !== 1 || !this.imageData) return;
+
+    const ctx = editor.ctx;
+    ctx.putImageData(this.imageData, 0, 0);
+    this.applyStroke(ctx, editor);
 
     const dx = e.offsetX - this.startX;
     const dy = e.offsetY - this.startY;


### PR DESCRIPTION
## Summary
- Capture start position and canvas image on pointer down
- Restore and preview circle during pointer move with optional fill
- Finalize circle drawing on pointer up and clear preview state

## Testing
- `npx jest tests/circleTool.test.ts`
- `npx jest` *(fails: editor/initEditor and TextTool parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a00b4573188328aaa495af9367118c