### PR TITLE
Add text overlay tool for canvas drawing

### DIFF
--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -1,30 +1,43 @@
 import { Editor } from "../core/Editor";
 import { Tool } from "./Tool";
 
+export class TextTool implements Tool {
+  textarea: HTMLTextAreaElement | null = null;
+  blurListener: ((e: FocusEvent) => void) | null = null;
+  keydownListener: ((e: KeyboardEvent) => void) | null = null;
+  cursor = "text";
+
+  onPointerDown(e: PointerEvent, editor: Editor): void {
+    if (this.textarea) {
+      this.cleanup();
+    }
+
     const textarea = document.createElement("textarea");
+    this.textarea = textarea;
+
     const x = e.offsetX;
     const y = e.offsetY;
+
     textarea.style.position = "absolute";
+    textarea.style.left = `${x}px`;
+    textarea.style.top = `${y}px`;
+    textarea.style.color = editor.strokeStyle;
+    textarea.style.fontSize = `${editor.lineWidthValue * 4}px`;
+    textarea.style.background = "transparent";
+    textarea.style.border = "none";
+    textarea.style.padding = "0";
+    textarea.style.margin = "0";
+    textarea.style.outline = "none";
+    textarea.style.resize = "none";
 
+    const container = editor.canvas.parentElement || document.body;
+    container.appendChild(textarea);
+    textarea.focus();
 
-
-
-    const commit = () => {
-      if (!this.textarea) return;
-      const text = this.textarea.value;
-      if (text) {
-        const ctx = editor.ctx;
-        ctx.fillStyle = editor.strokeStyle;
-        ctx.font = `${editor.lineWidthValue * 4}px sans-serif`;
-
-      }
-      this.cleanup();
-    };
-
+    const commit = () => this.commit(editor, x, y);
     const cancel = () => this.cleanup();
 
     this.blurListener = commit;
-
     this.keydownListener = (ev: KeyboardEvent) => {
       if (ev.key === "Enter") {
         ev.preventDefault();
@@ -35,10 +48,28 @@ import { Tool } from "./Tool";
       }
     };
 
+    textarea.addEventListener("blur", this.blurListener);
+    textarea.addEventListener("keydown", this.keydownListener);
+  }
 
-    if (this.textarea && document.activeElement !== this.textarea) {
-      this.cleanup();
+  onPointerMove(_e: PointerEvent, _editor: Editor): void {
+    // no-op
+  }
+
+  onPointerUp(_e: PointerEvent, _editor: Editor): void {
+    // no-op
+  }
+
+  private commit(editor: Editor, x: number, y: number): void {
+    if (!this.textarea) return;
+    const text = this.textarea.value;
+    if (text) {
+      const ctx = editor.ctx;
+      ctx.fillStyle = editor.strokeStyle;
+      ctx.font = `${editor.lineWidthValue * 4}px sans-serif`;
+      ctx.fillText(text, x, y);
     }
+    this.cleanup();
   }
 
   destroy(): void {
@@ -58,5 +89,5 @@ import { Tool } from "./Tool";
     this.blurListener = null;
     this.keydownListener = null;
   }
-
 }
+


### PR DESCRIPTION
## Summary
- implement TextTool to overlay textarea, commit text to canvas, and clean up

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx jest` *(fails: TypeError: Cannot set properties of null (setting 'getContext') and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a00b46696c8328a590034820a1e81e