### PR TITLE
Remove redundant pointer capture in Editor

### DIFF
--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -43,7 +43,6 @@ export class Editor {
   private handlePointerDown = (e: PointerEvent) => {
     this.canvas.setPointerCapture(e.pointerId);
     this.saveState();
-    this.canvas.setPointerCapture(e.pointerId);
     this.currentTool?.onPointerDown(e, this);
   };
 


### PR DESCRIPTION
## Summary
- call `setPointerCapture` only once when pointer down to avoid duplicate capture

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx jest` *(fails: SyntaxError and TypeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a00b474d5c8328b44dff7cfc791cc1