### PR TITLE
Remove redundant pointer capture in Editor

### DIFF
--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -41,9 +41,9 @@ export class Editor {
   }
 
   private handlePointerDown = (e: PointerEvent) => {
+    // Capture the pointer once before recording canvas state
     this.canvas.setPointerCapture(e.pointerId);
     this.saveState();
-    this.canvas.setPointerCapture(e.pointerId);
     this.currentTool?.onPointerDown(e, this);
   };
 


### PR DESCRIPTION
## Summary
- call `setPointerCapture` only once when pointer down to avoid duplicate capture
- document pointer capture behavior

## Testing
- `npx jest` *(fails: SyntaxError in TextTool.ts; Test Suites: 11 failed, 4 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a00b474d5c8328b44dff7cfc791cc1