### PR TITLE
Fix canvas scaling for device pixel ratio

### DIFF
--- a/dist/core/Editor.js
+++ b/dist/core/Editor.js
@@ -45,12 +45,7 @@ export class Editor {
         const rect = this.canvas.getBoundingClientRect();
         this.canvas.width = rect.width * dpr;
         this.canvas.height = rect.height * dpr;
-        if ("setTransform" in this.ctx) {
-            this.ctx.setTransform(1, 0, 0, 1, 0, 0);
-        }
-        if ("scale" in this.ctx) {
-            this.ctx.scale(dpr, dpr);
-        }
+        this.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     }
     saveState() {
         this.undoStack.push(this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height));

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -61,7 +61,7 @@ export class Editor {
     const rect = this.canvas.getBoundingClientRect();
     this.canvas.width = rect.width * dpr;
     this.canvas.height = rect.height * dpr;
-
+    this.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   }
 
   private handleResize = () => {


### PR DESCRIPTION
## Summary
- ensure canvas context uses device pixel ratio by setting transform
- remove redundant scale call

## Testing
- `npm test` *(fails: Missing script: "test"; to see a list of scripts, run: npm run)*
- `npx jest 2>&1 | tail -n 20` *(fails: TypeError: Cannot read properties of undefined (reading 'destroy'); Test Suites: 11 failed, 4 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a00b479a2c8328a2e28d1934494ca3