### PR TITLE
refactor circle tool to redraw cleanly

### DIFF
--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -9,15 +9,12 @@ export class CircleTool extends DrawingTool {
   onPointerDown(e: PointerEvent, editor: Editor): void {
     this.startX = e.offsetX;
     this.startY = e.offsetY;
-    this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
     this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
   }
 
   onPointerMove(e: PointerEvent, editor: Editor): void {
     if (e.buttons !== 1 || !this.imageData) return;
-    const ctx = editor.ctx;
-
     const ctx = editor.ctx;
     ctx.putImageData(this.imageData, 0, 0);
     this.applyStroke(ctx, editor);
@@ -35,9 +32,11 @@ export class CircleTool extends DrawingTool {
   }
 
   onPointerUp(e: PointerEvent, editor: Editor): void {
-
-    this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
+    if (this.imageData) {
+      ctx.putImageData(this.imageData, 0, 0);
+    }
+    this.applyStroke(ctx, editor);
     const dx = e.offsetX - this.startX;
     const dy = e.offsetY - this.startY;
     const radius = Math.sqrt(dx * dx + dy * dy);


### PR DESCRIPTION
## Summary
- capture canvas snapshot for circle drawing and restore as pointer moves
- configure stroke and context retrieval before drawing circles

## Testing
- `npm test` *(fails: Identifier 'ctx' has already been declared)*
- `npm run lint` *(fails: Parsing error: Unexpected token...)*

------
https://chatgpt.com/codex/tasks/task_e_68a048e7bf908328af6ca95e8d247ce6