### PR TITLE
Use single-canvas editor initialization

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,3 +1,5 @@
 import { initEditor } from "./editor";
+// Initialize a single editor instance for the existing #canvas element
+// and clean it up when the page unloads.
 const handle = initEditor();
 window.addEventListener("beforeunload", () => handle.destroy());

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { initEditor } from "./editor";
 
-const handles = [initEditor("layer1"), initEditor("layer2")];
-window.addEventListener("beforeunload", () =>
-  handles.forEach((h) => h.destroy()),
-);
+// Initialize a single editor instance for the existing #canvas element
+// and clean it up when the page unloads.
+const handle = initEditor();
+window.addEventListener("beforeunload", () => handle.destroy());
 


### PR DESCRIPTION
## Summary
- Initialize editor on the existing `#canvas` element and simplify unload handling
- Update built script for single-canvas editor setup

## Testing
- `npm run build` *(fails: Declaration or statement expected in src/core/Shortcuts.ts)*
- `npm test` *(fails: SyntaxError in src/tools/LineTool.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d8a07efc8328a3d0e6528f2325ab