### PR TITLE
Initialize keyboard shortcut listener in constructor

### DIFF
--- a/src/core/Shortcuts.ts
+++ b/src/core/Shortcuts.ts
@@ -16,6 +16,8 @@ export class Shortcuts {
   private readonly handler: (e: KeyboardEvent) => void;
   private editor: Editor;
 
+  constructor(editor: Editor) {
+    this.editor = editor;
     this.handler = (e: KeyboardEvent) => this.onKeyDown(e);
     document.addEventListener("keydown", this.handler);
   }


### PR DESCRIPTION
## Summary
- add `Shortcuts` constructor that accepts an `Editor` and registers the keydown handler

## Testing
- `npm test` *(fails: Identifier 'ctx' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d8a512a083288d8a29ec6d731a80