### PR TITLE
Import editor module in index

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,3 +1,3 @@
-
+import { initEditor } from "./editor.js";
 const handle = initEditor();
 window.addEventListener("beforeunload", () => handle.destroy());

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { initEditor } from "./editor.js";
 
 const handle = initEditor();
 window.addEventListener("beforeunload", () => handle.destroy());


### PR DESCRIPTION
## Summary
- import initEditor from editor module in index
- initialize editor before registering beforeunload cleanup

## Testing
- `npm run build` (fails: TextTool.ts errors)
- `npm test` (fails: canvas and TextTool parsing issues)


------
https://chatgpt.com/codex/tasks/task_e_68a2dd136ac88328b63c4a5b234820f6