### PR TITLE
Fix line tool preview and canvas state restoration

### DIFF
--- a/dist/tools/LineTool.js
+++ b/dist/tools/LineTool.js
@@ -7,11 +7,16 @@ export class LineTool extends DrawingTool {
         this.imageData = null;
     }
     onPointerDown(e, editor) {
-        const ctx = editor.ctx;
         this.startX = e.offsetX;
         this.startY = e.offsetY;
+        const ctx = editor.ctx;
         this.applyStroke(ctx, editor);
-        this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
+        if (typeof ctx.getImageData === "function") {
+            this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
+        }
+        else {
+            this.imageData = null;
+        }
     }
     onPointerMove(e, editor) {
         if (e.buttons !== 1 || !this.imageData)

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -9,12 +9,24 @@ export class LineTool extends DrawingTool {
   onPointerDown(e: PointerEvent, editor: Editor): void {
     this.startX = e.offsetX;
     this.startY = e.offsetY;
-
+    const ctx = editor.ctx;
+    this.applyStroke(ctx, editor);
+    if (typeof ctx.getImageData === "function") {
+      this.imageData = ctx.getImageData(
+        0,
+        0,
+        editor.canvas.width,
+        editor.canvas.height,
+      );
+    } else {
+      this.imageData = null;
+    }
   }
 
   onPointerMove(e: PointerEvent, editor: Editor): void {
     if (e.buttons !== 1 || !this.imageData) return;
-
+    const ctx = editor.ctx;
+    ctx.putImageData(this.imageData, 0, 0);
     this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
@@ -26,7 +38,7 @@ export class LineTool extends DrawingTool {
   onPointerUp(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
     if (this.imageData) {
-
+      ctx.putImageData(this.imageData, 0, 0);
     }
     this.applyStroke(ctx, editor);
     ctx.beginPath();


### PR DESCRIPTION
## Summary
- Save canvas image data and apply stroke settings on pointer start
- Restore image data while previewing and finalizing line draws
- Update compiled line tool module

## Testing
- `npm test` *(fails: ReferenceError: canvases is not defined)*
- `npm run lint` *(fails: Parsing error in TextTool.ts)*
- `npm run build` *(fails: TextTool.ts ';' expected)*

------
https://chatgpt.com/codex/tasks/task_e_68a2dd142cf0832883d0656e1046a7a9