### PR TITLE
Implement text overlay tool

### DIFF
--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -1,8 +1,48 @@
 import { Editor } from "../core/Editor.js";
 import { Tool } from "./Tool.js";
 
+export class TextTool implements Tool {
+  private textarea: HTMLTextAreaElement | null = null;
+  private blurListener: ((this: HTMLTextAreaElement, ev: FocusEvent) => void) | null = null;
+  private keydownListener:
+    | ((this: HTMLTextAreaElement, ev: KeyboardEvent) => void)
+    | null = null;
 
-    this.blurListener = commit;
+  onPointerDown(e: PointerEvent, editor: Editor): void {
+    this.cleanup();
+
+    const textarea = document.createElement("textarea");
+    textarea.style.position = "absolute";
+    const parent = editor.canvas.parentElement || document.body;
+    textarea.style.left = `${e.offsetX}px`;
+    textarea.style.top = `${e.offsetY}px`;
+    textarea.style.color = editor.strokeStyle;
+    textarea.style.fontSize = `${editor.lineWidthValue * 4}px`;
+    textarea.style.fontFamily = "sans-serif";
+    textarea.style.background = "transparent";
+    textarea.style.border = "none";
+    textarea.style.outline = "none";
+    parent.appendChild(textarea);
+    textarea.focus();
+
+    const commit = () => {
+      const text = textarea.value;
+      this.cleanup();
+      if (text) {
+        editor.ctx.fillStyle = editor.strokeStyle;
+        editor.ctx.font = `${editor.lineWidthValue * 4}px sans-serif`;
+        editor.ctx.fillText(text, e.offsetX, e.offsetY);
+        editor.saveState();
+      }
+    };
+
+    const cancel = () => {
+      this.cleanup();
+    };
+
+    this.blurListener = cancel;
+    textarea.addEventListener("blur", this.blurListener);
+
     this.keydownListener = (ev: KeyboardEvent) => {
       if (ev.key === "Enter") {
         ev.preventDefault();
@@ -13,15 +53,13 @@ import { Tool } from "./Tool.js";
       }
     };
 
-
-  onPointerUp(_e: PointerEvent, _editor: Editor): void {
-    if (this.textarea && document.activeElement !== this.textarea) {
-      this.cleanup();
-    }
+    textarea.addEventListener("keydown", this.keydownListener);
+    this.textarea = textarea;
   }
 
-  onPointerMove(): void {}
-  onPointerUp(): void {}
+  onPointerMove(_e: PointerEvent, _editor: Editor): void {}
+
+  onPointerUp(_e: PointerEvent, _editor: Editor): void {}
 
   destroy(): void {
     this.cleanup();
@@ -43,5 +81,5 @@ import { Tool } from "./Tool.js";
     this.blurListener = null;
     this.keydownListener = null;
   }
-
+}
 


### PR DESCRIPTION
## Summary
- implement TextTool to overlay textarea and commit text to canvas

## Testing
- `npm test` *(fails: ReferenceError canvases is not defined, TypeError etc.)*
- `npm run lint` *(fails: 8 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a2dd14b7548328b909eafbbf9219cb