### PR TITLE
Add Eraser keyboard shortcut

### DIFF
--- a/src/core/Shortcuts.ts
+++ b/src/core/Shortcuts.ts
@@ -54,7 +54,9 @@ export class Shortcuts {
         break;
       case "t":
         this.editor.setTool(new TextTool());
-
+        break;
+      case "e":
+        this.editor.setTool(new EraserTool());
         break;
     }
   }

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -1,6 +1,7 @@
 import { initEditor, EditorHandle } from "../src/editor.js";
 import { RectangleTool } from "../src/tools/RectangleTool.js";
 import { PencilTool } from "../src/tools/PencilTool.js";
+import { EraserTool } from "../src/tools/EraserTool.js";
 import { Shortcuts } from "../src/core/Shortcuts.js";
 import { Editor } from "../src/core/Editor.js";
 
@@ -51,6 +52,8 @@ describe("keyboard shortcuts", () => {
     expect(spy.mock.calls[0][0]).toBeInstanceOf(RectangleTool);
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "p" }));
     expect(spy.mock.calls[1][0]).toBeInstanceOf(PencilTool);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "e" }));
+    expect(spy.mock.calls[2][0]).toBeInstanceOf(EraserTool);
   });
 
   it("performs undo and redo with shortcuts", () => {


### PR DESCRIPTION
## Summary
- add `e` key support for selecting the Eraser tool
- test that shortcut letters switch to the correct tools

## Testing
- `npm run build` *(fails: Property or signature expected in src/editor.ts)*
- `npm run lint` *(fails: Parsing error in src/editor.ts and TextTool.ts)*
- `npm test` *(fails: ReferenceError canvases is not defined in editor.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a2dd1564c883288e58fce2411eeb71