### PR TITLE
Initialize editor in toolbar tests

### DIFF
--- a/tests/toolbar.test.ts
+++ b/tests/toolbar.test.ts
@@ -1,4 +1,4 @@
-import { initEditor, EditorHandle } from "../src/editor.js";
+import type { EditorHandle } from "../src/editor.js";
 import { PencilTool } from "../src/tools/PencilTool.js";
 import { EraserTool } from "../src/tools/EraserTool.js";
 import { RectangleTool } from "../src/tools/RectangleTool.js";
@@ -10,36 +10,60 @@ describe("toolbar controls", () => {
   let handle: EditorHandle;
   let canvas: HTMLCanvasElement;
   let ctx: Partial<CanvasRenderingContext2D>;
+  let initEditor: () => EditorHandle;
 
+  beforeEach(async () => {
+    document.body.innerHTML = `
+      <canvas id="canvas"></canvas>
+      <canvas id="canvas2"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
+      <button id="pencil"></button>
+      <button id="eraser"></button>
+      <button id="rectangle"></button>
+      <button id="line"></button>
+      <button id="circle"></button>
+      <button id="text"></button>
+      <select id="layerSelect">
+        <option value="0"></option>
+        <option value="1"></option>
+      </select>
+      <button id="undo"></button>
+      <button id="redo"></button>
+    `;
 
-      canvas = document.getElementById("canvas") as HTMLCanvasElement;
-      const canvas2 = document.getElementById("canvas2") as HTMLCanvasElement;
-      ctx = {
-        setTransform: jest.fn(),
-        scale: jest.fn(),
-        getImageData: jest.fn(),
-        putImageData: jest.fn(),
-        clearRect: jest.fn(),
-      };
-      const ctx2 = { ...ctx } as Partial<CanvasRenderingContext2D>;
-      canvas.getContext = jest.fn().mockReturnValue(ctx as CanvasRenderingContext2D);
-      canvas2.getContext = jest.fn().mockReturnValue(ctx2 as CanvasRenderingContext2D);
-      [canvas, canvas2].forEach((c) => {
-        c.getBoundingClientRect = () => ({
-          width: 100,
-          height: 100,
-          top: 0,
-          left: 0,
-          bottom: 100,
-          right: 100,
-          x: 0,
-          y: 0,
-          toJSON: () => {},
-        });
+    canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    const canvas2 = document.getElementById("canvas2") as HTMLCanvasElement;
+    ctx = {
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+      getImageData: jest.fn(),
+      putImageData: jest.fn(),
+      clearRect: jest.fn(),
+    };
+    const ctx2 = { ...ctx } as Partial<CanvasRenderingContext2D>;
+    canvas.getContext = jest.fn().mockReturnValue(ctx as CanvasRenderingContext2D);
+    canvas2.getContext = jest.fn().mockReturnValue(ctx2 as CanvasRenderingContext2D);
+
+    [canvas, canvas2].forEach((c) => {
+      c.getBoundingClientRect = () => ({
+        width: 100,
+        height: 100,
+        top: 0,
+        left: 0,
+        bottom: 100,
+        right: 100,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
       });
-
-      handle = initEditor();
     });
+
+    (globalThis as any).canvases = [canvas, canvas2];
+    ({ initEditor } = await import("../src/editor.js"));
+    handle = initEditor();
+  });
 
   afterEach(() => {
     handle.destroy();


### PR DESCRIPTION
## Summary
- Rebuild toolbar test setup to create DOM elements, canvases, and initialize the editor
- Load editor dynamically after defining canvases and expose them globally for init

## Testing
- `npm test tests/toolbar.test.ts` *(fails: Jest encountered an unexpected token in src/tools/TextTool.ts)*


------
https://chatgpt.com/codex/tasks/task_e_68a2dd16db4883288394eb5de40eff66