### PR TITLE
Wrap line preview test in it block

### DIFF
--- a/tests/lineTool.test.ts
+++ b/tests/lineTool.test.ts
@@ -46,7 +46,7 @@ describe("LineTool", () => {
     );
   });
 
-
+  it("renders line preview during drag", () => {
     const tool = new LineTool();
     tool.onPointerDown({ offsetX: 1, offsetY: 2 } as PointerEvent, editor);
     tool.onPointerMove({


### PR DESCRIPTION
## Summary
- wrap LineTool drag preview assertions in a proper test

## Testing
- `npm test` *(fails: ReferenceError: canvases is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a2dd3f55d88328be99d35a507113c9