### PR TITLE
Ensure editor initialization is imported in entry point

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,3 +1,3 @@
-
+import { initEditor } from "./editor.js";
 const handle = initEditor();
 window.addEventListener("beforeunload", () => handle.destroy());

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { initEditor } from "./editor.js";
 
 const handle = initEditor();
 window.addEventListener("beforeunload", () => handle.destroy());


### PR DESCRIPTION
## Summary
- import `initEditor` in `src/index.ts`
- update build output `dist/index.js`

## Testing
- `npm run lint` *(fails: 'EraserTool' is defined but never used, parsing errors, etc.)*
- `npm run build` *(fails: TypeScript errors in TextTool.ts)*
- `npm test` *(fails: canvases is not defined, SyntaxError in TextTool.ts, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a2dd7f458483289040c8d4c32de2f8