### PR TITLE
Add eraser keyboard shortcut

### DIFF
--- a/src/core/Shortcuts.ts
+++ b/src/core/Shortcuts.ts
@@ -52,6 +52,9 @@ export class Shortcuts {
       case "c":
         this.editor.setTool(new CircleTool());
         break;
+      case "e":
+        this.editor.setTool(new EraserTool());
+        break;
       case "t":
         this.editor.setTool(new TextTool());
 

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -1,6 +1,7 @@
 import { initEditor, EditorHandle } from "../src/editor.js";
 import { RectangleTool } from "../src/tools/RectangleTool.js";
 import { PencilTool } from "../src/tools/PencilTool.js";
+import { EraserTool } from "../src/tools/EraserTool.js";
 import { Shortcuts } from "../src/core/Shortcuts.js";
 import { Editor } from "../src/core/Editor.js";
 
@@ -51,6 +52,8 @@ describe("keyboard shortcuts", () => {
     expect(spy.mock.calls[0][0]).toBeInstanceOf(RectangleTool);
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "p" }));
     expect(spy.mock.calls[1][0]).toBeInstanceOf(PencilTool);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "e" }));
+    expect(spy.mock.calls[2][0]).toBeInstanceOf(EraserTool);
   });
 
   it("performs undo and redo with shortcuts", () => {


### PR DESCRIPTION
## Summary
- add `E` shortcut to activate eraser tool
- cover eraser shortcut in keyboard shortcut test

## Testing
- `npm test` *(fails: ReferenceError: canvases is not defined, SyntaxError in TextTool.ts, etc.)*
- `npm run lint` *(fails: Parsing errors in editor.ts, LineTool.ts, TextTool.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a2dd7bac6883288084198792821eb4