### PR TITLE
Add format selection dropdown for saves

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,8 +23,11 @@
       <input type="file" id="imageLoader" accept="image/*" />
       <button id="undo" disabled>Undo</button>
       <button id="redo" disabled>Redo</button>
+      <select id="formatSelect">
+        <option value="png">PNG</option>
+        <option value="jpeg">JPEG</option>
+      </select>
       <button id="save">Save</button>
-      <button id="saveJpeg">Save JPEG</button>
     </div>
     <canvas id="canvas" width="800" height="600"></canvas>
     <script type="module" src="dist/index.js"></script>


### PR DESCRIPTION
## Summary
- Add PNG/JPEG format dropdown to toolbar and remove unused "Save JPEG" button

## Testing
- `npm test` *(fails: ReferenceError: canvases is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a2dd80de8c8328903dff3a8a0e540f