### PR TITLE
fix save test anchor

### DIFF
--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -1,7 +1,5 @@
-import { initEditor } from "../src/editor.js";
-
 describe("save button", () => {
-  it("calls toDataURL on click", () => {
+  it("calls toDataURL on click", async () => {
     document.body.innerHTML = `
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
@@ -26,9 +24,11 @@ describe("save button", () => {
     });
 
     const click = jest.fn();
+    const anchor = { href: "", download: "", click } as any;
 
     jest.spyOn(document, "createElement").mockReturnValue(anchor);
 
+    const { initEditor } = await import("../dist/editor.js");
     const handle = initEditor();
 
     (document.getElementById("save") as HTMLButtonElement).click();
@@ -38,7 +38,7 @@ describe("save button", () => {
     handle.destroy();
   });
 
-  it("supports selecting jpeg format", () => {
+  it("supports selecting jpeg format", async () => {
     document.body.innerHTML = `
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
@@ -68,6 +68,7 @@ describe("save button", () => {
     const anchor = { href: "", download: "", click } as any;
     jest.spyOn(document, "createElement").mockReturnValue(anchor);
 
+    const { initEditor } = await import("../dist/editor.js");
     const handle = initEditor();
 
     (document.getElementById("save") as HTMLButtonElement).click();


### PR DESCRIPTION
## Summary
- Ensure save test defines an anchor element before spying on `document.createElement`
- Dynamically import editor during tests

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/save.test.ts` *(fails: Must use import to load ES Module)*

------
https://chatgpt.com/codex/tasks/task_e_68a2dd15e7fc832890dd61666571c598