### PR TITLE
feat: add spray painting tool

### DIFF
--- a/src/core/Shortcuts.ts
+++ b/src/core/Shortcuts.ts
@@ -5,6 +5,7 @@ import { LineTool } from "../tools/LineTool.js";
 import { CircleTool } from "../tools/CircleTool.js";
 import { TextTool } from "../tools/TextTool.js";
 import { EraserTool } from "../tools/EraserTool.js";
+import { SprayTool } from "../tools/SprayTool.js";
 
 /**
  * Keyboard shortcuts handler for the editor.
@@ -54,7 +55,9 @@ export class Shortcuts {
         break;
       case "t":
         this.editor.setTool(new TextTool());
-
+        break;
+      case "s":
+        this.editor.setTool(new SprayTool());
         break;
     }
   }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,10 +1,39 @@
+import { Editor } from "./core/Editor.js";
+import { Shortcuts } from "./core/Shortcuts.js";
+import { PencilTool } from "./tools/PencilTool.js";
+import { EraserTool } from "./tools/EraserTool.js";
+import { RectangleTool } from "./tools/RectangleTool.js";
+import { LineTool } from "./tools/LineTool.js";
+import { CircleTool } from "./tools/CircleTool.js";
+import { TextTool } from "./tools/TextTool.js";
+import { SprayTool } from "./tools/SprayTool.js";
+import { Tool } from "./tools/Tool.js";
 
+/** Utility to listen to events and auto-remove on destroy. */
+function listen(
+  el: EventTarget | null,
+  type: string,
+  handler: EventListenerOrEventListenerObject,
+  list: Array<() => void>,
+) {
+  if (!el) return;
+  el.addEventListener(type, handler);
+  list.push(() => el.removeEventListener(type, handler));
+}
 
 export interface EditorHandle {
   editor: Editor;
   editors: Editor[];
+  activateLayer(index: number): void;
+  destroy(): void;
+}
 
-
+/**
+ * Initialize the editor by wiring up DOM controls and returning an
+ * {@link EditorHandle} that allows tests or callers to tear down the editor.
+ */
+export function initEditor(): EditorHandle {
+  const canvases = Array.from(document.querySelectorAll("canvas"));
   const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
   const lineWidth = document.getElementById("lineWidth") as HTMLInputElement;
   const fillMode = document.getElementById("fillMode") as HTMLInputElement;
@@ -47,6 +76,7 @@ export interface EditorHandle {
     line: LineTool,
     circle: CircleTool,
     text: TextTool,
+    spray: SprayTool,
   };
 
   Object.entries(toolButtons).forEach(([id, ToolCtor]) =>

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -7,14 +7,17 @@ export class LineTool extends DrawingTool {
   private imageData: ImageData | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
+    const ctx = editor.ctx;
     this.startX = e.offsetX;
     this.startY = e.offsetY;
-
+    this.applyStroke(ctx, editor);
+    this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
   }
 
   onPointerMove(e: PointerEvent, editor: Editor): void {
     if (e.buttons !== 1 || !this.imageData) return;
-
+    const ctx = editor.ctx;
+    ctx.putImageData(this.imageData, 0, 0);
     this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
@@ -26,7 +29,7 @@ export class LineTool extends DrawingTool {
   onPointerUp(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
     if (this.imageData) {
-
+      ctx.putImageData(this.imageData, 0, 0);
     }
     this.applyStroke(ctx, editor);
     ctx.beginPath();
@@ -37,3 +40,4 @@ export class LineTool extends DrawingTool {
     this.imageData = null;
   }
 }
+

--- a/src/tools/SprayTool.ts
+++ b/src/tools/SprayTool.ts
@@ -1,0 +1,54 @@
+import { Editor } from "../core/Editor.js";
+import { DrawingTool } from "./DrawingTool.js";
+
+/**
+ * Tool that sprays random dots while the pointer is pressed.
+ */
+export class SprayTool extends DrawingTool {
+  private interval: number | null = null;
+  private x = 0;
+  private y = 0;
+
+  onPointerDown(e: PointerEvent, editor: Editor): void {
+    this.x = e.offsetX;
+    this.y = e.offsetY;
+    const ctx = editor.ctx;
+    // spray immediately then start interval
+    this.spray(ctx, editor);
+    this.interval = window.setInterval(() => this.spray(ctx, editor), 25);
+  }
+
+  onPointerMove(e: PointerEvent, _editor: Editor): void {
+    if (e.buttons !== 1) return;
+    this.x = e.offsetX;
+    this.y = e.offsetY;
+  }
+
+  onPointerUp(_e: PointerEvent, _editor: Editor): void {
+    if (this.interval !== null) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+  }
+
+  destroy(): void {
+    if (this.interval !== null) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+  }
+
+  private spray(ctx: CanvasRenderingContext2D, editor: Editor): void {
+    this.applyStroke(ctx, editor);
+    const radius = editor.lineWidthValue;
+    const count = radius; // number of dots per tick proportional to brush size
+    for (let i = 0; i < count; i++) {
+      const angle = Math.random() * Math.PI * 2;
+      const r = Math.random() * radius;
+      const x = this.x + Math.cos(angle) * r;
+      const y = this.y + Math.sin(angle) * r;
+      ctx.fillRect(x, y, editor.lineWidthValue, editor.lineWidthValue);
+    }
+  }
+}
+

--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -1,8 +1,44 @@
 import { Editor } from "../core/Editor.js";
 import { Tool } from "./Tool.js";
 
+export class TextTool implements Tool {
+  private textarea: HTMLTextAreaElement | null = null;
+  private blurListener: ((this: HTMLTextAreaElement, ev: FocusEvent) => any) | null = null;
+  private keydownListener: ((this: HTMLTextAreaElement, ev: KeyboardEvent) => any) | null = null;
 
-    this.blurListener = commit;
+  onPointerDown(e: PointerEvent, editor: Editor): void {
+    this.cleanup();
+    const textarea = document.createElement("textarea");
+    textarea.style.position = "absolute";
+    const parent = editor.canvas.parentElement || document.body;
+    textarea.style.left = `${e.offsetX}px`;
+    textarea.style.top = `${e.offsetY}px`;
+    textarea.style.color = editor.strokeStyle;
+    textarea.style.fontSize = `${editor.lineWidthValue * 4}px`;
+    textarea.style.fontFamily = "sans-serif";
+    textarea.style.background = "transparent";
+    textarea.style.border = "none";
+    textarea.style.outline = "none";
+    parent.appendChild(textarea);
+    textarea.focus();
+
+    const commit = () => {
+      const text = textarea.value;
+      this.cleanup();
+      if (text) {
+        editor.ctx.fillStyle = editor.strokeStyle;
+        editor.ctx.font = `${editor.lineWidthValue * 4}px sans-serif`;
+        editor.ctx.fillText(text, e.offsetX, e.offsetY);
+        editor.saveState();
+      }
+    };
+
+    const cancel = () => {
+      this.cleanup();
+    };
+
+    this.blurListener = cancel;
+    textarea.addEventListener("blur", this.blurListener);
     this.keydownListener = (ev: KeyboardEvent) => {
       if (ev.key === "Enter") {
         ev.preventDefault();
@@ -12,24 +48,18 @@ import { Tool } from "./Tool.js";
         cancel();
       }
     };
-
-
-  onPointerUp(_e: PointerEvent, _editor: Editor): void {
-    if (this.textarea && document.activeElement !== this.textarea) {
-      this.cleanup();
-    }
+    textarea.addEventListener("keydown", this.keydownListener);
+    this.textarea = textarea;
   }
 
-  onPointerMove(): void {}
-  onPointerUp(): void {}
+  onPointerMove(_e: PointerEvent, _editor: Editor): void {}
+  onPointerUp(_e: PointerEvent, _editor: Editor): void {}
 
   destroy(): void {
     this.cleanup();
   }
 
-  /**
-   * Remove textarea overlay and any registered listeners.
-   */
+  /** Remove textarea overlay and listeners. */
   private cleanup(): void {
     if (!this.textarea) return;
     if (this.blurListener) {
@@ -43,5 +73,5 @@ import { Tool } from "./Tool.js";
     this.blurListener = null;
     this.keydownListener = null;
   }
-
+}
 

--- a/tests/drawingTool.test.ts
+++ b/tests/drawingTool.test.ts
@@ -3,6 +3,7 @@ import { PencilTool } from "../src/tools/PencilTool.js";
 import { RectangleTool } from "../src/tools/RectangleTool.js";
 import { LineTool } from "../src/tools/LineTool.js";
 import { CircleTool } from "../src/tools/CircleTool.js";
+import { SprayTool } from "../src/tools/SprayTool.js";
 
 describe("DrawingTool subclasses", () => {
   it("PencilTool extends DrawingTool", () => {
@@ -19,5 +20,9 @@ describe("DrawingTool subclasses", () => {
 
   it("CircleTool extends DrawingTool", () => {
     expect(new CircleTool()).toBeInstanceOf(DrawingTool);
+  });
+
+  it("SprayTool extends DrawingTool", () => {
+    expect(new SprayTool()).toBeInstanceOf(DrawingTool);
   });
 });

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -1,6 +1,7 @@
 import { initEditor, EditorHandle } from "../src/editor.js";
 import { RectangleTool } from "../src/tools/RectangleTool.js";
 import { PencilTool } from "../src/tools/PencilTool.js";
+import { SprayTool } from "../src/tools/SprayTool.js";
 import { Shortcuts } from "../src/core/Shortcuts.js";
 import { Editor } from "../src/core/Editor.js";
 
@@ -51,6 +52,8 @@ describe("keyboard shortcuts", () => {
     expect(spy.mock.calls[0][0]).toBeInstanceOf(RectangleTool);
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "p" }));
     expect(spy.mock.calls[1][0]).toBeInstanceOf(PencilTool);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "s" }));
+    expect(spy.mock.calls[2][0]).toBeInstanceOf(SprayTool);
   });
 
   it("performs undo and redo with shortcuts", () => {

--- a/tests/sprayTool.test.ts
+++ b/tests/sprayTool.test.ts
@@ -1,0 +1,63 @@
+import { Editor } from "../src/core/Editor.js";
+import { SprayTool } from "../src/tools/SprayTool.js";
+
+describe("SprayTool", () => {
+  let editor: Editor;
+  let ctx: Partial<CanvasRenderingContext2D> & {
+    fillRect: jest.Mock;
+    fillStyle: string;
+    strokeStyle: string;
+    lineWidth: number;
+  };
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <canvas id="canvas"></canvas>
+      <input id="colorPicker" value="#ff0000" />
+      <input id="lineWidth" value="5" />
+      <input id="fillMode" type="checkbox" />
+    `;
+    const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    (canvas as any).setPointerCapture = jest.fn();
+    (canvas as any).releasePointerCapture = jest.fn();
+    ctx = {
+      fillRect: jest.fn(),
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+      fillStyle: "",
+      strokeStyle: "",
+      lineWidth: 0,
+    };
+    canvas.getContext = jest.fn().mockReturnValue(ctx as any);
+    editor = new Editor(
+      canvas,
+      document.getElementById("colorPicker") as HTMLInputElement,
+      document.getElementById("lineWidth") as HTMLInputElement,
+      document.getElementById("fillMode") as HTMLInputElement,
+    );
+  });
+
+  it("sprays dots within the specified radius", () => {
+    const tool = new SprayTool();
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    tool.onPointerDown({ offsetX: 10, offsetY: 10 } as PointerEvent, editor);
+    expect(ctx.fillRect).toHaveBeenCalled();
+    const [x, y] = (ctx.fillRect as jest.Mock).mock.calls[0];
+    const dx = x - 10;
+    const dy = y - 10;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    expect(dist).toBeLessThanOrEqual(editor.lineWidthValue);
+  });
+
+  it("uses editor color and line width for dots", () => {
+    const tool = new SprayTool();
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    tool.onPointerDown({ offsetX: 5, offsetY: 5 } as PointerEvent, editor);
+    const [, , w, h] = (ctx.fillRect as jest.Mock).mock.calls[0];
+    expect(ctx.fillStyle).toBe(editor.strokeStyle);
+    expect(ctx.lineWidth).toBe(editor.lineWidthValue);
+    expect(w).toBe(editor.lineWidthValue);
+    expect(h).toBe(editor.lineWidthValue);
+  });
+});
+

--- a/tests/toolbar.test.ts
+++ b/tests/toolbar.test.ts
@@ -5,82 +5,107 @@ import { RectangleTool } from "../src/tools/RectangleTool.js";
 import { LineTool } from "../src/tools/LineTool.js";
 import { CircleTool } from "../src/tools/CircleTool.js";
 import { TextTool } from "../src/tools/TextTool.js";
+import { SprayTool } from "../src/tools/SprayTool.js";
 
 describe("toolbar controls", () => {
   let handle: EditorHandle;
   let canvas: HTMLCanvasElement;
   let ctx: Partial<CanvasRenderingContext2D>;
 
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <canvas id="canvas"></canvas>
+      <canvas id="canvas2"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
+      <button id="pencil"></button>
+      <button id="eraser"></button>
+      <button id="rectangle"></button>
+      <button id="line"></button>
+      <button id="circle"></button>
+      <button id="text"></button>
+      <button id="spray"></button>
+      <button id="undo"></button>
+      <button id="redo"></button>
+      <select id="layerSelect"><option value="0"></option><option value="1"></option></select>
+    `;
 
-      canvas = document.getElementById("canvas") as HTMLCanvasElement;
-      const canvas2 = document.getElementById("canvas2") as HTMLCanvasElement;
-      ctx = {
-        setTransform: jest.fn(),
-        scale: jest.fn(),
-        getImageData: jest.fn(),
-        putImageData: jest.fn(),
-        clearRect: jest.fn(),
-      };
-      const ctx2 = { ...ctx } as Partial<CanvasRenderingContext2D>;
-      canvas.getContext = jest.fn().mockReturnValue(ctx as CanvasRenderingContext2D);
-      canvas2.getContext = jest.fn().mockReturnValue(ctx2 as CanvasRenderingContext2D);
-      [canvas, canvas2].forEach((c) => {
-        c.getBoundingClientRect = () => ({
-          width: 100,
-          height: 100,
-          top: 0,
-          left: 0,
-          bottom: 100,
-          right: 100,
-          x: 0,
-          y: 0,
-          toJSON: () => {},
-        });
+    canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    const canvas2 = document.getElementById("canvas2") as HTMLCanvasElement;
+
+    ctx = {
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+      getImageData: jest.fn(),
+      putImageData: jest.fn(),
+      clearRect: jest.fn(),
+    };
+    const ctx2 = { ...ctx } as Partial<CanvasRenderingContext2D>;
+
+    canvas.getContext = jest.fn().mockReturnValue(ctx as CanvasRenderingContext2D);
+    canvas2.getContext = jest.fn().mockReturnValue(ctx2 as CanvasRenderingContext2D);
+
+    [canvas, canvas2].forEach((c) => {
+      c.getBoundingClientRect = () => ({
+        width: 100,
+        height: 100,
+        top: 0,
+        left: 0,
+        bottom: 100,
+        right: 100,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
       });
-
-      handle = initEditor();
     });
+
+    handle = initEditor();
+  });
 
   afterEach(() => {
     handle.destroy();
   });
 
-    it("switches tools when buttons are clicked", () => {
-      const spy = jest.spyOn(handle.editor, "setTool");
-      (document.getElementById("pencil") as HTMLButtonElement).click();
-      expect(spy.mock.calls[0][0]).toBeInstanceOf(PencilTool);
+  it("switches tools when buttons are clicked", () => {
+    const spy = jest.spyOn(handle.editor, "setTool");
+    (document.getElementById("pencil") as HTMLButtonElement).click();
+    expect(spy.mock.calls[0][0]).toBeInstanceOf(PencilTool);
 
-      (document.getElementById("eraser") as HTMLButtonElement).click();
-      expect(spy.mock.calls[1][0]).toBeInstanceOf(EraserTool);
+    (document.getElementById("eraser") as HTMLButtonElement).click();
+    expect(spy.mock.calls[1][0]).toBeInstanceOf(EraserTool);
 
-      (document.getElementById("rectangle") as HTMLButtonElement).click();
-      expect(spy.mock.calls[2][0]).toBeInstanceOf(RectangleTool);
+    (document.getElementById("rectangle") as HTMLButtonElement).click();
+    expect(spy.mock.calls[2][0]).toBeInstanceOf(RectangleTool);
 
-      (document.getElementById("line") as HTMLButtonElement).click();
-      expect(spy.mock.calls[3][0]).toBeInstanceOf(LineTool);
+    (document.getElementById("line") as HTMLButtonElement).click();
+    expect(spy.mock.calls[3][0]).toBeInstanceOf(LineTool);
 
-      (document.getElementById("circle") as HTMLButtonElement).click();
-      expect(spy.mock.calls[4][0]).toBeInstanceOf(CircleTool);
+    (document.getElementById("circle") as HTMLButtonElement).click();
+    expect(spy.mock.calls[4][0]).toBeInstanceOf(CircleTool);
 
-      (document.getElementById("text") as HTMLButtonElement).click();
-      expect(spy.mock.calls[5][0]).toBeInstanceOf(TextTool);
-    });
+    (document.getElementById("text") as HTMLButtonElement).click();
+    expect(spy.mock.calls[5][0]).toBeInstanceOf(TextTool);
 
-    it("routes tool changes to the selected layer", () => {
-      const firstSpy = jest.spyOn(handle.editors[0], "setTool");
-      const secondSpy = jest.spyOn(handle.editors[1], "setTool");
+    (document.getElementById("spray") as HTMLButtonElement).click();
+    expect(spy.mock.calls[6][0]).toBeInstanceOf(SprayTool);
+  });
 
-      (document.getElementById("pencil") as HTMLButtonElement).click();
-      expect(firstSpy).toHaveBeenCalled();
-      expect(secondSpy).not.toHaveBeenCalled();
+  it("routes tool changes to the selected layer", () => {
+    const firstSpy = jest.spyOn(handle.editors[0], "setTool");
+    const secondSpy = jest.spyOn(handle.editors[1], "setTool");
 
-      const select = document.getElementById("layerSelect") as HTMLSelectElement;
-      select.value = "1";
-      select.dispatchEvent(new Event("change"));
+    (document.getElementById("pencil") as HTMLButtonElement).click();
+    expect(firstSpy).toHaveBeenCalled();
+    expect(secondSpy).not.toHaveBeenCalled();
 
-      (document.getElementById("eraser") as HTMLButtonElement).click();
-      expect(secondSpy).toHaveBeenCalled();
-    });
+    const select = document.getElementById("layerSelect") as HTMLSelectElement;
+    select.value = "1";
+    select.dispatchEvent(new Event("change"));
+
+    (document.getElementById("eraser") as HTMLButtonElement).click();
+    expect(secondSpy).toHaveBeenCalled();
+  });
 
   it("triggers undo and redo when buttons are clicked", () => {
     const undo = jest.spyOn(handle.editor, "undo").mockImplementation(() => {});


### PR DESCRIPTION
## Summary
- add SprayTool for random dot painting
- wire SprayTool into toolbar and keyboard shortcuts
- test spray rendering respects radius, color, and width

## Testing
- `npm test` *(fails: image.test.ts, tools.test.ts, save.test.ts, opacity.test.ts, lineTool.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a2dd76d3d88328804fa740c65906d4