### PR TITLE
feat: preview line while drawing

### DIFF
--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -9,12 +9,20 @@ export class LineTool extends DrawingTool {
   onPointerDown(e: PointerEvent, editor: Editor): void {
     this.startX = e.offsetX;
     this.startY = e.offsetY;
-
+    const ctx = editor.ctx;
+    this.applyStroke(ctx, editor);
+    this.imageData = ctx.getImageData(
+      0,
+      0,
+      editor.canvas.width,
+      editor.canvas.height,
+    );
   }
 
   onPointerMove(e: PointerEvent, editor: Editor): void {
     if (e.buttons !== 1 || !this.imageData) return;
-
+    const ctx = editor.ctx;
+    ctx.putImageData(this.imageData, 0, 0);
     this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
@@ -26,7 +34,7 @@ export class LineTool extends DrawingTool {
   onPointerUp(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
     if (this.imageData) {
-
+      ctx.putImageData(this.imageData, 0, 0);
     }
     this.applyStroke(ctx, editor);
     ctx.beginPath();


### PR DESCRIPTION
## Summary
- capture canvas image on pointer down in LineTool for preview restores
- restore saved image during pointer move to preview line
- restore image and clear cache on pointer up before drawing final line

## Testing
- `npm test` *(fails: Jest encountered an unexpected token, ReferenceError: canvases is not defined)*
- `npm run lint` *(fails: 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a2dd7c84748328a5272772efdee92c