### PR TITLE
Refactor editor initialization and tool modules

### DIFF
--- a/dist/editor.js
+++ b/dist/editor.js
@@ -1,11 +1,11 @@
-import { Editor } from "./core/Editor.js";
-import { Shortcuts } from "./core/Shortcuts.js";
-import { PencilTool } from "./tools/PencilTool.js";
-import { EraserTool } from "./tools/EraserTool.js";
-import { RectangleTool } from "./tools/RectangleTool.js";
-import { LineTool } from "./tools/LineTool.js";
-import { CircleTool } from "./tools/CircleTool.js";
-import { TextTool } from "./tools/TextTool.js";
+import { Editor } from "./core/Editor";
+import { Shortcuts } from "./core/Shortcuts";
+import { PencilTool } from "./tools/PencilTool";
+import { EraserTool } from "./tools/EraserTool";
+import { RectangleTool } from "./tools/RectangleTool";
+import { LineTool } from "./tools/LineTool";
+import { CircleTool } from "./tools/CircleTool";
+import { TextTool } from "./tools/TextTool";
 /** Utility to listen to events and auto-remove on destroy. */
 function listen(el, type, handler, list) {
     if (!el)

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,3 +1,3 @@
-
+import { initEditor } from "./editor";
 const handle = initEditor();
 window.addEventListener("beforeunload", () => handle.destroy());

--- a/dist/tools/TextTool.js
+++ b/dist/tools/TextTool.js
@@ -8,7 +8,6 @@ export class TextTool {
         this.cleanup();
         const textarea = document.createElement("textarea");
         textarea.style.position = "absolute";
-        const rect = editor.canvas.getBoundingClientRect();
         const parent = editor.canvas.parentElement || document.body;
         textarea.style.left = `${e.offsetX}px`;
         textarea.style.top = `${e.offsetY}px`;
@@ -53,6 +52,9 @@ export class TextTool {
     destroy() {
         this.cleanup();
     }
+    /**
+     * Remove textarea overlay and any registered listeners.
+     */
     cleanup() {
         if (!this.textarea)
             return;

--- a/src/core/Shortcuts.ts
+++ b/src/core/Shortcuts.ts
@@ -54,7 +54,9 @@ export class Shortcuts {
         break;
       case "t":
         this.editor.setTool(new TextTool());
-
+        break;
+      case "e":
+        this.editor.setTool(new EraserTool());
         break;
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { initEditor } from "./editor";
 
 const handle = initEditor();
 window.addEventListener("beforeunload", () => handle.destroy());

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -7,14 +7,17 @@ export class LineTool extends DrawingTool {
   private imageData: ImageData | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
+    const ctx = editor.ctx;
     this.startX = e.offsetX;
     this.startY = e.offsetY;
-
+    this.applyStroke(ctx, editor);
+    this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
   }
 
   onPointerMove(e: PointerEvent, editor: Editor): void {
     if (e.buttons !== 1 || !this.imageData) return;
-
+    const ctx = editor.ctx;
+    ctx.putImageData(this.imageData, 0, 0);
     this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
@@ -26,7 +29,7 @@ export class LineTool extends DrawingTool {
   onPointerUp(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
     if (this.imageData) {
-
+      ctx.putImageData(this.imageData, 0, 0);
     }
     this.applyStroke(ctx, editor);
     ctx.beginPath();
@@ -37,3 +40,4 @@ export class LineTool extends DrawingTool {
     this.imageData = null;
   }
 }
+

--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -1,8 +1,43 @@
 import { Editor } from "../core/Editor.js";
 import { Tool } from "./Tool.js";
 
+export class TextTool implements Tool {
+  private textarea: HTMLTextAreaElement | null = null;
+  private blurListener: (() => void) | null = null;
+  private keydownListener: ((ev: KeyboardEvent) => void) | null = null;
 
-    this.blurListener = commit;
+  onPointerDown(e: PointerEvent, editor: Editor): void {
+    this.cleanup();
+    const textarea = document.createElement("textarea");
+    textarea.style.position = "absolute";
+    const parent = editor.canvas.parentElement || document.body;
+    textarea.style.left = `${e.offsetX}px`;
+    textarea.style.top = `${e.offsetY}px`;
+    textarea.style.color = editor.strokeStyle;
+    textarea.style.fontSize = `${editor.lineWidthValue * 4}px`;
+    textarea.style.fontFamily = "sans-serif";
+    textarea.style.background = "transparent";
+    textarea.style.border = "none";
+    textarea.style.outline = "none";
+    parent.appendChild(textarea);
+    textarea.focus();
+
+    const commit = () => {
+      const text = textarea.value;
+      this.cleanup();
+      if (text) {
+        editor.ctx.fillStyle = editor.strokeStyle;
+        editor.ctx.font = `${editor.lineWidthValue * 4}px sans-serif`;
+        editor.ctx.fillText(text, e.offsetX, e.offsetY);
+        editor.saveState();
+      }
+    };
+    const cancel = () => {
+      this.cleanup();
+    };
+
+    this.blurListener = cancel;
+    textarea.addEventListener("blur", this.blurListener);
     this.keydownListener = (ev: KeyboardEvent) => {
       if (ev.key === "Enter") {
         ev.preventDefault();
@@ -12,15 +47,12 @@ import { Tool } from "./Tool.js";
         cancel();
       }
     };
-
-
-  onPointerUp(_e: PointerEvent, _editor: Editor): void {
-    if (this.textarea && document.activeElement !== this.textarea) {
-      this.cleanup();
-    }
+    textarea.addEventListener("keydown", this.keydownListener);
+    this.textarea = textarea;
   }
 
   onPointerMove(): void {}
+
   onPointerUp(): void {}
 
   destroy(): void {
@@ -43,5 +75,5 @@ import { Tool } from "./Tool.js";
     this.blurListener = null;
     this.keydownListener = null;
   }
-
+}
 


### PR DESCRIPTION
## Summary
- rebuild `editor.ts` with proper imports, a `listen` helper, and an exported `initEditor` that returns an `EditorHandle`
- fix shortcut mapping and restore line and text tool implementations
- wire `initEditor` into the app entry point

## Testing
- `npm run lint`
- `npm test` *(fails: HTMLCanvasElement.getContext not implemented, ctx.getImageData not a function, several tests failing)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2dd7ea600832883eee37c138c3d83