### PR TITLE
Implement text tool and fix line tool context bug

### DIFF
--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -7,7 +7,6 @@ export class LineTool extends DrawingTool {
   private imageData: ImageData | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
-    const ctx = editor.ctx;
     this.startX = e.offsetX;
     this.startY = e.offsetY;
     const ctx = editor.ctx;

--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -1,7 +1,56 @@
 import { Editor } from "../core/Editor.js";
 import { Tool } from "./Tool.js";
 
+/**
+ * Tool for entering text onto the canvas. When the user clicks on the
+ * canvas, a temporary `<textarea>` is overlaid at the click position. The
+ * text entered is committed to the canvas when the user presses Enter and
+ * cancelled on Escape or blur.
+ */
+export class TextTool implements Tool {
+  textarea: HTMLTextAreaElement | null = null;
+  private blurListener: ((e: FocusEvent) => void) | null = null;
+  private keydownListener: ((e: KeyboardEvent) => void) | null = null;
 
+  onPointerDown(e: PointerEvent, editor: Editor): void {
+    // Ensure no stray textarea remains from previous interactions.
+    this.cleanup();
+
+    const textarea = document.createElement("textarea");
+    textarea.style.position = "absolute";
+
+    // Place the textarea relative to the canvas's parent, falling back to
+    // the document body when the parent is unavailable.
+    const parent = editor.canvas.parentElement || document.body;
+    textarea.style.left = `${e.offsetX}px`;
+    textarea.style.top = `${e.offsetY}px`;
+    textarea.style.color = editor.strokeStyle;
+    textarea.style.fontSize = `${editor.lineWidthValue * 4}px`;
+    textarea.style.fontFamily = "sans-serif";
+    textarea.style.background = "transparent";
+    textarea.style.border = "none";
+    textarea.style.outline = "none";
+    parent.appendChild(textarea);
+    textarea.focus();
+
+    const commit = () => {
+      const text = textarea.value;
+      this.cleanup();
+      if (text) {
+        editor.ctx.fillStyle = editor.strokeStyle;
+        editor.ctx.font = `${editor.lineWidthValue * 4}px sans-serif`;
+        editor.ctx.fillText(text, e.offsetX, e.offsetY);
+        // Persist the state so the text can be undone/redone.
+        editor.saveState();
+      }
+    };
+
+    const cancel = () => {
+      this.cleanup();
+    };
+
+    this.blurListener = cancel;
+    textarea.addEventListener("blur", this.blurListener);
 
     this.keydownListener = (ev: KeyboardEvent) => {
       if (ev.key === "Enter") {
@@ -14,6 +63,19 @@ import { Tool } from "./Tool.js";
     };
     textarea.addEventListener("keydown", this.keydownListener);
 
+    this.textarea = textarea;
+  }
+
+  onPointerMove(_e: PointerEvent, _editor: Editor): void {
+    // TextTool does not draw during pointer movement.
+  }
+
+  onPointerUp(_e: PointerEvent, _editor: Editor): void {
+    // If the textarea loses focus before the pointer is released, ensure it
+    // is cleaned up to avoid lingering overlays.
+    if (this.textarea && document.activeElement !== this.textarea) {
+      this.cleanup();
+    }
   }
 
   destroy(): void {
@@ -35,3 +97,4 @@ import { Tool } from "./Tool.js";
     this.keydownListener = null;
   }
 }
+


### PR DESCRIPTION
## Summary
- implement full TextTool with textarea overlay, commit/cancel logic and cleanup
- remove duplicate ctx declaration in LineTool to avoid syntax errors

## Testing
- `npm test tests/textTool.test.ts`
- `npm test tests/editor.test.ts` *(fails: ReferenceError: canvases is not defined)*


------
https://chatgpt.com/codex/tasks/task_e_68a308548c88832896785cb7cd647776