### PR TITLE
Add layer controls and dynamic initialization

### DIFF
--- a/dist/editor.js
+++ b/dist/editor.js
@@ -25,9 +25,10 @@ export function initEditor() {
     const fillMode = document.getElementById("fillMode");
     const undoBtn = document.getElementById("undo");
     const redoBtn = document.getElementById("redo");
+    const layerSelect = document.getElementById("layerSelect");
+    const imageLoader = document.getElementById("imageLoader");
     const listeners = [];
-    // helper to update undo/redo button states for current editor
-    let editor; // will be set after editors are created
+    let editor;
     const updateHistoryButtons = () => {
         if (undoBtn)
             undoBtn.disabled = !editor?.canUndo;
@@ -45,8 +46,16 @@ export function initEditor() {
             /* skip canvases without 2D context */
         }
     });
-    // active editor defaults to the first successfully created editor
     editor = editors[0];
+    if (layerSelect) {
+        canvases.forEach((_, i) => {
+            const option = document.createElement("option");
+            option.value = String(i);
+            option.textContent = `Layer ${i + 1}`;
+            layerSelect.appendChild(option);
+        });
+        layerSelect.value = "0";
+    }
     // default tool
     editor.setTool(new PencilTool());
     // keyboard shortcuts
@@ -101,7 +110,6 @@ export function initEditor() {
         a.click();
     }, listeners);
     // image loading
-    const imageLoader = document.getElementById("imageLoader");
     listen(imageLoader, "change", (e) => {
         const file = e.target.files?.[0];
         if (!file)
@@ -116,7 +124,6 @@ export function initEditor() {
         };
         reader.readAsDataURL(file);
     }, listeners);
-    // layer opacity sliders: inputs ending with "Opacity" adjust corresponding canvas
     document
         .querySelectorAll('input[id$="Opacity"]')
         .forEach((input) => {
@@ -130,7 +137,6 @@ export function initEditor() {
         }, listeners);
     });
     // layer selection
-    const layerSelect = document.getElementById("layerSelect");
     listen(layerSelect, "change", () => {
         const idx = parseInt(layerSelect.value, 10);
         activateLayer(idx);

--- a/index.html
+++ b/index.html
@@ -24,6 +24,29 @@
       <input type="file" id="imageLoader" accept="image/*" />
       <button id="undo" disabled>Undo</button>
       <button id="redo" disabled>Redo</button>
+      <div id="layerControls" class="group">
+        <select id="layerSelect"></select>
+        <label>
+          Layer 1
+          <input
+            type="range"
+            id="canvasOpacity"
+            min="0"
+            max="100"
+            value="100"
+          />
+        </label>
+        <label>
+          Layer 2
+          <input
+            type="range"
+            id="layer2Opacity"
+            min="0"
+            max="100"
+            value="100"
+          />
+        </label>
+      </div>
       <select id="formatSelect">
         <option value="png">PNG</option>
         <option value="jpeg">JPEG</option>
@@ -31,7 +54,10 @@
       <button id="save">Save</button>
 
     </div>
-    <canvas id="canvas" width="800" height="600"></canvas>
+    <div id="canvasContainer">
+      <canvas id="canvas" width="800" height="600"></canvas>
+      <canvas id="layer2" width="800" height="600"></canvas>
+    </div>
     <script type="module" src="dist/index.js"></script>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -38,4 +38,27 @@ canvas {
   display: block;
 }
 
+#canvasContainer {
+  position: relative;
+  flex: 1;
+}
+
+#canvasContainer canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+#layerControls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#layerControls label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 

--- a/tests/layers.test.ts
+++ b/tests/layers.test.ts
@@ -103,3 +103,72 @@ describe("layer-specific undo/redo", () => {
   });
 });
 
+describe("layer control UI", () => {
+  let handle: EditorHandle;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <canvas id="c1"></canvas>
+      <input id="c1Opacity" value="100" />
+      <canvas id="c2"></canvas>
+      <input id="c2Opacity" value="100" />
+      <select id="layerSelect"></select>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
+    `;
+
+    const rect = {
+      width: 100,
+      height: 100,
+      top: 0,
+      left: 0,
+      bottom: 100,
+      right: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    };
+
+    document
+      .querySelectorAll("canvas")
+      .forEach((canvas) => {
+        const ctx = {
+          clearRect: jest.fn(),
+          putImageData: jest.fn(),
+          getImageData: jest
+            .fn()
+            .mockReturnValue({
+              data: new Uint8ClampedArray(),
+              width: 1,
+              height: 1,
+            } as ImageData),
+          setTransform: jest.fn(),
+          scale: jest.fn(),
+        } as any;
+        (canvas as HTMLCanvasElement).getContext = jest.fn().mockReturnValue(ctx);
+        (canvas as HTMLCanvasElement).getBoundingClientRect = () => rect;
+      });
+
+    handle = initEditor();
+  });
+
+  afterEach(() => handle.destroy());
+
+  it("populates layerSelect and activates chosen layer", () => {
+    const select = document.getElementById("layerSelect") as HTMLSelectElement;
+    expect(select.options.length).toBe(2);
+    select.value = "1";
+    select.dispatchEvent(new Event("change"));
+    expect(handle.editor).toBe(handle.editors[1]);
+  });
+
+  it("updates canvas opacity via slider", () => {
+    const slider = document.getElementById("c2Opacity") as HTMLInputElement;
+    const canvas = document.getElementById("c2") as HTMLCanvasElement;
+    slider.value = "40";
+    slider.dispatchEvent(new Event("input"));
+    expect(canvas.style.opacity).toBe("0.4");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add layer selection dropdown and per-layer opacity sliders to toolbar
- overlay multiple canvases for layer support and style new controls
- initialize layers dynamically and populate selection/opacity logic
- test layer selection and opacity slider behaviour

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars in existing tools, parsing error in TextTool.ts)*
- `npm run build` *(fails: TextTool.ts syntax errors)*
- `npm test` *(fails: LineTool.ts duplicate declarations and other existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a30855b8b08328a985fc9e75a79d05