### PR TITLE
Add layer and opacity controls

### DIFF
--- a/dist/core/Editor.js
+++ b/dist/core/Editor.js
@@ -1,9 +1,10 @@
 export class Editor {
-    constructor(canvas, colorPicker, lineWidth, fillMode, onChange) {
+    constructor(canvas, colorPicker, lineWidth, fillMode, onChange, fontFamily, fontSize) {
         this.undoStack = [];
         this.redoStack = [];
         this.currentTool = null;
         this.handlePointerDown = (e) => {
+            // Capture the pointer once before recording canvas state
             this.canvas.setPointerCapture(e.pointerId);
             this.saveState();
             this.currentTool?.onPointerDown(e, this);
@@ -33,6 +34,8 @@ export class Editor {
         this.lineWidth = lineWidth;
         this.fillMode = fillMode;
         this.onChange = onChange;
+        this.fontFamily = fontFamily ?? null;
+        this.fontSize = fontSize ?? null;
         this.adjustForPixelRatio();
         window.addEventListener("resize", this.handleResize);
         this.canvas.addEventListener("pointerdown", this.handlePointerDown);
@@ -92,6 +95,12 @@ export class Editor {
     }
     get fillStyle() {
         return this.colorPicker.value;
+    }
+    get fontFamilyValue() {
+        return this.fontFamily?.value || "sans-serif";
+    }
+    get fontSizeValue() {
+        return parseInt(this.fontSize?.value ?? "", 10) || 16;
     }
     /**
      * Remove all event listeners registered by the editor.

--- a/dist/core/Shortcuts.js
+++ b/dist/core/Shortcuts.js
@@ -45,11 +45,11 @@ export class Shortcuts {
             case "c":
                 this.editor.setTool(new CircleTool());
                 break;
-            case "t":
-                this.editor.setTool(new TextTool());
-                break;
             case "e":
                 this.editor.setTool(new EraserTool());
+                break;
+            case "t":
+                this.editor.setTool(new TextTool());
                 break;
             case "b":
                 this.editor.setTool(new BucketFillTool());

--- a/dist/tools/BucketFillTool.js
+++ b/dist/tools/BucketFillTool.js
@@ -1,11 +1,15 @@
-import { Tool } from "./Tool.js";
-export class BucketFillTool implements Tool {
+/**
+ * Tool that fills a contiguous region of pixels with the current fill color.
+ * Uses a simple stack-based flood fill on the canvas' pixel data.
+ */
+export class BucketFillTool {
     onPointerDown(e, editor) {
         const ctx = editor.ctx;
         const { width, height } = editor.canvas;
         const image = ctx.getImageData(0, 0, width, height);
         const targetColor = this.getPixel(image, e.offsetX, e.offsetY);
         const fillColor = this.hexToRgb(editor.fillStyle);
+        // if target already the fill color, nothing to do
         if (this.colorsMatch(targetColor, fillColor))
             return;
         const stack = [[e.offsetX | 0, e.offsetY | 0]];

--- a/dist/tools/CircleTool.js
+++ b/dist/tools/CircleTool.js
@@ -10,7 +10,13 @@ export class CircleTool extends DrawingTool {
         this.startX = e.offsetX;
         this.startY = e.offsetY;
         const ctx = editor.ctx;
-        this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
+        this.applyStroke(ctx, editor);
+        if (typeof ctx.getImageData === "function") {
+            this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
+        }
+        else {
+            this.imageData = null;
+        }
     }
     onPointerMove(e, editor) {
         if (e.buttons !== 1 || !this.imageData)

--- a/dist/tools/EyedropperTool.js
+++ b/dist/tools/EyedropperTool.js
@@ -1,0 +1,22 @@
+/**
+ * Tool that samples the canvas color at the clicked position and updates
+ * the editor's color picker to the sampled value.
+ */
+export class EyedropperTool {
+    constructor() {
+        this.cursor = "crosshair";
+    }
+    onPointerDown(e, editor) {
+        const { data } = editor.ctx.getImageData(e.offsetX, e.offsetY, 1, 1);
+        const [r, g, b] = data;
+        const toHex = (v) => v.toString(16).padStart(2, "0");
+        editor.colorPicker.value = `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+    }
+    onPointerMove(e, editor) {
+        if (e.buttons !== 1)
+            return;
+        this.onPointerDown(e, editor);
+    }
+    // No action needed on pointer up
+    onPointerUp(_e, _editor) { }
+}

--- a/dist/tools/LineTool.js
+++ b/dist/tools/LineTool.js
@@ -7,16 +7,11 @@ export class LineTool extends DrawingTool {
         this.imageData = null;
     }
     onPointerDown(e, editor) {
+        const ctx = editor.ctx;
         this.startX = e.offsetX;
         this.startY = e.offsetY;
-        const ctx = editor.ctx;
         this.applyStroke(ctx, editor);
-        if (typeof ctx.getImageData === "function") {
-            this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
-        }
-        else {
-            this.imageData = null;
-        }
+        this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
     }
     onPointerMove(e, editor) {
         if (e.buttons !== 1 || !this.imageData)

--- a/dist/tools/TextTool.js
+++ b/dist/tools/TextTool.js
@@ -12,8 +12,8 @@ export class TextTool {
         textarea.style.left = `${e.offsetX}px`;
         textarea.style.top = `${e.offsetY}px`;
         textarea.style.color = editor.strokeStyle;
-        textarea.style.fontSize = `${editor.lineWidthValue * 4}px`;
-        textarea.style.fontFamily = "sans-serif";
+        textarea.style.fontSize = `${editor.fontSizeValue}px`;
+        textarea.style.fontFamily = editor.fontFamilyValue;
         textarea.style.background = "transparent";
         textarea.style.border = "none";
         textarea.style.outline = "none";
@@ -24,7 +24,7 @@ export class TextTool {
             this.cleanup();
             if (text) {
                 editor.ctx.fillStyle = editor.strokeStyle;
-                editor.ctx.font = `${editor.lineWidthValue * 4}px sans-serif`;
+                editor.ctx.font = `${editor.fontSizeValue}px ${editor.fontFamilyValue}`;
                 editor.ctx.fillText(text, e.offsetX, e.offsetY);
                 editor.saveState();
             }
@@ -47,7 +47,11 @@ export class TextTool {
         textarea.addEventListener("keydown", this.keydownListener);
         this.textarea = textarea;
     }
-    onPointerMove(_e, _editor) { }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    onPointerMove(_e, _editor) {
+        /* no-op */
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     onPointerUp(_e, _editor) {
         if (this.textarea && document.activeElement !== this.textarea) {
             this.cleanup();
@@ -56,9 +60,6 @@ export class TextTool {
     destroy() {
         this.cleanup();
     }
-    /**
-     * Remove textarea overlay and any registered listeners.
-     */
     cleanup() {
         if (!this.textarea)
             return;

--- a/index.html
+++ b/index.html
@@ -30,6 +30,21 @@
       <input type="file" id="imageLoader" accept="image/*" />
       <button id="undo" disabled>Undo</button>
       <button id="redo" disabled>Redo</button>
+
+      <div class="group">
+        <label for="layerSelect">Layer</label>
+        <select id="layerSelect"></select>
+      </div>
+      <div class="group">
+        <label for="layer2Opacity">Layer 2 Opacity</label>
+        <input
+          id="layer2Opacity"
+          type="number"
+          min="0"
+          max="100"
+          value="100"
+        />
+      </div>
       <select id="formatSelect">
         <option value="png">PNG</option>
         <option value="jpeg">JPEG</option>
@@ -37,7 +52,10 @@
       <button id="save">Save</button>
 
     </div>
-    <canvas id="canvas" width="800" height="600"></canvas>
+    <div id="canvasContainer">
+      <canvas id="canvas" width="800" height="600"></canvas>
+      <canvas id="layer2" width="800" height="600"></canvas>
+    </div>
     <script type="module" src="dist/index.js"></script>
   </body>
 </html>

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -17,8 +17,9 @@ function listen<T extends Event>(
   list: Array<() => void>,
 ) {
   if (!el) return;
-  el.addEventListener(type, handler);
-  list.push(() => el.removeEventListener(type, handler));
+  const wrapped = handler as EventListener;
+  el.addEventListener(type, wrapped);
+  list.push(() => el.removeEventListener(type, wrapped));
 }
 
 export interface EditorHandle {
@@ -41,6 +42,17 @@ export function initEditor(): EditorHandle {
   const fillMode = document.getElementById("fillMode") as HTMLInputElement;
   const fontFamily = document.getElementById("fontFamily") as HTMLSelectElement | null;
   const fontSize = document.getElementById("fontSize") as HTMLInputElement | null;
+  const layerSelect = document.getElementById("layerSelect") as HTMLSelectElement | null;
+
+  if (layerSelect) {
+    layerSelect.innerHTML = "";
+    canvases.forEach((c, i) => {
+      const opt = document.createElement("option");
+      opt.value = String(i);
+      opt.textContent = c.id || `Layer ${i + 1}`;
+      layerSelect.appendChild(opt);
+    });
+  }
 
   const undoBtn = document.getElementById("undo") as HTMLButtonElement | null;
   const redoBtn = document.getElementById("redo") as HTMLButtonElement | null;
@@ -211,7 +223,6 @@ export function initEditor(): EditorHandle {
     });
 
   // layer selection
-  const layerSelect = document.getElementById("layerSelect") as HTMLSelectElement | null;
   listen(
     layerSelect,
     "change",

--- a/src/tools/BucketFillTool.ts
+++ b/src/tools/BucketFillTool.ts
@@ -48,7 +48,10 @@ export class BucketFillTool implements Tool {
     data[idx + 3] = 255;
   }
 
-  private colorsMatch(a: [number, number, number, number], b: [number, number, number]): boolean {
+  private colorsMatch(
+    a: [number, number, number, number],
+    b: [number, number, number] | [number, number, number, number],
+  ): boolean {
     return a[0] === b[0] && a[1] === b[1] && a[2] === b[2];
   }
 

--- a/style.css
+++ b/style.css
@@ -33,8 +33,15 @@ body {
   outline: 2px solid #007bff;
 }
 
-canvas {
+#canvasContainer {
   flex: 1;
+  position: relative;
+}
+
+#canvasContainer canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
   display: block;
 }
 

--- a/tests/toolbar.test.ts
+++ b/tests/toolbar.test.ts
@@ -28,7 +28,7 @@ describe("toolbar controls", () => {
 
       <button id="undo"></button>
       <button id="redo"></button>
-      <select id="layerSelect"><option value="0">0</option><option value="1">1</option></select>
+      <select id="layerSelect"></select>
     `;
 
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
@@ -64,6 +64,11 @@ describe("toolbar controls", () => {
 
   afterEach(() => {
     handle.destroy();
+  });
+
+  it("populates layer select", () => {
+    const select = document.getElementById("layerSelect") as HTMLSelectElement;
+    expect(select.options.length).toBe(2);
   });
 
     it("switches tools when buttons are clicked", () => {


### PR DESCRIPTION
## Summary
- add toolbar controls to switch layers and adjust layer opacity
- stack canvases in a container for multi-layer editing
- populate layer selector based on canvases and test its initialization

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a35afa3c808328862b5b8288b14af6