### PR TITLE
Validate required inputs before editor initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ At least one `<canvas>` element with a 2D rendering context must be present in
 the DOM before calling `initEditor()`; initialization will throw an error
 otherwise.
 
+The editor also expects these inputs to exist:
+
+```html
+<input type="color" id="colorPicker" />
+<input type="number" id="lineWidth" />
+<input type="checkbox" id="fillMode" />
+```
+
+If any of these elements are missing, `initEditor()` throws an error such as
+`"Missing #colorPicker input"` and halts initialization.
+
 ## Installing Dependencies
 
 Install the project dependencies using npm:

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -38,12 +38,23 @@ export function initEditor(): EditorHandle {
   const canvases = Array.from(
     document.querySelectorAll<HTMLCanvasElement>("canvas"),
   );
-  const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
-  const lineWidth = document.getElementById("lineWidth") as HTMLInputElement;
-  const fillMode = document.getElementById("fillMode") as HTMLInputElement;
+  const colorPicker =
+    document.getElementById("colorPicker") as HTMLInputElement | null;
+  const lineWidth = document.getElementById("lineWidth") as HTMLInputElement | null;
+  const fillMode = document.getElementById("fillMode") as HTMLInputElement | null;
   const fontFamily = document.getElementById("fontFamily") as HTMLSelectElement | null;
   const fontSize = document.getElementById("fontSize") as HTMLInputElement | null;
   const layerSelect = document.getElementById("layerSelect") as HTMLSelectElement | null;
+
+  if (!colorPicker) {
+    throw new Error("Missing #colorPicker input");
+  }
+  if (!lineWidth) {
+    throw new Error("Missing #lineWidth input");
+  }
+  if (!fillMode) {
+    throw new Error("Missing #fillMode input");
+  }
 
   if (layerSelect) {
     layerSelect.innerHTML = "";


### PR DESCRIPTION
## Summary
- Ensure `initEditor` validates existence of `#colorPicker`, `#lineWidth` and `#fillMode`
- Document required DOM elements for `initEditor`

## Testing
- `npm test` *(fails: TypeError: this.getPixel is not a function)*
- `npm run lint` *(fails: Merge conflict marker encountered)*
- `npm run build` *(fails: Merge conflict marker encountered)*

------
https://chatgpt.com/codex/tasks/task_e_68a368fdd0488328896fe548d9122d2e