### PR TITLE
Prevent default behavior for tool shortcuts

### DIFF
--- a/src/core/Shortcuts.ts
+++ b/src/core/Shortcuts.ts
@@ -45,27 +45,35 @@ export class Shortcuts {
     switch (e.key.toLowerCase()) {
       case "p":
         this.editor.setTool(new PencilTool());
+        e.preventDefault();
         break;
       case "r":
         this.editor.setTool(new RectangleTool());
+        e.preventDefault();
         break;
       case "l":
         this.editor.setTool(new LineTool());
+        e.preventDefault();
         break;
       case "c":
         this.editor.setTool(new CircleTool());
+        e.preventDefault();
         break;
       case "e":
         this.editor.setTool(new EraserTool());
+        e.preventDefault();
         break;
       case "t":
         this.editor.setTool(new TextTool());
+        e.preventDefault();
         break;
       case "b":
         this.editor.setTool(new BucketFillTool());
+        e.preventDefault();
         break;
       case "i":
         this.editor.setTool(new EyedropperTool());
+        e.preventDefault();
         break;
     }
   }

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -3,6 +3,10 @@ import { RectangleTool } from "../src/tools/RectangleTool.js";
 import { PencilTool } from "../src/tools/PencilTool.js";
 import { EraserTool } from "../src/tools/EraserTool.js";
 import { EyedropperTool } from "../src/tools/EyedropperTool.js";
+import { LineTool } from "../src/tools/LineTool.js";
+import { CircleTool } from "../src/tools/CircleTool.js";
+import { TextTool } from "../src/tools/TextTool.js";
+import { BucketFillTool } from "../src/tools/BucketFillTool.js";
 import { Shortcuts } from "../src/core/Shortcuts.js";
 import { Editor } from "../src/core/Editor.js";
 
@@ -49,25 +53,37 @@ describe("keyboard shortcuts", () => {
 
   it("switches tools with letter keys", () => {
     const spy = jest.spyOn(handle.editor, "setTool");
-    document.dispatchEvent(new KeyboardEvent("keydown", { key: "r" }));
-    expect(spy.mock.calls[0][0]).toBeInstanceOf(RectangleTool);
-      document.dispatchEvent(new KeyboardEvent("keydown", { key: "p" }));
-      expect(spy.mock.calls[1][0]).toBeInstanceOf(PencilTool);
-      document.dispatchEvent(new KeyboardEvent("keydown", { key: "e" }));
-      expect(spy.mock.calls[2][0]).toBeInstanceOf(EraserTool);
-      document.dispatchEvent(new KeyboardEvent("keydown", { key: "i" }));
-      expect(spy.mock.calls[3][0]).toBeInstanceOf(EyedropperTool);
+    const cases: [string, any][] = [
+      ["r", RectangleTool],
+      ["p", PencilTool],
+      ["e", EraserTool],
+      ["i", EyedropperTool],
+      ["l", LineTool],
+      ["c", CircleTool],
+      ["t", TextTool],
+      ["b", BucketFillTool],
+    ];
+
+    cases.forEach(([key, ToolClass], index) => {
+      const event = new KeyboardEvent("keydown", { key, cancelable: true });
+      document.dispatchEvent(event);
+      expect(spy.mock.calls[index][0]).toBeInstanceOf(ToolClass);
+      expect(event.defaultPrevented).toBe(true);
     });
+  });
 
   it("performs undo and redo with shortcuts", () => {
     const undo = jest.spyOn(handle.editor, "undo").mockImplementation(() => {});
     const redo = jest.spyOn(handle.editor, "redo").mockImplementation(() => {});
-    document.dispatchEvent(new KeyboardEvent("keydown", { key: "z", ctrlKey: true }));
+    const undoEvent = new KeyboardEvent("keydown", { key: "z", ctrlKey: true, cancelable: true });
+    document.dispatchEvent(undoEvent);
     expect(undo).toHaveBeenCalled();
-    document.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "z", ctrlKey: true, shiftKey: true }),
-    );
+    expect(undoEvent.defaultPrevented).toBe(true);
+
+    const redoEvent = new KeyboardEvent("keydown", { key: "z", ctrlKey: true, shiftKey: true, cancelable: true });
+    document.dispatchEvent(redoEvent);
     expect(redo).toHaveBeenCalled();
+    expect(redoEvent.defaultPrevented).toBe(true);
   });
 
   it("switches active editor when requested", () => {


### PR DESCRIPTION
## Summary
- ensure tool shortcuts call `preventDefault` to block browser scrolling or focus changes
- expand shortcut tests to cover all tools and verify default prevention for undo/redo

## Testing
- `npm run lint` *(fails: Parsing error: Merge conflict marker encountered in BucketFillTool.ts, EyedropperTool.ts)*
- `npm test tests/shortcuts.test.ts`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a368ff66788328b3f34bc67df89977