### PR TITLE
Clean up merge artifacts in tools and toolbar

### DIFF
--- a/dist/tools/BucketFillTool.js
+++ b/dist/tools/BucketFillTool.js
@@ -33,14 +33,8 @@ export class BucketFillTool {
         }
         ctx.putImageData(image, 0, 0);
     }
-    onPointerMove(_e, _editor) {
-        void _e;
-        void _editor;
-    }
-    onPointerUp(_e, _editor) {
-        void _e;
-        void _editor;
-    }
+    onPointerMove() { }
+    onPointerUp() { }
     getPixel(image, x, y) {
         const { width, data } = image;
         const idx = (Math.floor(y) * width + Math.floor(x)) * 4;

--- a/dist/tools/EyedropperTool.js
+++ b/dist/tools/EyedropperTool.js
@@ -22,8 +22,5 @@ export class EyedropperTool {
         this.onPointerDown(e, editor);
     }
     // No action needed on pointer up
-    onPointerUp(_e, _editor) {
-        void _e;
-        void _editor;
-    }
+    onPointerUp() { }
 }

--- a/index.html
+++ b/index.html
@@ -28,7 +28,6 @@
       <button id="text">Text</button>
       <button id="eyedropper">Eyedropper</button>
       <button id="bucket">Bucket</button>
-
       <input type="file" id="imageLoader" accept="image/*" />
       <button id="undo" disabled>Undo</button>
       <button id="redo" disabled>Redo</button>

--- a/src/tools/BucketFillTool.ts
+++ b/src/tools/BucketFillTool.ts
@@ -33,15 +33,9 @@ export class BucketFillTool implements Tool {
     ctx.putImageData(image, 0, 0);
   }
 
-  onPointerMove(_e: PointerEvent, _editor: Editor): void {
-    void _e;
-    void _editor;
-  }
+  onPointerMove(): void {}
 
-  onPointerUp(_e: PointerEvent, _editor: Editor): void {
-    void _e;
-    void _editor;
-  }
+  onPointerUp(): void {}
 
   private getPixel(image: ImageData, x: number, y: number): [number, number, number, number] {
     const { width, data } = image;

--- a/src/tools/EyedropperTool.ts
+++ b/src/tools/EyedropperTool.ts
@@ -25,10 +25,6 @@ export class EyedropperTool implements Tool {
   }
 
   // No action needed on pointer up
-
-  onPointerUp(_e: PointerEvent, _editor: Editor): void {
-    void _e;
-    void _editor;
-  }
+  onPointerUp(): void {}
 }
 


### PR DESCRIPTION
## Summary
- Replace leftover duplicated handlers in BucketFillTool with single no-op implementations
- Remove redundant EyedropperTool pointer-up logic
- Strip stray line from toolbar markup

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a377d2730883289510d2781b4de4ae