### PR TITLE
Use ImageData for canvas resize

### DIFF
--- a/dist/core/Editor.js
+++ b/dist/core/Editor.js
@@ -17,13 +17,10 @@ export class Editor {
             this.canvas.releasePointerCapture(e.pointerId);
         };
         this.handleResize = () => {
-            const data = this.canvas.toDataURL();
+            const image = this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height);
+            this.saveState();
             this.adjustForPixelRatio();
-            const img = new Image();
-            img.src = data;
-            img.onload = () => {
-                this.ctx.drawImage(img, 0, 0, this.canvas.clientWidth, this.canvas.clientHeight);
-            };
+            this.ctx.putImageData(image, 0, 0);
         };
         this.canvas = canvas;
         const ctx = canvas.getContext("2d");

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -73,19 +73,15 @@ export class Editor {
   }
 
   private handleResize = () => {
-    const data = this.canvas.toDataURL();
+    const image = this.ctx.getImageData(
+      0,
+      0,
+      this.canvas.width,
+      this.canvas.height,
+    );
+    this.saveState();
     this.adjustForPixelRatio();
-    const img = new Image();
-    img.src = data;
-    img.onload = () => {
-      this.ctx.drawImage(
-        img,
-        0,
-        0,
-        this.canvas.clientWidth,
-        this.canvas.clientHeight,
-      );
-    };
+    this.ctx.putImageData(image, 0, 0);
   };
 
   saveState() {


### PR DESCRIPTION
## Summary
- Replace canvas resize logic with synchronous ImageData capture and restore
- Preserve undo history during resize by saving state
- Update compiled JavaScript

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a377d37f2c83289da5fdc52445cfe7