### PR TITLE
feat: validate required DOM elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,32 @@ At least one `<canvas>` element with a 2D rendering context must be present in
 the DOM before calling `initEditor()`; initialization will throw an error
 otherwise.
 
-The editor also expects these inputs to exist:
+The editor also expects the following elements to exist:
 
 ```html
 <input type="color" id="colorPicker" />
 <input type="number" id="lineWidth" />
 <input type="checkbox" id="fillMode" />
+
+<button id="pencil"></button>
+<button id="eraser"></button>
+<button id="rectangle"></button>
+<button id="line"></button>
+<button id="circle"></button>
+<button id="text"></button>
+<button id="bucket"></button>
+<button id="eyedropper"></button>
+
+<select id="formatSelect"></select>
+<button id="save"></button>
 ```
 
 If any of these elements are missing, `initEditor()` throws an error such as
-`"Missing #colorPicker input"` and halts initialization.
+`"Missing #bucket button"` and halts initialization.
+
+Call `initEditor()` only after the DOM has been populated with these elements;
+the function returns an {@link EditorHandle} with a `destroy` method for
+cleanup.
 
 ## Installing Dependencies
 

--- a/tests/bucketIntegration.test.ts
+++ b/tests/bucketIntegration.test.ts
@@ -12,7 +12,16 @@ describe("bucket tool integration", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="1" />
       <input id="fillMode" type="checkbox" />
+      <button id="pencil"></button>
+      <button id="eraser"></button>
+      <button id="rectangle"></button>
+      <button id="line"></button>
+      <button id="circle"></button>
+      <button id="text"></button>
       <button id="bucket">Bucket</button>
+      <button id="eyedropper"></button>
+      <select id="formatSelect"><option value="png">PNG</option></select>
+      <button id="save"></button>
     `;
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
     (canvas as any).setPointerCapture = jest.fn();

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -19,6 +19,9 @@ describe("editor toolbar controls", () => {
       <button id="line"></button>
       <button id="circle"></button>
       <button id="text"></button>
+      <button id="bucket"></button>
+      <button id="eyedropper"></button>
+      <select id="formatSelect"><option value="png">PNG</option></select>
       <input id="imageLoader" type="file" />
       <button id="undo"></button>
       <button id="redo"></button>

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -15,7 +15,16 @@ describe("image load and save", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
+      <button id="pencil"></button>
+      <button id="eraser"></button>
+      <button id="rectangle"></button>
+      <button id="line"></button>
+      <button id="circle"></button>
+      <button id="text"></button>
+      <button id="bucket"></button>
+      <button id="eyedropper"></button>
       <input id="imageLoader" type="file" />
+      <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>
     `;
 

--- a/tests/layers.test.ts
+++ b/tests/layers.test.ts
@@ -17,6 +17,15 @@ describe("layer-specific undo/redo", () => {
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
       <button id="pencil"></button>
+      <button id="eraser"></button>
+      <button id="rectangle"></button>
+      <button id="line"></button>
+      <button id="circle"></button>
+      <button id="text"></button>
+      <button id="bucket"></button>
+      <button id="eyedropper"></button>
+      <select id="formatSelect"><option value="png">PNG</option></select>
+      <button id="save"></button>
       <button id="undo"></button>
       <button id="redo"></button>
     `;

--- a/tests/opacity.test.ts
+++ b/tests/opacity.test.ts
@@ -13,6 +13,15 @@ describe("layer opacity", () => {
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
       <input id="layer2Opacity" value="100" />
+      <button id="pencil"></button>
+      <button id="eraser"></button>
+      <button id="rectangle"></button>
+      <button id="line"></button>
+      <button id="circle"></button>
+      <button id="text"></button>
+      <button id="bucket"></button>
+      <button id="eyedropper"></button>
+      <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>
     `;
 

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -7,6 +7,15 @@ describe("save button", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
+      <button id="pencil"></button>
+      <button id="eraser"></button>
+      <button id="rectangle"></button>
+      <button id="line"></button>
+      <button id="circle"></button>
+      <button id="text"></button>
+      <button id="bucket"></button>
+      <button id="eyedropper"></button>
+      <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>
     `;
 
@@ -46,6 +55,14 @@ describe("save button", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
+      <button id="pencil"></button>
+      <button id="eraser"></button>
+      <button id="rectangle"></button>
+      <button id="line"></button>
+      <button id="circle"></button>
+      <button id="text"></button>
+      <button id="bucket"></button>
+      <button id="eyedropper"></button>
       <select id="formatSelect"><option value="png">PNG</option><option value="jpeg" selected>JPEG</option></select>
       <button id="save"></button>
     `;

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -17,6 +17,16 @@ describe("keyboard shortcuts", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
+      <button id="pencil"></button>
+      <button id="eraser"></button>
+      <button id="rectangle"></button>
+      <button id="line"></button>
+      <button id="circle"></button>
+      <button id="text"></button>
+      <button id="bucket"></button>
+      <button id="eyedropper"></button>
+      <select id="formatSelect"><option value="png">PNG</option></select>
+      <button id="save"></button>
     `;
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
     (canvas as any).setPointerCapture = jest.fn();

--- a/tests/toolbar.test.ts
+++ b/tests/toolbar.test.ts
@@ -27,6 +27,10 @@ describe("toolbar controls", () => {
       <button id="circle"></button>
       <button id="text"></button>
       <button id="eyedropper"></button>
+      <button id="bucket"></button>
+
+      <select id="formatSelect"><option value="png">PNG</option></select>
+      <button id="save"></button>
 
       <button id="undo"></button>
       <button id="redo"></button>


### PR DESCRIPTION
## Summary
- validate presence of tool buttons, save controls, and key inputs during `initEditor`
- document required DOM IDs and initialization contract
- update tests for stricter initialization checks

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a377d50ce883289dc65ad9bfecf304