### PR TITLE
Style toolbar buttons consistently

### DIFF
--- a/dist/tools/BucketFillTool.js
+++ b/dist/tools/BucketFillTool.js
@@ -33,8 +33,14 @@ export class BucketFillTool {
         }
         ctx.putImageData(image, 0, 0);
     }
-    onPointerMove() { }
-    onPointerUp() { }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    onPointerMove(_e, _editor) {
+        // intentionally unused
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    onPointerUp(_e, _editor) {
+        // intentionally unused
+    }
     getPixel(image, x, y) {
         const { width, data } = image;
         const idx = (Math.floor(y) * width + Math.floor(x)) * 4;

--- a/dist/tools/EyedropperTool.js
+++ b/dist/tools/EyedropperTool.js
@@ -16,11 +16,12 @@ export class EyedropperTool {
         const toHex = (v) => v.toString(16).padStart(2, "0");
         editor.colorPicker.value = `#${toHex(r)}${toHex(g)}${toHex(b)}`;
     }
-    onPointerMove(e, editor) {
-        if (e.buttons !== 1)
-            return;
-        this.onPointerDown(e, editor);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    onPointerMove(_e, _editor) {
+        // intentionally unused
     }
-    // No action needed on pointer up
-    onPointerUp() { }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    onPointerUp(_e, _editor) {
+        // intentionally unused
+    }
 }

--- a/index.html
+++ b/index.html
@@ -20,17 +20,17 @@
         <input type="checkbox" id="fillMode" />
         Fill
       </label>
-      <button id="pencil">Pencil</button>
-      <button id="eraser">Eraser</button>
-      <button id="rectangle">Rectangle</button>
-      <button id="line">Line</button>
-      <button id="circle">Circle</button>
-      <button id="text">Text</button>
-      <button id="eyedropper">Eyedropper</button>
-      <button id="bucket">Bucket</button>
+      <button id="pencil" class="tool-button">Pencil</button>
+      <button id="eraser" class="tool-button">Eraser</button>
+      <button id="rectangle" class="tool-button">Rectangle</button>
+      <button id="line" class="tool-button">Line</button>
+      <button id="circle" class="tool-button">Circle</button>
+      <button id="text" class="tool-button">Text</button>
+      <button id="eyedropper" class="tool-button">Eyedropper</button>
+      <button id="bucket" class="tool-button">Bucket</button>
       <input type="file" id="imageLoader" accept="image/*" />
-      <button id="undo" disabled>Undo</button>
-      <button id="redo" disabled>Redo</button>
+      <button id="undo" class="tool-button" disabled>Undo</button>
+      <button id="redo" class="tool-button" disabled>Redo</button>
 
       <div class="group">
         <label for="layerSelect">Layer</label>
@@ -40,7 +40,7 @@
         <option value="png">PNG</option>
         <option value="jpeg">JPEG</option>
       </select>
-      <button id="save">Save</button>
+      <button id="save" class="tool-button">Save</button>
 
     </div>
     <div id="canvasContainer">

--- a/src/tools/BucketFillTool.ts
+++ b/src/tools/BucketFillTool.ts
@@ -42,10 +42,6 @@ export class BucketFillTool implements Tool {
   onPointerUp(_e: PointerEvent, _editor: Editor): void {
     // intentionally unused
   }
-=======
-  onPointerMove(): void {}
-
-  onPointerUp(): void {}
 
   private getPixel(image: ImageData, x: number, y: number): [number, number, number, number] {
     const { width, data } = image;

--- a/src/tools/EyedropperTool.ts
+++ b/src/tools/EyedropperTool.ts
@@ -28,8 +28,5 @@ export class EyedropperTool implements Tool {
   onPointerUp(_e: PointerEvent, _editor: Editor): void {
     // intentionally unused
   }
-=======
-  // No action needed on pointer up
-  onPointerUp(): void {}
 }
 

--- a/style.css
+++ b/style.css
@@ -28,6 +28,17 @@ body {
   gap: 8px;
 }
 
+.tool-button {
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  background: #fff;
+  cursor: pointer;
+}
+
+.tool-button:hover {
+  background: #f0f0f0;
+}
+
 .tool-button.active {
   background: #e0e0e0;
   outline: 2px solid #007bff;


### PR DESCRIPTION
## Summary
- add `tool-button` class to all toolbar buttons
- style `.tool-button` with consistent padding, border and hover state
- clean up merge artifacts in bucket fill and eyedropper tools

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3f29785808328967afa86bd61901f