### PR TITLE
docs: document advanced tools and clean lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ A simple Photoshop-like web application built with HTML5 Canvas, CSS, and JavaSc
 - Color picker for stroke selection
 - Adjustable line width
 - Undo/redo support
+- Bucket fill tool for coloring regions
+- Eyedropper tool for sampling colors
+- Image import/export
+- Multi-layer support
 
 
 ### Keyboard Shortcuts
@@ -63,6 +67,9 @@ If any of these elements are missing, `initEditor()` throws an error such as
 Call `initEditor()` only after the DOM has been populated with these elements;
 the function returns an {@link EditorHandle} with a `destroy` method for
 cleanup.
+
+Layer selectors and opacity sliders are generated dynamically, enabling
+switching between layers and adjusting their transparency on the fly.
 
 ## Installing Dependencies
 

--- a/src/tools/BucketFillTool.ts
+++ b/src/tools/BucketFillTool.ts
@@ -42,10 +42,6 @@ export class BucketFillTool implements Tool {
   onPointerUp(_e: PointerEvent, _editor: Editor): void {
     // intentionally unused
   }
-=======
-  onPointerMove(): void {}
-
-  onPointerUp(): void {}
 
   private getPixel(image: ImageData, x: number, y: number): [number, number, number, number] {
     const { width, data } = image;

--- a/src/tools/EyedropperTool.ts
+++ b/src/tools/EyedropperTool.ts
@@ -28,8 +28,4 @@ export class EyedropperTool implements Tool {
   onPointerUp(_e: PointerEvent, _editor: Editor): void {
     // intentionally unused
   }
-=======
-  // No action needed on pointer up
-  onPointerUp(): void {}
 }
-


### PR DESCRIPTION
## Summary
- document bucket fill, eyedropper, image import/export, and multi-layer features
- mention dynamic layer selectors and opacity sliders in README
- resolve merge markers in bucket fill and eyedropper tools to fix lint

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3f2989f388328afd767d455bc33e5