### PR TITLE
Document bucket fill and eyedropper tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ A simple Photoshop-like web application built with HTML5 Canvas, CSS, and JavaSc
 - Rectangle tool for shape creation
 - Circle tool for drawing circles and ellipses
 - Text tool for adding labels
+- Bucket fill tool for painting contiguous areas
+- Eyedropper tool for sampling colors from the canvas
 - Color picker for stroke selection
+- Layer selection and opacity controls
 - Adjustable line width
 - Undo/redo support
 
@@ -37,7 +40,7 @@ At least one `<canvas>` element with a 2D rendering context must be present in
 the DOM before calling `initEditor()`; initialization will throw an error
 otherwise.
 
-The editor also expects the following elements to exist:
+The editor also expects the following toolbar elements to exist:
 
 ```html
 <input type="color" id="colorPicker" />
@@ -53,12 +56,19 @@ The editor also expects the following elements to exist:
 <button id="bucket"></button>
 <button id="eyedropper"></button>
 
+<button id="undo"></button>
+<button id="redo"></button>
+<select id="layerSelect"></select>
+<input type="file" id="imageLoader" />
 <select id="formatSelect"></select>
 <button id="save"></button>
 ```
 
 If any of these elements are missing, `initEditor()` throws an error such as
 `"Missing #bucket button"` and halts initialization.
+
+For additional layers, opacity inputs with IDs like `layer2Opacity` control
+the transparency of each canvas; these are created automatically if absent.
 
 Call `initEditor()` only after the DOM has been populated with these elements;
 the function returns an {@link EditorHandle} with a `destroy` method for

--- a/src/tools/BucketFillTool.ts
+++ b/src/tools/BucketFillTool.ts
@@ -42,10 +42,6 @@ export class BucketFillTool implements Tool {
   onPointerUp(_e: PointerEvent, _editor: Editor): void {
     // intentionally unused
   }
-=======
-  onPointerMove(): void {}
-
-  onPointerUp(): void {}
 
   private getPixel(image: ImageData, x: number, y: number): [number, number, number, number] {
     const { width, data } = image;

--- a/src/tools/EyedropperTool.ts
+++ b/src/tools/EyedropperTool.ts
@@ -28,8 +28,5 @@ export class EyedropperTool implements Tool {
   onPointerUp(_e: PointerEvent, _editor: Editor): void {
     // intentionally unused
   }
-=======
-  // No action needed on pointer up
-  onPointerUp(): void {}
 }
 


### PR DESCRIPTION
## Summary
- Document bucket fill and eyedropper tools plus layer controls in the README
- Expand Usage with all required toolbar elements
- Remove stray merge markers in tool stubs so linting passes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3ae23ec888328bf429212a72dc241