### PR TITLE
Remove redundant text tool saveState and adjust tests

### DIFF
--- a/src/tools/BucketFillTool.ts
+++ b/src/tools/BucketFillTool.ts
@@ -42,10 +42,6 @@ export class BucketFillTool implements Tool {
   onPointerUp(_e: PointerEvent, _editor: Editor): void {
     // intentionally unused
   }
-=======
-  onPointerMove(): void {}
-
-  onPointerUp(): void {}
 
   private getPixel(image: ImageData, x: number, y: number): [number, number, number, number] {
     const { width, data } = image;

--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -31,7 +31,6 @@ export class TextTool implements Tool {
         editor.ctx.fillStyle = editor.strokeStyle;
         editor.ctx.font = `${editor.fontSizeValue}px ${editor.fontFamilyValue}`;
         editor.ctx.fillText(text, e.offsetX, e.offsetY);
-        editor.saveState();
       }
     };
 

--- a/tests/textTool.test.ts
+++ b/tests/textTool.test.ts
@@ -120,7 +120,7 @@ describe("TextTool", () => {
     expect(document.querySelector("textarea")).toBeNull();
   });
 
-  it("supports undo after committing text", () => {
+  it("supports undo with a single step after committing text", () => {
     const tool = new TextTool();
     editor.saveState();
     tool.onPointerDown({ offsetX: 9, offsetY: 10 } as PointerEvent, editor);
@@ -130,6 +130,7 @@ describe("TextTool", () => {
       new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
     );
     expect(ctx.fillText).toHaveBeenCalledWith("undo", 9, 10);
+    // Only one undo should revert the text addition
     editor.undo();
     expect(ctx.clearRect).toHaveBeenCalledTimes(1);
     expect(ctx.putImageData).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- stop saving editor state twice when committing text
- update text tool test to confirm a single undo removes added text
- fix bucket fill tool class definition to restore helper methods

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3ae22efa48328a34d23edd7058cb2