### PR TITLE
Use synchronous canvas resize logic

### DIFF
--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -73,15 +73,14 @@ export class Editor {
   }
 
   private handleResize = () => {
-    const image = this.ctx.getImageData(
+    const data = this.ctx.getImageData(
       0,
       0,
       this.canvas.width,
       this.canvas.height,
     );
-    this.saveState();
     this.adjustForPixelRatio();
-    this.ctx.putImageData(image, 0, 0);
+    this.ctx.putImageData(data, 0, 0);
   };
 
   saveState() {

--- a/src/tools/BucketFillTool.ts
+++ b/src/tools/BucketFillTool.ts
@@ -42,18 +42,23 @@ export class BucketFillTool implements Tool {
   onPointerUp(_e: PointerEvent, _editor: Editor): void {
     // intentionally unused
   }
-=======
-  onPointerMove(): void {}
 
-  onPointerUp(): void {}
-
-  private getPixel(image: ImageData, x: number, y: number): [number, number, number, number] {
+  private getPixel(
+    image: ImageData,
+    x: number,
+    y: number,
+  ): [number, number, number, number] {
     const { width, data } = image;
     const idx = (Math.floor(y) * width + Math.floor(x)) * 4;
     return [data[idx], data[idx + 1], data[idx + 2], data[idx + 3]];
   }
 
-  private setPixel(image: ImageData, x: number, y: number, color: [number, number, number]): void {
+  private setPixel(
+    image: ImageData,
+    x: number,
+    y: number,
+    color: [number, number, number],
+  ): void {
     const { width, data } = image;
     const idx = (Math.floor(y) * width + Math.floor(x)) * 4;
     data[idx] = color[0];

--- a/src/tools/EyedropperTool.ts
+++ b/src/tools/EyedropperTool.ts
@@ -28,8 +28,5 @@ export class EyedropperTool implements Tool {
   onPointerUp(_e: PointerEvent, _editor: Editor): void {
     // intentionally unused
   }
-=======
-  // No action needed on pointer up
-  onPointerUp(): void {}
 }
 


### PR DESCRIPTION
## Summary
- replace Image/toDataURL resize with synchronous getImageData/putImageData
- clean up merge conflict artifacts in BucketFillTool and EyedropperTool

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3ae20d09c8328817e55a6b6342baf