### PR TITLE
Highlight active tool button

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,14 +20,14 @@
         <input type="checkbox" id="fillMode" />
         Fill
       </label>
-      <button id="pencil">Pencil</button>
-      <button id="eraser">Eraser</button>
-      <button id="rectangle">Rectangle</button>
-      <button id="line">Line</button>
-      <button id="circle">Circle</button>
-      <button id="text">Text</button>
-      <button id="eyedropper">Eyedropper</button>
-      <button id="bucket">Bucket</button>
+      <button id="pencil" class="tool-button">Pencil</button>
+      <button id="eraser" class="tool-button">Eraser</button>
+      <button id="rectangle" class="tool-button">Rectangle</button>
+      <button id="line" class="tool-button">Line</button>
+      <button id="circle" class="tool-button">Circle</button>
+      <button id="text" class="tool-button">Text</button>
+      <button id="eyedropper" class="tool-button">Eyedropper</button>
+      <button id="bucket" class="tool-button">Bucket</button>
       <input type="file" id="imageLoader" accept="image/*" />
       <button id="undo" disabled>Undo</button>
       <button id="redo" disabled>Redo</button>

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -59,6 +59,21 @@ export function initEditor(): EditorHandle {
     toolButtons[id] = btn;
   });
 
+  let activeButton: HTMLButtonElement | null = null;
+  const setActiveButton = (btn: HTMLButtonElement | null) => {
+    if (activeButton) activeButton.classList.remove("active");
+    if (btn) btn.classList.add("active");
+    activeButton = btn;
+  };
+  const buttonForTool = (tool: Tool): HTMLButtonElement | null => {
+    for (const [id, ToolCtor] of Object.entries(toolConstructors)) {
+      if (tool instanceof ToolCtor) {
+        return toolButtons[id];
+      }
+    }
+    return null;
+  };
+
   const colorPicker =
     document.getElementById("colorPicker") as HTMLInputElement | null;
   const lineWidth = document.getElementById("lineWidth") as HTMLInputElement | null;
@@ -160,6 +175,14 @@ export function initEditor(): EditorHandle {
       "initEditor() requires at least one <canvas> element with a 2D context",
     );
   }
+
+  editors.forEach((e) => {
+    const original = e.setTool.bind(e);
+    e.setTool = (tool: Tool) => {
+      original(tool);
+      setActiveButton(buttonForTool(tool));
+    };
+  });
 
   // active editor defaults to the first successfully created editor
   editor = editors[0];

--- a/src/tools/BucketFillTool.ts
+++ b/src/tools/BucketFillTool.ts
@@ -42,11 +42,6 @@ export class BucketFillTool implements Tool {
   onPointerUp(_e: PointerEvent, _editor: Editor): void {
     // intentionally unused
   }
-=======
-  onPointerMove(): void {}
-
-  onPointerUp(): void {}
-
   private getPixel(image: ImageData, x: number, y: number): [number, number, number, number] {
     const { width, data } = image;
     const idx = (Math.floor(y) * width + Math.floor(x)) * 4;

--- a/src/tools/EyedropperTool.ts
+++ b/src/tools/EyedropperTool.ts
@@ -28,8 +28,5 @@ export class EyedropperTool implements Tool {
   onPointerUp(_e: PointerEvent, _editor: Editor): void {
     // intentionally unused
   }
-=======
-  // No action needed on pointer up
-  onPointerUp(): void {}
 }
 


### PR DESCRIPTION
## Summary
- style: mark tool buttons with `tool-button` for unified styling
- feat: track active tool button and toggle `.active` class on tool change
- chore: resolve merge artifacts in BucketFillTool and EyedropperTool

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `node --input-type=module <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68a3ae221fa083288a708572a601ee7a