### PR TITLE
Prevent default actions for tool shortcuts

### DIFF
--- a/src/core/Shortcuts.ts
+++ b/src/core/Shortcuts.ts
@@ -44,36 +44,36 @@ export class Shortcuts {
 
     switch (e.key.toLowerCase()) {
       case "p":
-        this.editor.setTool(new PencilTool());
         e.preventDefault();
+        this.editor.setTool(new PencilTool());
         break;
       case "r":
-        this.editor.setTool(new RectangleTool());
         e.preventDefault();
+        this.editor.setTool(new RectangleTool());
         break;
       case "l":
-        this.editor.setTool(new LineTool());
         e.preventDefault();
+        this.editor.setTool(new LineTool());
         break;
       case "c":
-        this.editor.setTool(new CircleTool());
         e.preventDefault();
+        this.editor.setTool(new CircleTool());
         break;
       case "e":
-        this.editor.setTool(new EraserTool());
         e.preventDefault();
+        this.editor.setTool(new EraserTool());
         break;
       case "t":
-        this.editor.setTool(new TextTool());
         e.preventDefault();
+        this.editor.setTool(new TextTool());
         break;
       case "b":
-        this.editor.setTool(new BucketFillTool());
         e.preventDefault();
+        this.editor.setTool(new BucketFillTool());
         break;
       case "i":
-        this.editor.setTool(new EyedropperTool());
         e.preventDefault();
+        this.editor.setTool(new EyedropperTool());
         break;
     }
   }

--- a/src/tools/BucketFillTool.ts
+++ b/src/tools/BucketFillTool.ts
@@ -42,11 +42,6 @@ export class BucketFillTool implements Tool {
   onPointerUp(_e: PointerEvent, _editor: Editor): void {
     // intentionally unused
   }
-=======
-  onPointerMove(): void {}
-
-  onPointerUp(): void {}
-
   private getPixel(image: ImageData, x: number, y: number): [number, number, number, number] {
     const { width, data } = image;
     const idx = (Math.floor(y) * width + Math.floor(x)) * 4;

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -76,8 +76,10 @@ describe("keyboard shortcuts", () => {
 
     cases.forEach(([key, ToolClass], index) => {
       const event = new KeyboardEvent("keydown", { key, cancelable: true });
+      const prevent = jest.spyOn(event, "preventDefault");
       document.dispatchEvent(event);
       expect(spy.mock.calls[index][0]).toBeInstanceOf(ToolClass);
+      expect(prevent).toHaveBeenCalled();
       expect(event.defaultPrevented).toBe(true);
     });
   });


### PR DESCRIPTION
## Summary
- Move `e.preventDefault()` ahead of tool switching for all non-modifier shortcut keys
- Test each shortcut key ensures `preventDefault` is invoked
- Clean up stray code in `BucketFillTool` to restore helper methods

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3ae2193888328b78a5367f05e6e20