### PR TITLE
Refactor editor initialization and resolve merge remnants

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -51,27 +51,15 @@ export function initEditor(): EditorHandle {
   };
 
   const toolButtons: Record<string, HTMLButtonElement> = {};
-  const constructorToId = new Map<new () => Tool, string>();
-  Object.entries(toolConstructors).forEach(([id, Ctor]) => {
+  Object.keys(toolConstructors).forEach((id) => {
     const btn = document.getElementById(id) as HTMLButtonElement | null;
     if (!btn) {
       throw new Error(`Missing #${id} button`);
     }
     toolButtons[id] = btn;
-    constructorToId.set(Ctor, id);
   });
 
   let activeButton: HTMLButtonElement | null = null;
-  function setActiveButton(tool: Tool) {
-    const id = constructorToId.get(tool.constructor as new () => Tool);
-    if (!id) return;
-    const btn = toolButtons[id];
-    if (!btn) return;
-    activeButton?.classList.remove("active");
-    btn.classList.add("active");
-    activeButton = btn;
-  }
-=======
   const setActiveButton = (btn: HTMLButtonElement | null) => {
     if (activeButton) activeButton.classList.remove("active");
     if (btn) btn.classList.add("active");
@@ -178,7 +166,7 @@ export function initEditor(): EditorHandle {
       const originalSetTool = e.setTool.bind(e);
       e.setTool = (tool: Tool) => {
         originalSetTool(tool);
-        setActiveButton(tool);
+        setActiveButton(buttonForTool(tool));
       };
       editors.push(e);
     } catch {
@@ -191,14 +179,6 @@ export function initEditor(): EditorHandle {
       "initEditor() requires at least one <canvas> element with a 2D context",
     );
   }
-
-  editors.forEach((e) => {
-    const original = e.setTool.bind(e);
-    e.setTool = (tool: Tool) => {
-      original(tool);
-      setActiveButton(buttonForTool(tool));
-    };
-  });
 
   // active editor defaults to the first successfully created editor
   editor = editors[0];

--- a/src/tools/BucketFillTool.ts
+++ b/src/tools/BucketFillTool.ts
@@ -33,37 +33,21 @@ export class BucketFillTool implements Tool {
     ctx.putImageData(image, 0, 0);
   }
 
-  onPointerMove(): void {}
-
-  onPointerUp(): void {}
-=======
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onPointerMove(_e: PointerEvent, _editor: Editor): void {
     // intentionally unused
   }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    onPointerUp(_e: PointerEvent, _editor: Editor): void {
-      // intentionally unused
-    }
-=======
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onPointerUp(_e: PointerEvent, _editor: Editor): void {
     // intentionally unused
   }
-=======
-=======
 
   private getPixel(
     image: ImageData,
     x: number,
     y: number,
   ): [number, number, number, number] {
-=======
-
-
-
-    private getPixel(image: ImageData, x: number, y: number): [number, number, number, number] {
     const { width, data } = image;
     const idx = (Math.floor(y) * width + Math.floor(x)) * 4;
     return [data[idx], data[idx + 1], data[idx + 2], data[idx + 3]];
@@ -99,3 +83,4 @@ export class BucketFillTool implements Tool {
     return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
   }
 }
+

--- a/src/tools/EyedropperTool.ts
+++ b/src/tools/EyedropperTool.ts
@@ -24,18 +24,9 @@ export class EyedropperTool implements Tool {
     this.onPointerDown(e, editor);
   }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    onPointerUp(_e: PointerEvent, _editor: Editor): void {
-      // intentionally unused
-    }
-  }
-
-=======
-  // No action needed on pointer up
-  onPointerUp(): void {}
-=======
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onPointerUp(_e: PointerEvent, _editor: Editor): void {
     // intentionally unused
   }
 }
+

--- a/style.css
+++ b/style.css
@@ -61,14 +61,8 @@ body {
   left: 0;
   display: block;
   background: transparent;
-=======
-  background: #fff;
-  border: 1px solid #ccc;
-  box-shadow: 0 0 4px rgba(0,0,0,.1);
-=======
   width: 100%;
   height: 100%;
   box-sizing: border-box;
 }
-
 


### PR DESCRIPTION
## Summary
- simplify active-tool tracking with a single `setActiveButton` helper and `buttonForTool` lookup
- ensure tool activation is updated once during editor creation
- clean up merge artifacts in tools and stylesheet

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4c0e776b08328b499cd812f30de52