### PR TITLE
chore: resolve EyedropperTool onPointerUp conflict

### DIFF
--- a/src/tools/EyedropperTool.ts
+++ b/src/tools/EyedropperTool.ts
@@ -24,16 +24,6 @@ export class EyedropperTool implements Tool {
     this.onPointerDown(e, editor);
   }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    onPointerUp(_e: PointerEvent, _editor: Editor): void {
-      // intentionally unused
-    }
-  }
-
-=======
-  // No action needed on pointer up
-  onPointerUp(): void {}
-=======
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onPointerUp(_e: PointerEvent, _editor: Editor): void {
     // intentionally unused


### PR DESCRIPTION
## Summary
- remove leftover merge markers in EyedropperTool
- keep a single `onPointerUp` stub to satisfy eslint

## Testing
- `npm run build` *(fails: Merge conflict marker encountered in editor.ts and BucketFillTool.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c0e8be748328ad0f471c59f3218e