### PR TITLE
Use SVG icons for toolbar buttons

### DIFF
--- a/icons/circle.svg
+++ b/icons/circle.svg
@@ -1,0 +1,15 @@
+<!-- @license lucide-static v0.541.0 - ISC -->
+<svg
+  class="lucide lucide-circle"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+</svg>

--- a/icons/eraser.svg
+++ b/icons/eraser.svg
@@ -1,0 +1,16 @@
+<!-- @license lucide-static v0.541.0 - ISC -->
+<svg
+  class="lucide lucide-eraser"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21 21H8a2 2 0 0 1-1.42-.587l-3.994-3.999a2 2 0 0 1 0-2.828l10-10a2 2 0 0 1 2.829 0l5.999 6a2 2 0 0 1 0 2.828L12.834 21" />
+  <path d="m5.082 11.09 8.828 8.828" />
+</svg>

--- a/icons/paint-bucket.svg
+++ b/icons/paint-bucket.svg
@@ -1,0 +1,18 @@
+<!-- @license lucide-static v0.541.0 - ISC -->
+<svg
+  class="lucide lucide-paint-bucket"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m19 11-8-8-8.6 8.6a2 2 0 0 0 0 2.8l5.2 5.2c.8.8 2 .8 2.8 0L19 11Z" />
+  <path d="m5 2 5 5" />
+  <path d="M2 13h15" />
+  <path d="M22 20a2 2 0 1 1-4 0c0-1.6 1.7-2.4 2-4 .3 1.6 2 2.4 2 4Z" />
+</svg>

--- a/icons/pencil.svg
+++ b/icons/pencil.svg
@@ -1,0 +1,16 @@
+<!-- @license lucide-static v0.541.0 - ISC -->
+<svg
+  class="lucide lucide-pencil"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z" />
+  <path d="m15 5 4 4" />
+</svg>

--- a/icons/pipette.svg
+++ b/icons/pipette.svg
@@ -1,0 +1,17 @@
+<!-- @license lucide-static v0.541.0 - ISC -->
+<svg
+  class="lucide lucide-pipette"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m12 9-8.414 8.414A2 2 0 0 0 3 18.828v1.344a2 2 0 0 1-.586 1.414A2 2 0 0 1 3.828 21h1.344a2 2 0 0 0 1.414-.586L15 12" />
+  <path d="m18 9 .4.4a1 1 0 1 1-3 3l-3.8-3.8a1 1 0 1 1 3-3l.4.4 3.4-3.4a1 1 0 1 1 3 3z" />
+  <path d="m2 22 .414-.414" />
+</svg>

--- a/icons/rectangle-horizontal.svg
+++ b/icons/rectangle-horizontal.svg
@@ -1,0 +1,15 @@
+<!-- @license lucide-static v0.541.0 - ISC -->
+<svg
+  class="lucide lucide-rectangle-horizontal"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="20" height="12" x="2" y="6" rx="2" />
+</svg>

--- a/icons/redo.svg
+++ b/icons/redo.svg
@@ -1,0 +1,16 @@
+<!-- @license lucide-static v0.541.0 - ISC -->
+<svg
+  class="lucide lucide-redo"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21 7v6h-6" />
+  <path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3l3 2.7" />
+</svg>

--- a/icons/save.svg
+++ b/icons/save.svg
@@ -1,0 +1,17 @@
+<!-- @license lucide-static v0.541.0 - ISC -->
+<svg
+  class="lucide lucide-save"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" />
+  <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" />
+  <path d="M7 3v4a1 1 0 0 0 1 1h7" />
+</svg>

--- a/icons/slash.svg
+++ b/icons/slash.svg
@@ -1,0 +1,15 @@
+<!-- @license lucide-static v0.541.0 - ISC -->
+<svg
+  class="lucide lucide-slash"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M22 2 2 22" />
+</svg>

--- a/icons/type.svg
+++ b/icons/type.svg
@@ -1,0 +1,17 @@
+<!-- @license lucide-static v0.541.0 - ISC -->
+<svg
+  class="lucide lucide-type"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 4v16" />
+  <path d="M4 7V5a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v2" />
+  <path d="M9 20h6" />
+</svg>

--- a/icons/undo.svg
+++ b/icons/undo.svg
@@ -1,0 +1,16 @@
+<!-- @license lucide-static v0.541.0 - ISC -->
+<svg
+  class="lucide lucide-undo"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 7v6h6" />
+  <path d="M21 17a9 9 0 0 0-9-9 9 9 0 0 0-6 2.3L3 13" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -20,17 +20,37 @@
         <input type="checkbox" id="fillMode" />
         Fill
       </label>
-      <button id="pencil" class="tool-button">Pencil</button>
-      <button id="eraser" class="tool-button">Eraser</button>
-      <button id="rectangle" class="tool-button">Rectangle</button>
-      <button id="line" class="tool-button">Line</button>
-      <button id="circle" class="tool-button">Circle</button>
-      <button id="text" class="tool-button">Text</button>
-      <button id="eyedropper" class="tool-button">Eyedropper</button>
-      <button id="bucket" class="tool-button">Bucket</button>
+      <button id="pencil" class="tool-button" title="Pencil">
+        <img src="icons/pencil.svg" alt="Pencil" />
+      </button>
+      <button id="eraser" class="tool-button" title="Eraser">
+        <img src="icons/eraser.svg" alt="Eraser" />
+      </button>
+      <button id="rectangle" class="tool-button" title="Rectangle">
+        <img src="icons/rectangle-horizontal.svg" alt="Rectangle" />
+      </button>
+      <button id="line" class="tool-button" title="Line">
+        <img src="icons/slash.svg" alt="Line" />
+      </button>
+      <button id="circle" class="tool-button" title="Circle">
+        <img src="icons/circle.svg" alt="Circle" />
+      </button>
+      <button id="text" class="tool-button" title="Text">
+        <img src="icons/type.svg" alt="Text" />
+      </button>
+      <button id="eyedropper" class="tool-button" title="Eyedropper">
+        <img src="icons/pipette.svg" alt="Eyedropper" />
+      </button>
+      <button id="bucket" class="tool-button" title="Bucket">
+        <img src="icons/paint-bucket.svg" alt="Bucket" />
+      </button>
       <input type="file" id="imageLoader" accept="image/*" />
-      <button id="undo" class="tool-button" disabled>Undo</button>
-      <button id="redo" class="tool-button" disabled>Redo</button>
+      <button id="undo" class="tool-button" title="Undo" disabled>
+        <img src="icons/undo.svg" alt="Undo" />
+      </button>
+      <button id="redo" class="tool-button" title="Redo" disabled>
+        <img src="icons/redo.svg" alt="Redo" />
+      </button>
 
       <div class="group">
         <label for="layerSelect">Layer</label>
@@ -40,7 +60,9 @@
         <option value="png">PNG</option>
         <option value="jpeg">JPEG</option>
       </select>
-      <button id="save" class="tool-button">Save</button>
+      <button id="save" class="tool-button" title="Save">
+        <img src="icons/save.svg" alt="Save" />
+      </button>
 
     </div>
     <div id="canvasContainer">

--- a/style.css
+++ b/style.css
@@ -29,10 +29,21 @@ body {
 }
 
 .tool-button {
-  padding: 4px 8px;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
   border: 1px solid #ccc;
   background: #fff;
   cursor: pointer;
+}
+
+.tool-button img {
+  width: 20px;
+  height: 20px;
+  pointer-events: none;
 }
 
 .tool-button:hover {
@@ -41,7 +52,10 @@ body {
 
 .tool-button.active {
   background: #007bff;
-  color: #fff;
+}
+
+.tool-button.active img {
+  filter: brightness(0) invert(1);
 }
 
 #canvasContainer {


### PR DESCRIPTION
## Summary
- replace tool button text with SVG icons and tooltips
- size and align icons in tool buttons, styling active state
- add Lucide SVG assets for each tool

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab4510ad908328af69332c43b67548