### PR TITLE
Add line width slider with stroke preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,8 @@
   <body>
     <div id="toolbar">
       <input type="color" id="colorPicker" />
-      <input type="number" id="lineWidth" min="1" value="1" />
+      <input type="range" id="lineWidth" min="1" max="100" value="1" />
+      <canvas id="lineWidthPreview" width="40" height="20"></canvas>
       <select id="fontFamily">
         <option value="sans-serif">Sans-Serif</option>
         <option value="serif">Serif</option>

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -79,6 +79,8 @@ export function initEditor(): EditorHandle {
   const colorPicker =
     document.getElementById("colorPicker") as HTMLInputElement | null;
   const lineWidth = document.getElementById("lineWidth") as HTMLInputElement | null;
+  const lineWidthPreview =
+    document.getElementById("lineWidthPreview") as HTMLCanvasElement | null;
   const fillMode = document.getElementById("fillMode") as HTMLInputElement | null;
   const fontFamily = document.getElementById("fontFamily") as HTMLSelectElement | null;
   const fontSize = document.getElementById("fontSize") as HTMLInputElement | null;
@@ -143,6 +145,27 @@ export function initEditor(): EditorHandle {
   const undoBtn = document.getElementById("undo") as HTMLButtonElement | null;
   const redoBtn = document.getElementById("redo") as HTMLButtonElement | null;
   const listeners: Array<() => void> = [];
+
+  const updateLineWidthPreview = () => {
+    if (!lineWidthPreview) return;
+    const ctx = lineWidthPreview.getContext("2d");
+    if (!ctx) return;
+    const w = lineWidthPreview.width;
+    const h = lineWidthPreview.height;
+    ctx.clearRect(0, 0, w, h);
+    ctx.strokeStyle = colorPicker.value;
+    ctx.lineWidth = parseInt(lineWidth.value, 10) || 1;
+    ctx.lineCap = "round";
+    ctx.beginPath();
+    ctx.moveTo(5, h / 2);
+    ctx.lineTo(w - 5, h / 2);
+    ctx.stroke();
+  };
+
+  updateLineWidthPreview();
+
+  listen(lineWidth, "input", updateLineWidthPreview, listeners);
+  listen(colorPicker, "input", updateLineWidthPreview, listeners);
 
   let editor: Editor; // set after editors created
 

--- a/style.css
+++ b/style.css
@@ -66,4 +66,8 @@ body {
   box-sizing: border-box;
 }
 
+#lineWidthPreview {
+  border: 1px solid #ccc;
+}
+
 


### PR DESCRIPTION
## Summary
- Replace numeric line width input with range slider and add preview canvas.
- Render live line width preview and update on color or width changes.

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab451146c883288aeecd93ac29750b