### PR TITLE
Add zoom and pan controls to canvas editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A simple Photoshop-like web application built with HTML5 Canvas, CSS, and JavaSc
 - Eyedropper tool for sampling colors
 - Image import/export
 - Multi-layer support
+- Zoom and pan controls
 
 
 ### Keyboard Shortcuts
@@ -33,13 +34,18 @@ A simple Photoshop-like web application built with HTML5 Canvas, CSS, and JavaSc
 - `E`: Eraser
 - `Ctrl+Z`: Undo
 - `Ctrl+Shift+Z`: Redo
+- `Ctrl++`: Zoom in
+- `Ctrl+-`: Zoom out
+- `Ctrl+0`: Reset view
+- Arrow keys: Pan canvas
 
 
 ## Usage
 
 Draw on the canvas using a mouse, a single finger, or a stylus. Pointer events
-enable touch input, but multi-touch gestures such as pinch-to-zoom or panning
-are handled by the browser and are not yet supported by the app.
+enable touch input. Zoom using the mouse wheel or `Ctrl` `+`/`-` and pan with
+the middle mouse button or arrow keys. Multi-touch gestures such as
+pinch-to-zoom are handled by the browser and are not yet supported by the app.
 At least one `<canvas>` element with a 2D rendering context must be present in
 the DOM before calling `initEditor()`; initialization will throw an error
 otherwise.

--- a/index.html
+++ b/index.html
@@ -32,6 +32,10 @@
       <button id="undo" class="tool-button" disabled>Undo</button>
       <button id="redo" class="tool-button" disabled>Redo</button>
 
+      <button id="zoomIn" class="tool-button">Zoom In</button>
+      <button id="zoomOut" class="tool-button">Zoom Out</button>
+      <button id="resetView" class="tool-button">Reset View</button>
+
       <div class="group">
         <label for="layerSelect">Layer</label>
         <select id="layerSelect"></select>

--- a/src/core/Shortcuts.ts
+++ b/src/core/Shortcuts.ts
@@ -16,9 +16,20 @@ import { EyedropperTool } from "../tools/EyedropperTool.js";
 export class Shortcuts {
   private readonly handler: (e: KeyboardEvent) => void;
   private editor: Editor;
+  private onZoom: (factor: number) => void;
+  private onPan: (dx: number, dy: number) => void;
+  private onReset: () => void;
 
-  constructor(editor: Editor) {
+  constructor(
+    editor: Editor,
+    onZoom?: (factor: number) => void,
+    onPan?: (dx: number, dy: number) => void,
+    onReset?: () => void,
+  ) {
     this.editor = editor;
+    this.onZoom = onZoom ?? ((f) => this.editor.zoomBy(f));
+    this.onPan = onPan ?? ((dx, dy) => this.editor.pan(dx, dy));
+    this.onReset = onReset ?? (() => this.editor.resetView());
     this.handler = (e: KeyboardEvent) => this.onKeyDown(e);
     document.addEventListener("keydown", this.handler);
   }
@@ -31,15 +42,49 @@ export class Shortcuts {
   private onKeyDown(e: KeyboardEvent) {
 
     if (e.ctrlKey || e.metaKey) {
-      if (e.key.toLowerCase() === "z") {
-        if (e.shiftKey) {
-          this.editor.redo();
-        } else {
-          this.editor.undo();
-        }
-        e.preventDefault();
+      switch (e.key) {
+        case "z":
+        case "Z":
+          if (e.shiftKey) {
+            this.editor.redo();
+          } else {
+            this.editor.undo();
+          }
+          e.preventDefault();
+          return;
+        case "=":
+        case "+":
+          this.onZoom(1.1);
+          e.preventDefault();
+          return;
+        case "-":
+          this.onZoom(0.9);
+          e.preventDefault();
+          return;
+        case "0":
+          this.onReset();
+          e.preventDefault();
+          return;
       }
-      return;
+    }
+
+    switch (e.key) {
+      case "ArrowUp":
+        this.onPan(0, -10);
+        e.preventDefault();
+        return;
+      case "ArrowDown":
+        this.onPan(0, 10);
+        e.preventDefault();
+        return;
+      case "ArrowLeft":
+        this.onPan(-10, 0);
+        e.preventDefault();
+        return;
+      case "ArrowRight":
+        this.onPan(10, 0);
+        e.preventDefault();
+        return;
     }
 
     switch (e.key.toLowerCase()) {


### PR DESCRIPTION
## Summary
- track zoom level and offsets in the editor and transform pointer coordinates
- add zoom buttons, mouse wheel zooming, and middle-mouse panning
- document new zoom/pan keyboard shortcuts and controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab4511c4b48328a83daa74f462ab00