### PR TITLE
feat: add dynamic layer management

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,8 @@
       <div class="group">
         <label for="layerSelect">Layer</label>
         <select id="layerSelect"></select>
+        <button id="addLayer" class="tool-button">Add Layer</button>
+        <button id="deleteLayer" class="tool-button">Delete Layer</button>
       </div>
       <select id="formatSelect">
         <option value="png">PNG</option>
@@ -45,7 +47,6 @@
     </div>
     <div id="canvasContainer">
       <canvas id="canvas" width="800" height="600"></canvas>
-      <canvas id="layer2" width="800" height="600"></canvas>
     </div>
     <script type="module" src="dist/index.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- add Add/Delete Layer controls and single canvas base in UI
- implement dynamic layer creation, deletion, reordering, and renaming
- test layer management features including undo/redo per layer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab451261548328b8746be5b7b0302c