### PR TITLE
Add viewport transform with zoom and pan

### DIFF
--- a/src/tools/BucketFillTool.ts
+++ b/src/tools/BucketFillTool.ts
@@ -11,15 +11,16 @@ export class BucketFillTool implements Tool {
     const image = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
     const { width, height } = image;
     const dpr = window.devicePixelRatio || 1;
-    const x = Math.max(0, Math.min(width - 1, Math.floor(e.offsetX * dpr)));
-    const y = Math.max(0, Math.min(height - 1, Math.floor(e.offsetY * dpr)));
-    const targetColor = this.getPixel(image, x, y);
+    const { x, y } = editor.toCanvasCoords(e);
+    const px = Math.max(0, Math.min(width - 1, Math.floor(x * dpr)));
+    const py = Math.max(0, Math.min(height - 1, Math.floor(y * dpr)));
+    const targetColor = this.getPixel(image, px, py);
     const fillColor = this.hexToRgb(editor.fillStyle);
 
     // if target already the fill color, nothing to do
     if (this.colorsMatch(targetColor, fillColor)) return;
 
-    const stack: Array<[number, number]> = [[x, y]];
+    const stack: Array<[number, number]> = [[px, py]];
     while (stack.length) {
       const [px, py] = stack.pop()!;
       const current = this.getPixel(image, px, py);

--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -7,8 +7,9 @@ export class CircleTool extends DrawingTool {
   private imageData: ImageData | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
-    this.startX = e.offsetX;
-    this.startY = e.offsetY;
+    const { x, y } = editor.toCanvasCoords(e);
+    this.startX = x;
+    this.startY = y;
     const ctx = editor.ctx;
     this.applyStroke(ctx, editor);
     if (typeof ctx.getImageData === "function") {
@@ -23,9 +24,9 @@ export class CircleTool extends DrawingTool {
     const ctx = editor.ctx;
     ctx.putImageData(this.imageData, 0, 0);
     this.applyStroke(ctx, editor);
-
-    const dx = e.offsetX - this.startX;
-    const dy = e.offsetY - this.startY;
+    const { x, y } = editor.toCanvasCoords(e);
+    const dx = x - this.startX;
+    const dy = y - this.startY;
     const radius = Math.sqrt(dx * dx + dy * dy);
     ctx.beginPath();
     ctx.arc(this.startX, this.startY, radius, 0, Math.PI * 2);
@@ -42,8 +43,9 @@ export class CircleTool extends DrawingTool {
       ctx.putImageData(this.imageData, 0, 0);
     }
     this.applyStroke(ctx, editor);
-    const dx = e.offsetX - this.startX;
-    const dy = e.offsetY - this.startY;
+    const { x, y } = editor.toCanvasCoords(e);
+    const dx = x - this.startX;
+    const dy = y - this.startY;
     const radius = Math.sqrt(dx * dx + dy * dy);
     ctx.beginPath();
     ctx.arc(this.startX, this.startY, radius, 0, Math.PI * 2);

--- a/src/tools/EraserTool.ts
+++ b/src/tools/EraserTool.ts
@@ -6,11 +6,12 @@ export class EraserTool extends DrawingTool {
     const ctx = editor.ctx;
     ctx.globalCompositeOperation = "destination-out";
     this.applyStroke(ctx, editor);
+    const { x, y } = editor.toCanvasCoords(e);
     ctx.beginPath();
-    ctx.moveTo(e.offsetX, e.offsetY);
+    ctx.moveTo(x, y);
     ctx.clearRect(
-      e.offsetX - editor.lineWidthValue / 2,
-      e.offsetY - editor.lineWidthValue / 2,
+      x - editor.lineWidthValue / 2,
+      y - editor.lineWidthValue / 2,
       editor.lineWidthValue,
       editor.lineWidthValue,
     );
@@ -20,11 +21,12 @@ export class EraserTool extends DrawingTool {
     if (e.buttons !== 1) return;
     const ctx = editor.ctx;
     this.applyStroke(ctx, editor);
-    ctx.lineTo(e.offsetX, e.offsetY);
+    const { x, y } = editor.toCanvasCoords(e);
+    ctx.lineTo(x, y);
     ctx.stroke();
     ctx.clearRect(
-      e.offsetX - editor.lineWidthValue / 2,
-      e.offsetY - editor.lineWidthValue / 2,
+      x - editor.lineWidthValue / 2,
+      y - editor.lineWidthValue / 2,
       editor.lineWidthValue,
       editor.lineWidthValue,
     );

--- a/src/tools/EyedropperTool.ts
+++ b/src/tools/EyedropperTool.ts
@@ -11,9 +11,10 @@ export class EyedropperTool implements Tool {
   onPointerDown(e: PointerEvent, editor: Editor): void {
     const { width, height } = editor.canvas;
     const dpr = window.devicePixelRatio || 1;
-    const x = Math.max(0, Math.min(width - 1, Math.floor(e.offsetX * dpr)));
-    const y = Math.max(0, Math.min(height - 1, Math.floor(e.offsetY * dpr)));
-    const { data } = editor.ctx.getImageData(x, y, 1, 1);
+    const { x, y } = editor.toCanvasCoords(e);
+    const px = Math.max(0, Math.min(width - 1, Math.floor(x * dpr)));
+    const py = Math.max(0, Math.min(height - 1, Math.floor(y * dpr)));
+    const { data } = editor.ctx.getImageData(px, py, 1, 1);
     const [r, g, b] = data;
     const toHex = (v: number) => v.toString(16).padStart(2, "0");
     editor.colorPicker.value = `#${toHex(r)}${toHex(g)}${toHex(b)}`;

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -8,16 +8,17 @@ export class LineTool extends DrawingTool {
 
     onPointerDown(e: PointerEvent, editor: Editor): void {
       const ctx = editor.ctx;
-      this.startX = e.offsetX;
-      this.startY = e.offsetY;
+      const { x, y } = editor.toCanvasCoords(e);
+      this.startX = x;
+      this.startY = y;
       this.applyStroke(ctx, editor);
-    this.imageData = ctx.getImageData(
-      0,
-      0,
-      editor.canvas.width,
-      editor.canvas.height,
-    );
-  }
+      this.imageData = ctx.getImageData(
+        0,
+        0,
+        editor.canvas.width,
+        editor.canvas.height,
+      );
+    }
 
   onPointerMove(e: PointerEvent, editor: Editor): void {
     if (e.buttons !== 1 || !this.imageData) return;
@@ -26,7 +27,8 @@ export class LineTool extends DrawingTool {
     this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
-    ctx.lineTo(e.offsetX, e.offsetY);
+    const { x, y } = editor.toCanvasCoords(e);
+    ctx.lineTo(x, y);
     ctx.stroke();
     ctx.closePath();
   }
@@ -39,7 +41,8 @@ export class LineTool extends DrawingTool {
     this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
-    ctx.lineTo(e.offsetX, e.offsetY);
+    const { x, y } = editor.toCanvasCoords(e);
+    ctx.lineTo(x, y);
     ctx.stroke();
     ctx.closePath();
     this.imageData = null;

--- a/src/tools/PencilTool.ts
+++ b/src/tools/PencilTool.ts
@@ -5,15 +5,17 @@ export class PencilTool extends DrawingTool {
   onPointerDown(e: PointerEvent, editor: Editor) {
     this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
+    const { x, y } = editor.toCanvasCoords(e);
     ctx.beginPath();
-    ctx.moveTo(e.offsetX, e.offsetY);
+    ctx.moveTo(x, y);
   }
 
   onPointerMove(e: PointerEvent, editor: Editor) {
     if (e.buttons !== 1) return;
     this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
-    ctx.lineTo(e.offsetX, e.offsetY);
+    const { x, y } = editor.toCanvasCoords(e);
+    ctx.lineTo(x, y);
     ctx.stroke();
   }
 

--- a/src/tools/RectangleTool.ts
+++ b/src/tools/RectangleTool.ts
@@ -7,8 +7,9 @@ export class RectangleTool extends DrawingTool {
   private imageData: ImageData | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor) {
-    this.startX = e.offsetX;
-    this.startY = e.offsetY;
+    const { x, y } = editor.toCanvasCoords(e);
+    this.startX = x;
+    this.startY = y;
     this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
     this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
@@ -19,9 +20,7 @@ export class RectangleTool extends DrawingTool {
     const ctx = editor.ctx;
     ctx.putImageData(this.imageData, 0, 0);
     this.applyStroke(editor.ctx, editor);
-
-    const x = e.offsetX;
-    const y = e.offsetY;
+    const { x, y } = editor.toCanvasCoords(e);
     ctx.strokeRect(this.startX, this.startY, x - this.startX, y - this.startY);
     if (editor.fill) {
       ctx.fillRect(this.startX, this.startY, x - this.startX, y - this.startY);
@@ -35,8 +34,7 @@ export class RectangleTool extends DrawingTool {
     }
 
     this.applyStroke(editor.ctx, editor);
-    const x = e.offsetX;
-    const y = e.offsetY;
+    const { x, y } = editor.toCanvasCoords(e);
     ctx.strokeRect(this.startX, this.startY, x - this.startX, y - this.startY);
     if (editor.fill) {
       ctx.fillRect(this.startX, this.startY, x - this.startX, y - this.startY);

--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -24,13 +24,14 @@ export class TextTool implements Tool {
     parent.appendChild(textarea);
     textarea.focus();
 
+    const { x, y } = editor.toCanvasCoords(e);
     const commit = () => {
       const text = textarea.value;
       this.cleanup();
       if (text) {
         editor.ctx.fillStyle = editor.strokeStyle;
         editor.ctx.font = `${editor.fontSizeValue}px ${editor.fontFamilyValue}`;
-        editor.ctx.fillText(text, e.offsetX, e.offsetY);
+        editor.ctx.fillText(text, x, y);
       }
     };
 

--- a/tests/bucketFillTool.test.ts
+++ b/tests/bucketFillTool.test.ts
@@ -37,6 +37,8 @@ describe("BucketFillTool", () => {
       clearRect: jest.fn(),
       setTransform: jest.fn(),
       scale: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
     };
     canvas.getContext = jest.fn().mockReturnValue(ctx as CanvasRenderingContext2D);
 

--- a/tests/bucketIntegration.test.ts
+++ b/tests/bucketIntegration.test.ts
@@ -29,6 +29,8 @@ describe("bucket tool integration", () => {
     ctx = {
       setTransform: jest.fn(),
       scale: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
       getImageData: jest.fn(),
       putImageData: jest.fn(),
       clearRect: jest.fn(),

--- a/tests/circleTool.test.ts
+++ b/tests/circleTool.test.ts
@@ -26,6 +26,8 @@ describe("CircleTool", () => {
       closePath: jest.fn(),
       setTransform: jest.fn(),
       scale: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
     };
     canvas.getContext = jest
       .fn()

--- a/tests/colorRendering.test.ts
+++ b/tests/colorRendering.test.ts
@@ -44,6 +44,8 @@ describe("color rendering", () => {
       lineWidth: 0,
       setTransform: jest.fn(),
       scale: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
     };
 
     canvas.getContext = jest.fn().mockReturnValue(ctx);

--- a/tests/eraserTool.test.ts
+++ b/tests/eraserTool.test.ts
@@ -24,6 +24,8 @@ describe("EraserTool", () => {
       scale: jest.fn(),
       setTransform: jest.fn(),
       clearRect: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
       globalCompositeOperation: "source-over" as GlobalCompositeOperation,
       lineWidth: 0,
     };

--- a/tests/eyedropperTool.test.ts
+++ b/tests/eyedropperTool.test.ts
@@ -19,6 +19,8 @@ describe("EyedropperTool", () => {
       getImageData: jest.fn(() => image),
       setTransform: jest.fn(),
       scale: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
     };
     canvas.getContext = jest.fn().mockReturnValue(ctx as CanvasRenderingContext2D);
     canvas.getBoundingClientRect = () => ({

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -38,6 +38,8 @@ describe("image load and save", () => {
       drawImage: jest.fn(),
       setTransform: jest.fn(),
       scale: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
       getImageData: jest.fn().mockReturnValue(imageData),
       putImageData: jest.fn(),
       clearRect: jest.fn(),

--- a/tests/layers.test.ts
+++ b/tests/layers.test.ts
@@ -57,6 +57,8 @@ describe("layer-specific undo/redo", () => {
         } as ImageData),
       setTransform: jest.fn(),
       scale: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
     };
     ctx2 = {
       clearRect: jest.fn(),
@@ -70,6 +72,8 @@ describe("layer-specific undo/redo", () => {
         } as ImageData),
       setTransform: jest.fn(),
       scale: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
     };
 
     canvas1.getContext = jest.fn().mockReturnValue(ctx1 as any);

--- a/tests/lineTool.test.ts
+++ b/tests/lineTool.test.ts
@@ -31,6 +31,8 @@ describe("LineTool", () => {
       closePath: jest.fn(),
       scale: jest.fn(),
       setTransform: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
       strokeStyle: "red",
       fillStyle: "blue",
       lineWidth: 5,

--- a/tests/opacity.test.ts
+++ b/tests/opacity.test.ts
@@ -30,6 +30,8 @@ describe("layer opacity", () => {
       drawImage: jest.fn(),
       setTransform: jest.fn(),
       scale: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
       getImageData: jest.fn(),
       putImageData: jest.fn(),
       clearRect: jest.fn(),

--- a/tests/rectangleTool.test.ts
+++ b/tests/rectangleTool.test.ts
@@ -35,6 +35,8 @@ describe("RectangleTool", () => {
       stroke: jest.fn(),
       setTransform: jest.fn(),
       scale: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
     };
 
     canvas.getContext = jest

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -20,7 +20,12 @@ describe("save button", () => {
     `;
 
     const canvas = document.getElementById("canvas") as HTMLCanvasElement;
-    const ctx = { scale: jest.fn(), setTransform: jest.fn() } as any;
+    const ctx = {
+      scale: jest.fn(),
+      setTransform: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
+    } as any;
     canvas.getContext = jest.fn().mockReturnValue(ctx);
     canvas.toDataURL = jest.fn().mockReturnValue("data:image/png;base64,TEST");
     canvas.getBoundingClientRect = () => ({
@@ -68,7 +73,12 @@ describe("save button", () => {
     `;
 
     const canvas = document.getElementById("canvas") as HTMLCanvasElement;
-    const ctx = { scale: jest.fn(), setTransform: jest.fn() } as any;
+    const ctx = {
+      scale: jest.fn(),
+      setTransform: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
+    } as any;
     canvas.getContext = jest.fn().mockReturnValue(ctx);
     canvas.toDataURL = jest.fn().mockReturnValue("data:image/jpeg;base64,TEST");
     canvas.getBoundingClientRect = () => ({

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -38,6 +38,8 @@ describe("keyboard shortcuts", () => {
     ctx = {
       setTransform: jest.fn(),
       scale: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
       getImageData: jest.fn(),
       putImageData: jest.fn(),
       clearRect: jest.fn(),

--- a/tests/textTool.test.ts
+++ b/tests/textTool.test.ts
@@ -37,6 +37,8 @@ describe("TextTool", () => {
       putImageData: jest.fn(),
       setTransform: jest.fn(),
       scale: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
     };
 
     canvas.getContext = jest

--- a/tests/toolbar.test.ts
+++ b/tests/toolbar.test.ts
@@ -42,6 +42,8 @@ describe("toolbar controls", () => {
     ctx = {
       setTransform: jest.fn(),
       scale: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
       getImageData: jest.fn(),
       putImageData: jest.fn(),
       clearRect: jest.fn(),

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -29,6 +29,8 @@ describe("additional tools", () => {
       closePath: jest.fn(),
       scale: jest.fn(),
       setTransform: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
       getImageData: jest
         .fn()
         .mockReturnValue({


### PR DESCRIPTION
## Summary
- Track scale and translation in Editor and handle wheel zoom and space-drag panning
- Convert pointer coordinates to canvas space and update drawing tools to respect viewport transforms
- Add tests for zooming, panning, and provide canvas mocks with save/restore methods

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae0c4c074083288fa9ac145d61cdbd