### PR TITLE
Add shift-constrained drawing and line snapping

### DIFF
--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -26,9 +26,15 @@ export class CircleTool extends DrawingTool {
 
     const dx = e.offsetX - this.startX;
     const dy = e.offsetY - this.startY;
-    const radius = Math.sqrt(dx * dx + dy * dy);
+    let radiusX = Math.abs(dx);
+    let radiusY = Math.abs(dy);
+    if (e.shiftKey) {
+      const radius = Math.sqrt(dx * dx + dy * dy);
+      radiusX = radius;
+      radiusY = radius;
+    }
     ctx.beginPath();
-    ctx.arc(this.startX, this.startY, radius, 0, Math.PI * 2);
+    ctx.ellipse(this.startX, this.startY, radiusX, radiusY, 0, 0, Math.PI * 2);
     ctx.stroke();
     if (editor.fill) {
       ctx.fill();
@@ -44,9 +50,15 @@ export class CircleTool extends DrawingTool {
     this.applyStroke(ctx, editor);
     const dx = e.offsetX - this.startX;
     const dy = e.offsetY - this.startY;
-    const radius = Math.sqrt(dx * dx + dy * dy);
+    let radiusX = Math.abs(dx);
+    let radiusY = Math.abs(dy);
+    if (e.shiftKey) {
+      const radius = Math.sqrt(dx * dx + dy * dy);
+      radiusX = radius;
+      radiusY = radius;
+    }
     ctx.beginPath();
-    ctx.arc(this.startX, this.startY, radius, 0, Math.PI * 2);
+    ctx.ellipse(this.startX, this.startY, radiusX, radiusY, 0, 0, Math.PI * 2);
     ctx.stroke();
     if (editor.fill) {
       ctx.fill();

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -24,9 +24,20 @@ export class LineTool extends DrawingTool {
     const ctx = editor.ctx;
     ctx.putImageData(this.imageData, 0, 0);
     this.applyStroke(ctx, editor);
+    let x = e.offsetX;
+    let y = e.offsetY;
+    if (e.shiftKey) {
+      const dx = x - this.startX;
+      const dy = y - this.startY;
+      const angle = Math.atan2(dy, dx);
+      const snappedAngle = Math.round(angle / (Math.PI / 4)) * (Math.PI / 4);
+      const length = Math.sqrt(dx * dx + dy * dy);
+      x = this.startX + Math.cos(snappedAngle) * length;
+      y = this.startY + Math.sin(snappedAngle) * length;
+    }
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
-    ctx.lineTo(e.offsetX, e.offsetY);
+    ctx.lineTo(x, y);
     ctx.stroke();
     ctx.closePath();
   }
@@ -37,9 +48,20 @@ export class LineTool extends DrawingTool {
       ctx.putImageData(this.imageData, 0, 0);
     }
     this.applyStroke(ctx, editor);
+    let x = e.offsetX;
+    let y = e.offsetY;
+    if (e.shiftKey) {
+      const dx = x - this.startX;
+      const dy = y - this.startY;
+      const angle = Math.atan2(dy, dx);
+      const snappedAngle = Math.round(angle / (Math.PI / 4)) * (Math.PI / 4);
+      const length = Math.sqrt(dx * dx + dy * dy);
+      x = this.startX + Math.cos(snappedAngle) * length;
+      y = this.startY + Math.sin(snappedAngle) * length;
+    }
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
-    ctx.lineTo(e.offsetX, e.offsetY);
+    ctx.lineTo(x, y);
     ctx.stroke();
     ctx.closePath();
     this.imageData = null;

--- a/src/tools/RectangleTool.ts
+++ b/src/tools/RectangleTool.ts
@@ -20,11 +20,16 @@ export class RectangleTool extends DrawingTool {
     ctx.putImageData(this.imageData, 0, 0);
     this.applyStroke(editor.ctx, editor);
 
-    const x = e.offsetX;
-    const y = e.offsetY;
-    ctx.strokeRect(this.startX, this.startY, x - this.startX, y - this.startY);
+    let width = e.offsetX - this.startX;
+    let height = e.offsetY - this.startY;
+    if (e.shiftKey) {
+      const size = Math.min(Math.abs(width), Math.abs(height));
+      width = Math.sign(width) * size;
+      height = Math.sign(height) * size;
+    }
+    ctx.strokeRect(this.startX, this.startY, width, height);
     if (editor.fill) {
-      ctx.fillRect(this.startX, this.startY, x - this.startX, y - this.startY);
+      ctx.fillRect(this.startX, this.startY, width, height);
     }
   }
 
@@ -35,11 +40,16 @@ export class RectangleTool extends DrawingTool {
     }
 
     this.applyStroke(editor.ctx, editor);
-    const x = e.offsetX;
-    const y = e.offsetY;
-    ctx.strokeRect(this.startX, this.startY, x - this.startX, y - this.startY);
+    let width = e.offsetX - this.startX;
+    let height = e.offsetY - this.startY;
+    if (e.shiftKey) {
+      const size = Math.min(Math.abs(width), Math.abs(height));
+      width = Math.sign(width) * size;
+      height = Math.sign(height) * size;
+    }
+    ctx.strokeRect(this.startX, this.startY, width, height);
     if (editor.fill) {
-      ctx.fillRect(this.startX, this.startY, x - this.startX, y - this.startY);
+      ctx.fillRect(this.startX, this.startY, width, height);
     }
     this.imageData = null;
   }

--- a/tests/circleTool.test.ts
+++ b/tests/circleTool.test.ts
@@ -20,7 +20,7 @@ describe("CircleTool", () => {
       getImageData: jest.fn().mockReturnValue(imageData),
       putImageData: jest.fn(),
       beginPath: jest.fn(),
-      arc: jest.fn(),
+      ellipse: jest.fn(),
       stroke: jest.fn(),
       fill: jest.fn(),
       closePath: jest.fn(),
@@ -38,7 +38,7 @@ describe("CircleTool", () => {
     );
   });
 
-  it("previews circle during pointer move", () => {
+  it("previews ellipse during pointer move", () => {
     const tool = new CircleTool();
     tool.onPointerDown({ offsetX: 2, offsetY: 3 } as PointerEvent, editor);
     tool.onPointerMove({
@@ -52,9 +52,8 @@ describe("CircleTool", () => {
     expect(ctx.putImageData).toHaveBeenCalledWith(image, 0, 0);
     const dx = 5 - 2;
     const dy = 7 - 3;
-    const radius = Math.sqrt(dx * dx + dy * dy);
     expect(ctx.beginPath).toHaveBeenCalled();
-    expect(ctx.arc).toHaveBeenCalledWith(2, 3, radius, 0, Math.PI * 2);
+    expect(ctx.ellipse).toHaveBeenCalledWith(2, 3, Math.abs(dx), Math.abs(dy), 0, 0, Math.PI * 2);
     expect(ctx.stroke).toHaveBeenCalled();
     expect(ctx.closePath).toHaveBeenCalled();
   });
@@ -65,5 +64,25 @@ describe("CircleTool", () => {
     tool.onPointerDown({ offsetX: 2, offsetY: 3 } as PointerEvent, editor);
     tool.onPointerUp({ offsetX: 5, offsetY: 7 } as PointerEvent, editor);
     expect(ctx.fill).toHaveBeenCalled();
+  });
+
+  it("constrains to a circle when shift is held", () => {
+    const tool = new CircleTool();
+    tool.onPointerDown({ offsetX: 10, offsetY: 10 } as PointerEvent, editor);
+    tool.onPointerUp({
+      offsetX: 30,
+      offsetY: 20,
+      shiftKey: true,
+    } as PointerEvent, editor);
+    const radius = Math.sqrt(20 * 20 + 10 * 10);
+    expect(ctx.ellipse).toHaveBeenLastCalledWith(
+      10,
+      10,
+      radius,
+      radius,
+      0,
+      0,
+      Math.PI * 2,
+    );
   });
 });

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -48,7 +48,7 @@ describe("editor toolbar controls", () => {
       putImageData: jest.fn(),
       strokeRect: jest.fn(),
       fillRect: jest.fn(),
-      arc: jest.fn(),
+      ellipse: jest.fn(),
       fill: jest.fn(),
       drawImage: jest.fn(),
       fillText: jest.fn(),
@@ -149,7 +149,7 @@ describe("editor toolbar controls", () => {
     dispatch("pointerdown", 2, 2, 1);
     dispatch("pointermove", 4, 2, 1);
     dispatch("pointerup", 4, 2, 0);
-    expect(ctx.arc).toHaveBeenCalled();
+    expect(ctx.ellipse).toHaveBeenCalled();
   });
 
   it("writes text with text tool", () => {

--- a/tests/lineTool.test.ts
+++ b/tests/lineTool.test.ts
@@ -92,4 +92,18 @@ describe("LineTool", () => {
     expect(ctx.clearRect).toHaveBeenCalledTimes(1);
     expect(ctx.putImageData).toHaveBeenCalledTimes(2);
   });
+
+  it("snaps to 45 degree increments when shift is held", () => {
+    const tool = new LineTool();
+    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+    tool.onPointerUp({
+      offsetX: 1,
+      offsetY: 3,
+      shiftKey: true,
+    } as PointerEvent, editor);
+    const length = Math.sqrt(1 * 1 + 3 * 3);
+    const lastCall = (ctx.lineTo as jest.Mock).mock.calls.pop();
+    expect(lastCall[0]).toBeCloseTo(0);
+    expect(lastCall[1]).toBeCloseTo(length);
+  });
 });

--- a/tests/rectangleTool.test.ts
+++ b/tests/rectangleTool.test.ts
@@ -80,5 +80,16 @@ describe("RectangleTool", () => {
     tool.onPointerUp({ offsetX: 20, offsetY: 25 } as PointerEvent, editor);
     expect(ctx.fillRect).toHaveBeenCalledWith(10, 15, 10, 10);
   });
+
+  it("constrains to a square when shift is held", () => {
+    const tool = new RectangleTool();
+    tool.onPointerDown({ offsetX: 5, offsetY: 5 } as PointerEvent, editor);
+    tool.onPointerUp({
+      offsetX: 25,
+      offsetY: 15,
+      shiftKey: true,
+    } as PointerEvent, editor);
+    expect(ctx.strokeRect).toHaveBeenLastCalledWith(5, 5, 10, 10);
+  });
 });
 

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -24,7 +24,7 @@ describe("additional tools", () => {
       moveTo: jest.fn(),
       lineTo: jest.fn(),
       stroke: jest.fn(),
-      arc: jest.fn(),
+      ellipse: jest.fn(),
       fillText: jest.fn(),
       closePath: jest.fn(),
       scale: jest.fn(),
@@ -70,11 +70,15 @@ describe("additional tools", () => {
     expect(ctx.lineTo).toHaveBeenCalledWith(3, 4);
   });
 
-  it("circle tool draws a circle", () => {
+  it("circle tool draws a circle when shift is held", () => {
     const tool = new CircleTool();
     tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
-    tool.onPointerUp({ offsetX: 3, offsetY: 4 } as PointerEvent, editor);
-    expect(ctx.arc).toHaveBeenCalledWith(0, 0, 5, 0, Math.PI * 2);
+    tool.onPointerUp({
+      offsetX: 3,
+      offsetY: 4,
+      shiftKey: true,
+    } as PointerEvent, editor);
+    expect(ctx.ellipse).toHaveBeenCalledWith(0, 0, 5, 5, 0, 0, Math.PI * 2);
   });
 
   it("text tool commits text on Enter", () => {


### PR DESCRIPTION
## Summary
- Allow RectangleTool to draw squares when shift is held
- Update CircleTool to draw ellipses and constrain to circles with shift
- Snap LineTool angles to 45° increments with shift
- Expand tool tests for shift-modified behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae0c4b21e8832886ebb2a42146240e