### PR TITLE
Support additional redo keyboard shortcuts

### DIFF
--- a/src/core/Shortcuts.ts
+++ b/src/core/Shortcuts.ts
@@ -31,12 +31,17 @@ export class Shortcuts {
   private onKeyDown(e: KeyboardEvent) {
 
     if (e.ctrlKey || e.metaKey) {
-      if (e.key.toLowerCase() === "z") {
+      const key = e.key.toLowerCase();
+
+      if (key === "z") {
         if (e.shiftKey) {
           this.editor.redo();
         } else {
           this.editor.undo();
         }
+        e.preventDefault();
+      } else if (e.ctrlKey && key === "y") {
+        this.editor.redo();
         e.preventDefault();
       }
       return;

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -87,15 +87,21 @@ describe("keyboard shortcuts", () => {
   it("performs undo and redo with shortcuts", () => {
     const undo = jest.spyOn(handle.editor, "undo").mockImplementation(() => {});
     const redo = jest.spyOn(handle.editor, "redo").mockImplementation(() => {});
+
     const undoEvent = new KeyboardEvent("keydown", { key: "z", ctrlKey: true, cancelable: true });
     document.dispatchEvent(undoEvent);
     expect(undo).toHaveBeenCalled();
     expect(undoEvent.defaultPrevented).toBe(true);
 
-    const redoEvent = new KeyboardEvent("keydown", { key: "z", ctrlKey: true, shiftKey: true, cancelable: true });
-    document.dispatchEvent(redoEvent);
-    expect(redo).toHaveBeenCalled();
-    expect(redoEvent.defaultPrevented).toBe(true);
+    const redoCtrlY = new KeyboardEvent("keydown", { key: "y", ctrlKey: true, cancelable: true });
+    document.dispatchEvent(redoCtrlY);
+    expect(redo).toHaveBeenCalledTimes(1);
+    expect(redoCtrlY.defaultPrevented).toBe(true);
+
+    const redoMetaShiftZ = new KeyboardEvent("keydown", { key: "z", metaKey: true, shiftKey: true, cancelable: true });
+    document.dispatchEvent(redoMetaShiftZ);
+    expect(redo).toHaveBeenCalledTimes(2);
+    expect(redoMetaShiftZ.defaultPrevented).toBe(true);
   });
 
   it("switches active editor when requested", () => {


### PR DESCRIPTION
## Summary
- allow redo via Ctrl+Y or Cmd+Shift+Z
- expand shortcut tests for redo combinations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae0c4a54248328a6fa2fc291dd3961