### PR TITLE
Fix indentation for LineTool onPointerDown

### DIFF
--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -6,11 +6,11 @@ export class LineTool extends DrawingTool {
   private startY = 0;
   private imageData: ImageData | null = null;
 
-    onPointerDown(e: PointerEvent, editor: Editor): void {
-      const ctx = editor.ctx;
-      this.startX = e.offsetX;
-      this.startY = e.offsetY;
-      this.applyStroke(ctx, editor);
+  onPointerDown(e: PointerEvent, editor: Editor): void {
+    const ctx = editor.ctx;
+    this.startX = e.offsetX;
+    this.startY = e.offsetY;
+    this.applyStroke(ctx, editor);
     this.imageData = ctx.getImageData(
       0,
       0,


### PR DESCRIPTION
## Summary
- align LineTool.onPointerDown indentation with rest of file

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae0c49622883288f0ad939b0d2c8f3