### PR TITLE
Trigger color history update with EyedropperTool

### DIFF
--- a/dist/tools/EyedropperTool.js
+++ b/dist/tools/EyedropperTool.js
@@ -15,10 +15,12 @@ export class EyedropperTool {
         const [r, g, b] = data;
         const toHex = (v) => v.toString(16).padStart(2, "0");
         editor.colorPicker.value = `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+        editor.colorPicker.dispatchEvent(new Event("input", { bubbles: true }));
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    onPointerMove(_e, _editor) {
-        // intentionally unused
+    onPointerMove(e, editor) {
+        if (e.buttons !== 1)
+            return;
+        this.onPointerDown(e, editor);
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     onPointerUp(_e, _editor) {

--- a/src/tools/EyedropperTool.ts
+++ b/src/tools/EyedropperTool.ts
@@ -17,6 +17,7 @@ export class EyedropperTool implements Tool {
     const [r, g, b] = data;
     const toHex = (v: number) => v.toString(16).padStart(2, "0");
     editor.colorPicker.value = `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+    editor.colorPicker.dispatchEvent(new Event("input", { bubbles: true }));
   }
 
   onPointerMove(e: PointerEvent, editor: Editor): void {

--- a/tests/eyedropperTool.test.ts
+++ b/tests/eyedropperTool.test.ts
@@ -1,5 +1,6 @@
 import { Editor } from "../src/core/Editor.js";
 import { EyedropperTool } from "../src/tools/EyedropperTool.js";
+import { initEditor, type EditorHandle } from "../src/editor.js";
 
 describe("EyedropperTool", () => {
   let canvas: HTMLCanvasElement;
@@ -44,6 +45,68 @@ describe("EyedropperTool", () => {
     const tool = new EyedropperTool();
     tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
     expect(editor.colorPicker.value).toBe("#0c2238");
+  });
+});
+
+describe("EyedropperTool color history", () => {
+  let handle: EditorHandle;
+  let canvas: HTMLCanvasElement;
+  let ctx: Partial<CanvasRenderingContext2D>;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <canvas id="canvas"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="1" />
+      <input id="fillMode" type="checkbox" />
+
+      <button id="pencil"></button>
+      <button id="eraser"></button>
+      <button id="rectangle"></button>
+      <button id="line"></button>
+      <button id="circle"></button>
+      <button id="text"></button>
+      <button id="bucket"></button>
+      <button id="eyedropper"></button>
+
+      <select id="formatSelect"><option value="png">PNG</option></select>
+      <button id="save"></button>
+      <div id="colorHistory"></div>
+    `;
+    canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    const image = { data: new Uint8ClampedArray([12, 34, 56, 255]) } as ImageData;
+    ctx = {
+      getImageData: jest.fn(() => image),
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+    };
+    canvas.getContext = jest.fn().mockReturnValue(ctx as CanvasRenderingContext2D);
+    canvas.getBoundingClientRect = () => ({
+      width: 0,
+      height: 0,
+      left: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+    handle = initEditor();
+  });
+
+  afterEach(() => {
+    handle.destroy();
+  });
+
+  it("records sampled colors in the color history", () => {
+    const history = document.getElementById("colorHistory") as HTMLDivElement;
+    expect(history.children).toHaveLength(1);
+    const tool = new EyedropperTool();
+    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, handle.editor);
+    expect(history.children).toHaveLength(2);
+    const swatch = history.children[0] as HTMLButtonElement;
+    expect(swatch.style.backgroundColor).toBe("rgb(12, 34, 56)");
   });
 });
 


### PR DESCRIPTION
## Summary
- Fire an `input` event after the Eyedropper tool sets the color picker value
- Test that using the eyedropper adds the sampled color to the history

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae0c4972a4832892c38c05dc2f19ac