### PR TITLE
Add viewport transform with pan and zoom

### DIFF
--- a/src/tools/BucketFillTool.ts
+++ b/src/tools/BucketFillTool.ts
@@ -11,15 +11,16 @@ export class BucketFillTool implements Tool {
     const image = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
     const { width, height } = image;
     const dpr = window.devicePixelRatio || 1;
-    const x = Math.max(0, Math.min(width - 1, Math.floor(e.offsetX * dpr)));
-    const y = Math.max(0, Math.min(height - 1, Math.floor(e.offsetY * dpr)));
-    const targetColor = this.getPixel(image, x, y);
+    const { x, y } = editor.getCanvasCoords(e);
+    const px = Math.max(0, Math.min(width - 1, Math.floor(x * dpr)));
+    const py = Math.max(0, Math.min(height - 1, Math.floor(y * dpr)));
+    const targetColor = this.getPixel(image, px, py);
     const fillColor = this.hexToRgb(editor.fillStyle);
 
     // if target already the fill color, nothing to do
     if (this.colorsMatch(targetColor, fillColor)) return;
 
-    const stack: Array<[number, number]> = [[x, y]];
+    const stack: Array<[number, number]> = [[px, py]];
     while (stack.length) {
       const [px, py] = stack.pop()!;
       const current = this.getPixel(image, px, py);

--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -7,8 +7,9 @@ export class CircleTool extends DrawingTool {
   private imageData: ImageData | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
-    this.startX = e.offsetX;
-    this.startY = e.offsetY;
+    const { x, y } = editor.getCanvasCoords(e);
+    this.startX = x;
+    this.startY = y;
     const ctx = editor.ctx;
     this.applyStroke(ctx, editor);
     if (typeof ctx.getImageData === "function") {
@@ -24,8 +25,9 @@ export class CircleTool extends DrawingTool {
     ctx.putImageData(this.imageData, 0, 0);
     this.applyStroke(ctx, editor);
 
-    const dx = e.offsetX - this.startX;
-    const dy = e.offsetY - this.startY;
+    const { x, y } = editor.getCanvasCoords(e);
+    const dx = x - this.startX;
+    const dy = y - this.startY;
     const radius = Math.sqrt(dx * dx + dy * dy);
     ctx.beginPath();
     ctx.arc(this.startX, this.startY, radius, 0, Math.PI * 2);
@@ -42,8 +44,9 @@ export class CircleTool extends DrawingTool {
       ctx.putImageData(this.imageData, 0, 0);
     }
     this.applyStroke(ctx, editor);
-    const dx = e.offsetX - this.startX;
-    const dy = e.offsetY - this.startY;
+    const { x, y } = editor.getCanvasCoords(e);
+    const dx = x - this.startX;
+    const dy = y - this.startY;
     const radius = Math.sqrt(dx * dx + dy * dy);
     ctx.beginPath();
     ctx.arc(this.startX, this.startY, radius, 0, Math.PI * 2);

--- a/src/tools/EraserTool.ts
+++ b/src/tools/EraserTool.ts
@@ -4,13 +4,14 @@ import { DrawingTool } from "./DrawingTool.js";
 export class EraserTool extends DrawingTool {
   onPointerDown(e: PointerEvent, editor: Editor) {
     const ctx = editor.ctx;
+    const { x, y } = editor.getCanvasCoords(e);
     ctx.globalCompositeOperation = "destination-out";
     this.applyStroke(ctx, editor);
     ctx.beginPath();
-    ctx.moveTo(e.offsetX, e.offsetY);
+    ctx.moveTo(x, y);
     ctx.clearRect(
-      e.offsetX - editor.lineWidthValue / 2,
-      e.offsetY - editor.lineWidthValue / 2,
+      x - editor.lineWidthValue / 2,
+      y - editor.lineWidthValue / 2,
       editor.lineWidthValue,
       editor.lineWidthValue,
     );
@@ -20,11 +21,12 @@ export class EraserTool extends DrawingTool {
     if (e.buttons !== 1) return;
     const ctx = editor.ctx;
     this.applyStroke(ctx, editor);
-    ctx.lineTo(e.offsetX, e.offsetY);
+    const { x, y } = editor.getCanvasCoords(e);
+    ctx.lineTo(x, y);
     ctx.stroke();
     ctx.clearRect(
-      e.offsetX - editor.lineWidthValue / 2,
-      e.offsetY - editor.lineWidthValue / 2,
+      x - editor.lineWidthValue / 2,
+      y - editor.lineWidthValue / 2,
       editor.lineWidthValue,
       editor.lineWidthValue,
     );

--- a/src/tools/EyedropperTool.ts
+++ b/src/tools/EyedropperTool.ts
@@ -11,9 +11,10 @@ export class EyedropperTool implements Tool {
   onPointerDown(e: PointerEvent, editor: Editor): void {
     const { width, height } = editor.canvas;
     const dpr = window.devicePixelRatio || 1;
-    const x = Math.max(0, Math.min(width - 1, Math.floor(e.offsetX * dpr)));
-    const y = Math.max(0, Math.min(height - 1, Math.floor(e.offsetY * dpr)));
-    const { data } = editor.ctx.getImageData(x, y, 1, 1);
+    const { x, y } = editor.getCanvasCoords(e);
+    const px = Math.max(0, Math.min(width - 1, Math.floor(x * dpr)));
+    const py = Math.max(0, Math.min(height - 1, Math.floor(y * dpr)));
+    const { data } = editor.ctx.getImageData(px, py, 1, 1);
     const [r, g, b] = data;
     const toHex = (v: number) => v.toString(16).padStart(2, "0");
     editor.colorPicker.value = `#${toHex(r)}${toHex(g)}${toHex(b)}`;

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -8,8 +8,9 @@ export class LineTool extends DrawingTool {
 
     onPointerDown(e: PointerEvent, editor: Editor): void {
       const ctx = editor.ctx;
-      this.startX = e.offsetX;
-      this.startY = e.offsetY;
+      const { x, y } = editor.getCanvasCoords(e);
+      this.startX = x;
+      this.startY = y;
       this.applyStroke(ctx, editor);
     this.imageData = ctx.getImageData(
       0,
@@ -26,7 +27,8 @@ export class LineTool extends DrawingTool {
     this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
-    ctx.lineTo(e.offsetX, e.offsetY);
+    const { x, y } = editor.getCanvasCoords(e);
+    ctx.lineTo(x, y);
     ctx.stroke();
     ctx.closePath();
   }
@@ -38,8 +40,9 @@ export class LineTool extends DrawingTool {
     }
     this.applyStroke(ctx, editor);
     ctx.beginPath();
+    const { x, y } = editor.getCanvasCoords(e);
     ctx.moveTo(this.startX, this.startY);
-    ctx.lineTo(e.offsetX, e.offsetY);
+    ctx.lineTo(x, y);
     ctx.stroke();
     ctx.closePath();
     this.imageData = null;

--- a/src/tools/PencilTool.ts
+++ b/src/tools/PencilTool.ts
@@ -5,15 +5,17 @@ export class PencilTool extends DrawingTool {
   onPointerDown(e: PointerEvent, editor: Editor) {
     this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
+    const { x, y } = editor.getCanvasCoords(e);
     ctx.beginPath();
-    ctx.moveTo(e.offsetX, e.offsetY);
+    ctx.moveTo(x, y);
   }
 
   onPointerMove(e: PointerEvent, editor: Editor) {
     if (e.buttons !== 1) return;
     this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
-    ctx.lineTo(e.offsetX, e.offsetY);
+    const { x, y } = editor.getCanvasCoords(e);
+    ctx.lineTo(x, y);
     ctx.stroke();
   }
 

--- a/src/tools/RectangleTool.ts
+++ b/src/tools/RectangleTool.ts
@@ -7,8 +7,9 @@ export class RectangleTool extends DrawingTool {
   private imageData: ImageData | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor) {
-    this.startX = e.offsetX;
-    this.startY = e.offsetY;
+    const { x, y } = editor.getCanvasCoords(e);
+    this.startX = x;
+    this.startY = y;
     this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
     this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
@@ -20,8 +21,7 @@ export class RectangleTool extends DrawingTool {
     ctx.putImageData(this.imageData, 0, 0);
     this.applyStroke(editor.ctx, editor);
 
-    const x = e.offsetX;
-    const y = e.offsetY;
+    const { x, y } = editor.getCanvasCoords(e);
     ctx.strokeRect(this.startX, this.startY, x - this.startX, y - this.startY);
     if (editor.fill) {
       ctx.fillRect(this.startX, this.startY, x - this.startX, y - this.startY);
@@ -35,8 +35,7 @@ export class RectangleTool extends DrawingTool {
     }
 
     this.applyStroke(editor.ctx, editor);
-    const x = e.offsetX;
-    const y = e.offsetY;
+    const { x, y } = editor.getCanvasCoords(e);
     ctx.strokeRect(this.startX, this.startY, x - this.startX, y - this.startY);
     if (editor.fill) {
       ctx.fillRect(this.startX, this.startY, x - this.startX, y - this.startY);

--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -30,7 +30,8 @@ export class TextTool implements Tool {
       if (text) {
         editor.ctx.fillStyle = editor.strokeStyle;
         editor.ctx.font = `${editor.fontSizeValue}px ${editor.fontFamilyValue}`;
-        editor.ctx.fillText(text, e.offsetX, e.offsetY);
+        const { x, y } = editor.getCanvasCoords(e);
+        editor.ctx.fillText(text, x, y);
       }
     };
 


### PR DESCRIPTION
## Summary
- Track viewport scale and translation in the editor and update canvas transform
- Support wheel-based zooming and space+drag panning
- Update drawing tools to use transformed coordinates
- Add tests for zoom and pan interactions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae078b3e8c8328bb55cbb34f36d608