### PR TITLE
Add redo shortcut support for Ctrl+Y and Cmd+Shift+Z

### DIFF
--- a/src/core/Shortcuts.ts
+++ b/src/core/Shortcuts.ts
@@ -31,12 +31,16 @@ export class Shortcuts {
   private onKeyDown(e: KeyboardEvent) {
 
     if (e.ctrlKey || e.metaKey) {
-      if (e.key.toLowerCase() === "z") {
+      const key = e.key.toLowerCase();
+      if (key === "z") {
         if (e.shiftKey) {
           this.editor.redo();
         } else {
           this.editor.undo();
         }
+        e.preventDefault();
+      } else if (key === "y" && e.ctrlKey && !e.metaKey) {
+        this.editor.redo();
         e.preventDefault();
       }
       return;

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -87,15 +87,44 @@ describe("keyboard shortcuts", () => {
   it("performs undo and redo with shortcuts", () => {
     const undo = jest.spyOn(handle.editor, "undo").mockImplementation(() => {});
     const redo = jest.spyOn(handle.editor, "redo").mockImplementation(() => {});
-    const undoEvent = new KeyboardEvent("keydown", { key: "z", ctrlKey: true, cancelable: true });
+
+    const undoEvent = new KeyboardEvent("keydown", {
+      key: "z",
+      ctrlKey: true,
+      cancelable: true,
+    });
     document.dispatchEvent(undoEvent);
-    expect(undo).toHaveBeenCalled();
+    expect(undo).toHaveBeenCalledTimes(1);
     expect(undoEvent.defaultPrevented).toBe(true);
 
-    const redoEvent = new KeyboardEvent("keydown", { key: "z", ctrlKey: true, shiftKey: true, cancelable: true });
-    document.dispatchEvent(redoEvent);
-    expect(redo).toHaveBeenCalled();
-    expect(redoEvent.defaultPrevented).toBe(true);
+    const redoEventCtrlShiftZ = new KeyboardEvent("keydown", {
+      key: "z",
+      ctrlKey: true,
+      shiftKey: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(redoEventCtrlShiftZ);
+    expect(redo).toHaveBeenCalledTimes(1);
+    expect(redoEventCtrlShiftZ.defaultPrevented).toBe(true);
+
+    const redoEventCtrlY = new KeyboardEvent("keydown", {
+      key: "y",
+      ctrlKey: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(redoEventCtrlY);
+    expect(redo).toHaveBeenCalledTimes(2);
+    expect(redoEventCtrlY.defaultPrevented).toBe(true);
+
+    const redoEventCmdShiftZ = new KeyboardEvent("keydown", {
+      key: "z",
+      metaKey: true,
+      shiftKey: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(redoEventCmdShiftZ);
+    expect(redo).toHaveBeenCalledTimes(3);
+    expect(redoEventCmdShiftZ.defaultPrevented).toBe(true);
   });
 
   it("switches active editor when requested", () => {


### PR DESCRIPTION
## Summary
- Allow Ctrl+Y or Cmd+Shift+Z to trigger redo in keyboard shortcuts
- Test redo shortcuts across Ctrl+Y and Cmd+Shift+Z combinations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae078a793c8328a2a65452c44c99a2