### PR TITLE
Add shift-constrained shapes and line angle snapping

### DIFF
--- a/dist/tools/CircleTool.js
+++ b/dist/tools/CircleTool.js
@@ -26,9 +26,15 @@ export class CircleTool extends DrawingTool {
         this.applyStroke(ctx, editor);
         const dx = e.offsetX - this.startX;
         const dy = e.offsetY - this.startY;
-        const radius = Math.sqrt(dx * dx + dy * dy);
+        let radiusX = Math.abs(dx);
+        let radiusY = Math.abs(dy);
+        if (e.shiftKey) {
+            const radius = Math.max(radiusX, radiusY);
+            radiusX = radius;
+            radiusY = radius;
+        }
         ctx.beginPath();
-        ctx.arc(this.startX, this.startY, radius, 0, Math.PI * 2);
+        ctx.ellipse(this.startX, this.startY, radiusX, radiusY, 0, 0, Math.PI * 2);
         ctx.stroke();
         if (editor.fill) {
             ctx.fill();
@@ -43,9 +49,15 @@ export class CircleTool extends DrawingTool {
         this.applyStroke(ctx, editor);
         const dx = e.offsetX - this.startX;
         const dy = e.offsetY - this.startY;
-        const radius = Math.sqrt(dx * dx + dy * dy);
+        let radiusX = Math.abs(dx);
+        let radiusY = Math.abs(dy);
+        if (e.shiftKey) {
+            const radius = Math.max(radiusX, radiusY);
+            radiusX = radius;
+            radiusY = radius;
+        }
         ctx.beginPath();
-        ctx.arc(this.startX, this.startY, radius, 0, Math.PI * 2);
+        ctx.ellipse(this.startX, this.startY, radiusX, radiusY, 0, 0, Math.PI * 2);
         ctx.stroke();
         if (editor.fill) {
             ctx.fill();

--- a/dist/tools/LineTool.js
+++ b/dist/tools/LineTool.js
@@ -21,7 +21,18 @@ export class LineTool extends DrawingTool {
         this.applyStroke(ctx, editor);
         ctx.beginPath();
         ctx.moveTo(this.startX, this.startY);
-        ctx.lineTo(e.offsetX, e.offsetY);
+        let x = e.offsetX;
+        let y = e.offsetY;
+        if (e.shiftKey) {
+            const dx = x - this.startX;
+            const dy = y - this.startY;
+            const angle = Math.atan2(dy, dx);
+            const snapped = Math.round(angle / (Math.PI / 4)) * (Math.PI / 4);
+            const length = Math.sqrt(dx * dx + dy * dy);
+            x = this.startX + length * Math.cos(snapped);
+            y = this.startY + length * Math.sin(snapped);
+        }
+        ctx.lineTo(x, y);
         ctx.stroke();
         ctx.closePath();
     }
@@ -33,7 +44,18 @@ export class LineTool extends DrawingTool {
         this.applyStroke(ctx, editor);
         ctx.beginPath();
         ctx.moveTo(this.startX, this.startY);
-        ctx.lineTo(e.offsetX, e.offsetY);
+        let x = e.offsetX;
+        let y = e.offsetY;
+        if (e.shiftKey) {
+            const dx = x - this.startX;
+            const dy = y - this.startY;
+            const angle = Math.atan2(dy, dx);
+            const snapped = Math.round(angle / (Math.PI / 4)) * (Math.PI / 4);
+            const length = Math.sqrt(dx * dx + dy * dy);
+            x = this.startX + length * Math.cos(snapped);
+            y = this.startY + length * Math.sin(snapped);
+        }
+        ctx.lineTo(x, y);
         ctx.stroke();
         ctx.closePath();
         this.imageData = null;

--- a/dist/tools/RectangleTool.js
+++ b/dist/tools/RectangleTool.js
@@ -21,9 +21,16 @@ export class RectangleTool extends DrawingTool {
         this.applyStroke(editor.ctx, editor);
         const x = e.offsetX;
         const y = e.offsetY;
-        ctx.strokeRect(this.startX, this.startY, x - this.startX, y - this.startY);
+        let width = x - this.startX;
+        let height = y - this.startY;
+        if (e.shiftKey) {
+            const size = Math.min(Math.abs(width), Math.abs(height));
+            width = size * Math.sign(width);
+            height = size * Math.sign(height);
+        }
+        ctx.strokeRect(this.startX, this.startY, width, height);
         if (editor.fill) {
-            ctx.fillRect(this.startX, this.startY, x - this.startX, y - this.startY);
+            ctx.fillRect(this.startX, this.startY, width, height);
         }
     }
     onPointerUp(e, editor) {
@@ -34,9 +41,16 @@ export class RectangleTool extends DrawingTool {
         this.applyStroke(editor.ctx, editor);
         const x = e.offsetX;
         const y = e.offsetY;
-        ctx.strokeRect(this.startX, this.startY, x - this.startX, y - this.startY);
+        let width = x - this.startX;
+        let height = y - this.startY;
+        if (e.shiftKey) {
+            const size = Math.min(Math.abs(width), Math.abs(height));
+            width = size * Math.sign(width);
+            height = size * Math.sign(height);
+        }
+        ctx.strokeRect(this.startX, this.startY, width, height);
         if (editor.fill) {
-            ctx.fillRect(this.startX, this.startY, x - this.startX, y - this.startY);
+            ctx.fillRect(this.startX, this.startY, width, height);
         }
         this.imageData = null;
     }

--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -23,12 +23,17 @@ export class CircleTool extends DrawingTool {
     const ctx = editor.ctx;
     ctx.putImageData(this.imageData, 0, 0);
     this.applyStroke(ctx, editor);
-
     const dx = e.offsetX - this.startX;
     const dy = e.offsetY - this.startY;
-    const radius = Math.sqrt(dx * dx + dy * dy);
+    let radiusX = Math.abs(dx);
+    let radiusY = Math.abs(dy);
+    if (e.shiftKey) {
+      const radius = Math.max(radiusX, radiusY);
+      radiusX = radius;
+      radiusY = radius;
+    }
     ctx.beginPath();
-    ctx.arc(this.startX, this.startY, radius, 0, Math.PI * 2);
+    ctx.ellipse(this.startX, this.startY, radiusX, radiusY, 0, 0, Math.PI * 2);
     ctx.stroke();
     if (editor.fill) {
       ctx.fill();
@@ -44,9 +49,15 @@ export class CircleTool extends DrawingTool {
     this.applyStroke(ctx, editor);
     const dx = e.offsetX - this.startX;
     const dy = e.offsetY - this.startY;
-    const radius = Math.sqrt(dx * dx + dy * dy);
+    let radiusX = Math.abs(dx);
+    let radiusY = Math.abs(dy);
+    if (e.shiftKey) {
+      const radius = Math.max(radiusX, radiusY);
+      radiusX = radius;
+      radiusY = radius;
+    }
     ctx.beginPath();
-    ctx.arc(this.startX, this.startY, radius, 0, Math.PI * 2);
+    ctx.ellipse(this.startX, this.startY, radiusX, radiusY, 0, 0, Math.PI * 2);
     ctx.stroke();
     if (editor.fill) {
       ctx.fill();

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -26,7 +26,18 @@ export class LineTool extends DrawingTool {
     this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
-    ctx.lineTo(e.offsetX, e.offsetY);
+    let x = e.offsetX;
+    let y = e.offsetY;
+    if (e.shiftKey) {
+      const dx = x - this.startX;
+      const dy = y - this.startY;
+      const angle = Math.atan2(dy, dx);
+      const snapped = Math.round(angle / (Math.PI / 4)) * (Math.PI / 4);
+      const length = Math.sqrt(dx * dx + dy * dy);
+      x = this.startX + length * Math.cos(snapped);
+      y = this.startY + length * Math.sin(snapped);
+    }
+    ctx.lineTo(x, y);
     ctx.stroke();
     ctx.closePath();
   }
@@ -39,7 +50,18 @@ export class LineTool extends DrawingTool {
     this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
-    ctx.lineTo(e.offsetX, e.offsetY);
+    let x = e.offsetX;
+    let y = e.offsetY;
+    if (e.shiftKey) {
+      const dx = x - this.startX;
+      const dy = y - this.startY;
+      const angle = Math.atan2(dy, dx);
+      const snapped = Math.round(angle / (Math.PI / 4)) * (Math.PI / 4);
+      const length = Math.sqrt(dx * dx + dy * dy);
+      x = this.startX + length * Math.cos(snapped);
+      y = this.startY + length * Math.sin(snapped);
+    }
+    ctx.lineTo(x, y);
     ctx.stroke();
     ctx.closePath();
     this.imageData = null;

--- a/src/tools/RectangleTool.ts
+++ b/src/tools/RectangleTool.ts
@@ -22,9 +22,16 @@ export class RectangleTool extends DrawingTool {
 
     const x = e.offsetX;
     const y = e.offsetY;
-    ctx.strokeRect(this.startX, this.startY, x - this.startX, y - this.startY);
+    let width = x - this.startX;
+    let height = y - this.startY;
+    if (e.shiftKey) {
+      const size = Math.min(Math.abs(width), Math.abs(height));
+      width = size * Math.sign(width);
+      height = size * Math.sign(height);
+    }
+    ctx.strokeRect(this.startX, this.startY, width, height);
     if (editor.fill) {
-      ctx.fillRect(this.startX, this.startY, x - this.startX, y - this.startY);
+      ctx.fillRect(this.startX, this.startY, width, height);
     }
   }
 
@@ -37,9 +44,16 @@ export class RectangleTool extends DrawingTool {
     this.applyStroke(editor.ctx, editor);
     const x = e.offsetX;
     const y = e.offsetY;
-    ctx.strokeRect(this.startX, this.startY, x - this.startX, y - this.startY);
+    let width = x - this.startX;
+    let height = y - this.startY;
+    if (e.shiftKey) {
+      const size = Math.min(Math.abs(width), Math.abs(height));
+      width = size * Math.sign(width);
+      height = size * Math.sign(height);
+    }
+    ctx.strokeRect(this.startX, this.startY, width, height);
     if (editor.fill) {
-      ctx.fillRect(this.startX, this.startY, x - this.startX, y - this.startY);
+      ctx.fillRect(this.startX, this.startY, width, height);
     }
     this.imageData = null;
   }

--- a/tests/circleTool.test.ts
+++ b/tests/circleTool.test.ts
@@ -20,7 +20,7 @@ describe("CircleTool", () => {
       getImageData: jest.fn().mockReturnValue(imageData),
       putImageData: jest.fn(),
       beginPath: jest.fn(),
-      arc: jest.fn(),
+      ellipse: jest.fn(),
       stroke: jest.fn(),
       fill: jest.fn(),
       closePath: jest.fn(),
@@ -52,9 +52,10 @@ describe("CircleTool", () => {
     expect(ctx.putImageData).toHaveBeenCalledWith(image, 0, 0);
     const dx = 5 - 2;
     const dy = 7 - 3;
-    const radius = Math.sqrt(dx * dx + dy * dy);
+    const radiusX = Math.abs(dx);
+    const radiusY = Math.abs(dy);
     expect(ctx.beginPath).toHaveBeenCalled();
-    expect(ctx.arc).toHaveBeenCalledWith(2, 3, radius, 0, Math.PI * 2);
+    expect(ctx.ellipse).toHaveBeenCalledWith(2, 3, radiusX, radiusY, 0, 0, Math.PI * 2);
     expect(ctx.stroke).toHaveBeenCalled();
     expect(ctx.closePath).toHaveBeenCalled();
   });
@@ -65,5 +66,15 @@ describe("CircleTool", () => {
     tool.onPointerDown({ offsetX: 2, offsetY: 3 } as PointerEvent, editor);
     tool.onPointerUp({ offsetX: 5, offsetY: 7 } as PointerEvent, editor);
     expect(ctx.fill).toHaveBeenCalled();
+  });
+
+  it("constrains to a circle when shift is held", () => {
+    const tool = new CircleTool();
+    tool.onPointerDown({ offsetX: 2, offsetY: 3 } as PointerEvent, editor);
+    tool.onPointerUp({ offsetX: 5, offsetY: 7, shiftKey: true } as PointerEvent, editor);
+    const dx = 5 - 2;
+    const dy = 7 - 3;
+    const radius = Math.max(Math.abs(dx), Math.abs(dy));
+    expect(ctx.ellipse).toHaveBeenLastCalledWith(2, 3, radius, radius, 0, 0, Math.PI * 2);
   });
 });

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -48,7 +48,7 @@ describe("editor toolbar controls", () => {
       putImageData: jest.fn(),
       strokeRect: jest.fn(),
       fillRect: jest.fn(),
-      arc: jest.fn(),
+      ellipse: jest.fn(),
       fill: jest.fn(),
       drawImage: jest.fn(),
       fillText: jest.fn(),
@@ -149,7 +149,7 @@ describe("editor toolbar controls", () => {
     dispatch("pointerdown", 2, 2, 1);
     dispatch("pointermove", 4, 2, 1);
     dispatch("pointerup", 4, 2, 0);
-    expect(ctx.arc).toHaveBeenCalled();
+    expect(ctx.ellipse).toHaveBeenCalled();
   });
 
   it("writes text with text tool", () => {

--- a/tests/lineTool.test.ts
+++ b/tests/lineTool.test.ts
@@ -92,4 +92,25 @@ describe("LineTool", () => {
     expect(ctx.clearRect).toHaveBeenCalledTimes(1);
     expect(ctx.putImageData).toHaveBeenCalledTimes(2);
   });
+
+  it("snaps angles to 45° increments when shift is held", () => {
+    const tool = new LineTool();
+    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+    tool.onPointerMove({
+      offsetX: 10,
+      offsetY: 5,
+      buttons: 1,
+      shiftKey: true,
+    } as PointerEvent, editor);
+    const args = (ctx.lineTo as jest.Mock).mock.calls.pop();
+    const dx = 10;
+    const dy = 5;
+    const angle = Math.atan2(dy, dx);
+    const snapped = Math.round(angle / (Math.PI / 4)) * (Math.PI / 4);
+    const length = Math.sqrt(dx * dx + dy * dy);
+    const expectedX = length * Math.cos(snapped);
+    const expectedY = length * Math.sin(snapped);
+    expect(args[0]).toBeCloseTo(expectedX);
+    expect(args[1]).toBeCloseTo(expectedY);
+  });
 });

--- a/tests/rectangleTool.test.ts
+++ b/tests/rectangleTool.test.ts
@@ -80,5 +80,16 @@ describe("RectangleTool", () => {
     tool.onPointerUp({ offsetX: 20, offsetY: 25 } as PointerEvent, editor);
     expect(ctx.fillRect).toHaveBeenCalledWith(10, 15, 10, 10);
   });
+
+  it("constrains to a square when shift is held", () => {
+    const tool = new RectangleTool();
+    tool.onPointerDown({ offsetX: 10, offsetY: 15 } as PointerEvent, editor);
+    tool.onPointerUp({
+      offsetX: 30,
+      offsetY: 25,
+      shiftKey: true,
+    } as PointerEvent, editor);
+    expect(ctx.strokeRect).toHaveBeenLastCalledWith(10, 15, 10, 10);
+  });
 });
 

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -24,7 +24,7 @@ describe("additional tools", () => {
       moveTo: jest.fn(),
       lineTo: jest.fn(),
       stroke: jest.fn(),
-      arc: jest.fn(),
+      ellipse: jest.fn(),
       fillText: jest.fn(),
       closePath: jest.fn(),
       scale: jest.fn(),
@@ -74,7 +74,7 @@ describe("additional tools", () => {
     const tool = new CircleTool();
     tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
     tool.onPointerUp({ offsetX: 3, offsetY: 4 } as PointerEvent, editor);
-    expect(ctx.arc).toHaveBeenCalledWith(0, 0, 5, 0, Math.PI * 2);
+    expect(ctx.ellipse).toHaveBeenCalledWith(0, 0, 3, 4, 0, 0, Math.PI * 2);
   });
 
   it("text tool commits text on Enter", () => {


### PR DESCRIPTION
## Summary
- Constrain rectangle and circle tools when holding Shift
- Snap line tool angles to 45° increments with Shift
- Add tests for new Shift behaviors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae078ad5708328836d91ce8c66b431