### PR TITLE
Refactor bucket fill to use typed-array queue

### DIFF
--- a/src/tools/BucketFillTool.ts
+++ b/src/tools/BucketFillTool.ts
@@ -3,32 +3,93 @@ import { Tool } from "./Tool.js";
 
 /**
  * Tool that fills a contiguous region of pixels with the current fill color.
- * Uses a simple stack-based flood fill on the canvas' pixel data.
+ * Uses an iterative flood fill with typed-array backed queue to reduce memory churn.
  */
 export class BucketFillTool implements Tool {
+  private static readonly MAX_FILL_PIXELS = 1_000_000;
+
   onPointerDown(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
     const image = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
-    const { width, height } = image;
+    const { width, height, data } = image;
+
+    const pixelCount = width * height;
+    if (pixelCount > BucketFillTool.MAX_FILL_PIXELS) {
+      console.warn("Bucket fill aborted: area too large");
+      return;
+    }
+
     const dpr = window.devicePixelRatio || 1;
-    const x = Math.max(0, Math.min(width - 1, Math.floor(e.offsetX * dpr)));
-    const y = Math.max(0, Math.min(height - 1, Math.floor(e.offsetY * dpr)));
-    const targetColor = this.getPixel(image, x, y);
-    const fillColor = this.hexToRgb(editor.fillStyle);
+    const sx = Math.max(0, Math.min(width - 1, Math.floor(e.offsetX * dpr)));
+    const sy = Math.max(0, Math.min(height - 1, Math.floor(e.offsetY * dpr)));
+    const start = sy * width + sx;
+    const targetOffset = start * 4;
+    const tr = data[targetOffset];
+    const tg = data[targetOffset + 1];
+    const tb = data[targetOffset + 2];
+
+    const [fr, fg, fb] = this.hexToRgb(editor.fillStyle);
 
     // if target already the fill color, nothing to do
-    if (this.colorsMatch(targetColor, fillColor)) return;
+    if (tr === fr && tg === fg && tb === fb) return;
 
-    const stack: Array<[number, number]> = [[x, y]];
-    while (stack.length) {
-      const [px, py] = stack.pop()!;
-      const current = this.getPixel(image, px, py);
-      if (!this.colorsMatch(current, targetColor)) continue;
-      this.setPixel(image, px, py, fillColor);
-      if (px > 0) stack.push([px - 1, py]);
-      if (px < width - 1) stack.push([px + 1, py]);
-      if (py > 0) stack.push([px, py - 1]);
-      if (py < height - 1) stack.push([px, py + 1]);
+    const queue = new Uint32Array(pixelCount);
+    const visited = new Uint8Array(pixelCount);
+    let head = 0;
+    let tail = 0;
+    let processed = 0;
+
+    queue[tail++] = start;
+    visited[start] = 1;
+
+    while (head < tail) {
+      const idx = queue[head++];
+      const offset = idx * 4;
+      if (data[offset] !== tr || data[offset + 1] !== tg || data[offset + 2] !== tb) {
+        continue;
+      }
+
+      data[offset] = fr;
+      data[offset + 1] = fg;
+      data[offset + 2] = fb;
+      data[offset + 3] = 255;
+      processed++;
+      if (processed > BucketFillTool.MAX_FILL_PIXELS) {
+        console.warn("Bucket fill aborted: exceeded pixel limit");
+        break;
+      }
+
+      const x = idx % width;
+      const y = (idx / width) | 0;
+
+      if (x > 0) {
+        const n = idx - 1;
+        if (!visited[n]) {
+          queue[tail++] = n;
+          visited[n] = 1;
+        }
+      }
+      if (x < width - 1) {
+        const n = idx + 1;
+        if (!visited[n]) {
+          queue[tail++] = n;
+          visited[n] = 1;
+        }
+      }
+      if (y > 0) {
+        const n = idx - width;
+        if (!visited[n]) {
+          queue[tail++] = n;
+          visited[n] = 1;
+        }
+      }
+      if (y < height - 1) {
+        const n = idx + width;
+        if (!visited[n]) {
+          queue[tail++] = n;
+          visited[n] = 1;
+        }
+      }
     }
     ctx.putImageData(image, 0, 0);
   }
@@ -41,33 +102,6 @@ export class BucketFillTool implements Tool {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onPointerUp(_e: PointerEvent, _editor: Editor): void {
     // intentionally unused
-  }
-
-  private getPixel(image: ImageData, x: number, y: number): [number, number, number, number] {
-    const { width, data } = image;
-    const idx = (Math.floor(y) * width + Math.floor(x)) * 4;
-    return [data[idx], data[idx + 1], data[idx + 2], data[idx + 3]];
-  }
-
-  private setPixel(
-    image: ImageData,
-    x: number,
-    y: number,
-    color: [number, number, number],
-  ): void {
-    const { width, data } = image;
-    const idx = (Math.floor(y) * width + Math.floor(x)) * 4;
-    data[idx] = color[0];
-    data[idx + 1] = color[1];
-    data[idx + 2] = color[2];
-    data[idx + 3] = 255;
-  }
-
-  private colorsMatch(
-    a: [number, number, number, number],
-    b: [number, number, number] | [number, number, number, number],
-  ): boolean {
-    return a[0] === b[0] && a[1] === b[1] && a[2] === b[2];
   }
 
   private hexToRgb(hex: string): [number, number, number] {

--- a/tests/bucketFillTool.test.ts
+++ b/tests/bucketFillTool.test.ts
@@ -65,4 +65,28 @@ describe("BucketFillTool", () => {
     expect(image.data[corner + 2]).toBe(0);
     expect(ctx.putImageData).toHaveBeenCalledWith(image, 0, 0);
   });
+
+  it("fills large areas efficiently", () => {
+    const width = 100;
+    const height = 100;
+    const data = new Uint8ClampedArray(width * height * 4);
+    for (let i = 0; i < width * height; i++) {
+      const idx = i * 4;
+      data[idx] = 255;
+      data[idx + 1] = 255;
+      data[idx + 2] = 255;
+      data[idx + 3] = 255;
+    }
+    const image = { data, width, height } as ImageData;
+    (ctx.getImageData as jest.Mock).mockReturnValueOnce(image);
+
+    const tool = new BucketFillTool();
+    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+
+    const last = (width * height - 1) * 4;
+    expect(image.data[last]).toBe(0);
+    expect(image.data[last + 1]).toBe(0);
+    expect(image.data[last + 2]).toBe(255);
+    expect(ctx.putImageData).toHaveBeenCalledWith(image, 0, 0);
+  });
 });


### PR DESCRIPTION
## Summary
- replace stack-based bucket fill with typed-array queue algorithm
- abort bucket fill when exceeding maximum pixel threshold
- add large-area fill test for BucketFillTool

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae0789f1bc832880eb1aa0f8e3c694