### PR TITLE
style: fix indentation in LineTool

### DIFF
--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -6,11 +6,11 @@ export class LineTool extends DrawingTool {
   private startY = 0;
   private imageData: ImageData | null = null;
 
-    onPointerDown(e: PointerEvent, editor: Editor): void {
-      const ctx = editor.ctx;
-      this.startX = e.offsetX;
-      this.startY = e.offsetY;
-      this.applyStroke(ctx, editor);
+  onPointerDown(e: PointerEvent, editor: Editor): void {
+    const ctx = editor.ctx;
+    this.startX = e.offsetX;
+    this.startY = e.offsetY;
+    this.applyStroke(ctx, editor);
     this.imageData = ctx.getImageData(
       0,
       0,


### PR DESCRIPTION
## Summary
- reindent LineTool.onPointerDown for consistent 2-space formatting

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae07897c448328b3357baaaf3ab7f4