### PR TITLE
feat: dispatch color picker input event

### DIFF
--- a/src/tools/EyedropperTool.ts
+++ b/src/tools/EyedropperTool.ts
@@ -17,6 +17,7 @@ export class EyedropperTool implements Tool {
     const [r, g, b] = data;
     const toHex = (v: number) => v.toString(16).padStart(2, "0");
     editor.colorPicker.value = `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+    editor.colorPicker.dispatchEvent(new Event("input", { bubbles: true }));
   }
 
   onPointerMove(e: PointerEvent, editor: Editor): void {

--- a/tests/eyedropperTool.test.ts
+++ b/tests/eyedropperTool.test.ts
@@ -12,6 +12,7 @@ describe("EyedropperTool", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="1" />
       <input id="fillMode" type="checkbox" />
+      <div id="colorHistory"></div>
     `;
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
     const image = { data: new Uint8ClampedArray([12, 34, 56, 255]) } as ImageData;
@@ -44,6 +45,42 @@ describe("EyedropperTool", () => {
     const tool = new EyedropperTool();
     tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
     expect(editor.colorPicker.value).toBe("#0c2238");
+  });
+
+  it("updates the color history when the color picker changes", () => {
+    const tool = new EyedropperTool();
+    const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
+    const colorHistory = document.getElementById("colorHistory") as HTMLDivElement;
+
+    const recentColors: string[] = [];
+    const renderColorHistory = () => {
+      colorHistory.innerHTML = "";
+      recentColors.forEach((color) => {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "color-swatch";
+        btn.style.backgroundColor = color;
+        btn.setAttribute("aria-label", `Select ${color}`);
+        colorHistory.appendChild(btn);
+      });
+    };
+    const recordColor = (color: string) => {
+      const existing = recentColors.indexOf(color);
+      if (existing !== -1) recentColors.splice(existing, 1);
+      recentColors.unshift(color);
+      if (recentColors.length > 10) recentColors.pop();
+      renderColorHistory();
+    };
+    colorPicker.addEventListener("input", () => {
+      recordColor(colorPicker.value);
+    });
+
+    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+
+    expect(recentColors[0]).toBe("#0c2238");
+    expect(colorHistory.children).toHaveLength(1);
+    const swatch = colorHistory.children[0] as HTMLElement;
+    expect(swatch.style.backgroundColor).toBe("rgb(12, 34, 56)");
   });
 });
 


### PR DESCRIPTION
## Summary
- fire `input` event when Eyedropper updates color picker so color history reacts
- test Eyedropper integration with color history

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae078959388328b0731aab2159f448