### PR TITLE
Add clear canvas button to toolbar

### DIFF
--- a/dist/editor.js
+++ b/dist/editor.js
@@ -114,6 +114,7 @@ export function initEditor() {
     });
     const undoBtn = document.getElementById("undo");
     const redoBtn = document.getElementById("redo");
+    const clearBtn = document.getElementById("clear");
     const listeners = [];
     const recentColors = [];
     const maxRecentColors = 10;
@@ -189,6 +190,11 @@ export function initEditor() {
     }, listeners);
     listen(redoBtn, "click", () => {
         editor.redo();
+        updateHistoryButtons();
+    }, listeners);
+    listen(clearBtn, "click", () => {
+        editor.saveState();
+        editor.ctx.clearRect(0, 0, editor.canvas.width, editor.canvas.height);
         updateHistoryButtons();
     }, listeners);
     // saving

--- a/index.html
+++ b/index.html
@@ -53,6 +53,8 @@
         <img src="icons/redo.svg" alt="Redo" />
       </button>
 
+      <button id="clear">Clear</button>
+
       <div class="group">
         <label for="layerSelect">Layer</label>
         <select id="layerSelect"></select>

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -145,6 +145,7 @@ export function initEditor(): EditorHandle {
 
   const undoBtn = document.getElementById("undo") as HTMLButtonElement | null;
   const redoBtn = document.getElementById("redo") as HTMLButtonElement | null;
+  const clearBtn = document.getElementById("clear") as HTMLButtonElement | null;
   const listeners: Array<() => void> = [];
 
   const recentColors: string[] = [];
@@ -253,6 +254,17 @@ export function initEditor(): EditorHandle {
     "click",
     () => {
       editor.redo();
+      updateHistoryButtons();
+    },
+    listeners,
+  );
+
+  listen(
+    clearBtn,
+    "click",
+    () => {
+      editor.saveState();
+      editor.ctx.clearRect(0, 0, editor.canvas.width, editor.canvas.height);
       updateHistoryButtons();
     },
     listeners,

--- a/tests/clear.test.ts
+++ b/tests/clear.test.ts
@@ -1,0 +1,67 @@
+import { initEditor, type EditorHandle } from "../src/editor.js";
+
+describe("clear button", () => {
+  let handle: EditorHandle;
+  let canvas: HTMLCanvasElement;
+  let ctx: Partial<CanvasRenderingContext2D>;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="toolbar">
+        <input id="colorPicker" value="#000000" />
+        <input id="lineWidth" value="2" />
+        <input id="fillMode" type="checkbox" />
+        <button id="pencil"></button>
+        <button id="eraser"></button>
+        <button id="rectangle"></button>
+        <button id="line"></button>
+        <button id="circle"></button>
+        <button id="text"></button>
+        <button id="eyedropper"></button>
+        <button id="bucket"></button>
+        <select id="formatSelect"><option value="png">PNG</option></select>
+        <button id="save"></button>
+        <button id="undo"></button>
+        <button id="redo"></button>
+        <button id="clear"></button>
+      </div>
+      <canvas id="canvas"></canvas>
+    `;
+
+    canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    const mockImage = { data: new Uint8ClampedArray(), width: 100, height: 100 } as ImageData;
+    ctx = {
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+      getImageData: jest.fn(() => mockImage),
+      putImageData: jest.fn(),
+      clearRect: jest.fn(),
+    };
+    canvas.getContext = jest.fn().mockReturnValue(ctx as CanvasRenderingContext2D);
+    canvas.getBoundingClientRect = () => ({
+      width: 100,
+      height: 100,
+      top: 0,
+      left: 0,
+      bottom: 100,
+      right: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+
+    handle = initEditor();
+  });
+
+  afterEach(() => {
+    handle.destroy();
+  });
+
+  it("clears canvas and saves state", () => {
+    const btn = document.getElementById("clear") as HTMLButtonElement;
+    expect(handle.editor.canUndo).toBe(false);
+    btn.click();
+    expect(ctx.clearRect).toHaveBeenCalledWith(0, 0, canvas.width, canvas.height);
+    expect(handle.editor.canUndo).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add Clear button to toolbar
- clear canvas while saving undo state
- test Clear button clears canvas and updates history

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0fdecdad08328998e40ba1874a3e6