### PR TITLE
Add active tool button styling and toggle

### DIFF
--- a/dist/editor.js
+++ b/dist/editor.js
@@ -45,9 +45,9 @@ export function initEditor() {
     let activeButton = null;
     const setActiveButton = (btn) => {
         if (activeButton)
-            activeButton.classList.remove("active");
+            activeButton.classList.remove("active-tool");
         if (btn)
-            btn.classList.add("active");
+            btn.classList.add("active-tool");
         activeButton = btn;
     };
     const buttonForTool = (tool) => {
@@ -273,6 +273,7 @@ export function initEditor() {
         editors,
         activateLayer,
         destroy() {
+            setActiveButton(null);
             listeners.forEach((fn) => fn());
             shortcuts.destroy();
             editors.forEach((e) => e.destroy());

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -63,8 +63,8 @@ export function initEditor(): EditorHandle {
 
   let activeButton: HTMLButtonElement | null = null;
   const setActiveButton = (btn: HTMLButtonElement | null) => {
-    if (activeButton) activeButton.classList.remove("active");
-    if (btn) btn.classList.add("active");
+    if (activeButton) activeButton.classList.remove("active-tool");
+    if (btn) btn.classList.add("active-tool");
     activeButton = btn;
   };
   const buttonForTool = (tool: Tool): HTMLButtonElement | null => {
@@ -369,6 +369,7 @@ export function initEditor(): EditorHandle {
     editors,
     activateLayer,
     destroy() {
+      setActiveButton(null);
       listeners.forEach((fn) => fn());
       shortcuts.destroy();
       editors.forEach((e) => e.destroy());

--- a/style.css
+++ b/style.css
@@ -69,11 +69,11 @@ body {
   background: #f0f0f0;
 }
 
-.tool-button.active {
+.tool-button.active-tool {
   background: #007bff;
 }
 
-.tool-button.active img {
+.tool-button.active-tool img {
   filter: brightness(0) invert(1);
 }
 

--- a/tests/toolbar.test.ts
+++ b/tests/toolbar.test.ts
@@ -77,6 +77,23 @@ describe("toolbar controls", () => {
     expect(select.options.length).toBe(2);
   });
 
+  it("toggles active-tool class on tool buttons", () => {
+    const pencilBtn = document.getElementById("pencil") as HTMLButtonElement;
+    const eraserBtn = document.getElementById("eraser") as HTMLButtonElement;
+
+    // pencil is active by default
+    expect(pencilBtn.classList.contains("active-tool")).toBe(true);
+    expect(eraserBtn.classList.contains("active-tool")).toBe(false);
+
+    eraserBtn.click();
+    expect(eraserBtn.classList.contains("active-tool")).toBe(true);
+    expect(pencilBtn.classList.contains("active-tool")).toBe(false);
+
+    pencilBtn.click();
+    expect(pencilBtn.classList.contains("active-tool")).toBe(true);
+    expect(eraserBtn.classList.contains("active-tool")).toBe(false);
+  });
+
     it("switches tools when buttons are clicked", () => {
       const spy = jest.spyOn(handle.editor, "setTool");
       (document.getElementById("pencil") as HTMLButtonElement).click();


### PR DESCRIPTION
## Summary
- style active toolbar button with new `.active-tool` class
- toggle `.active-tool` when tools change and clear it on destroy
- test button click updates the active class

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0fdedb1f883289788b76d31ad0fa9