### PR TITLE
Add configurable history memory cap

### DIFF
--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -1,10 +1,20 @@
 import { Tool } from "../tools/Tool.js";
 
+interface Snapshot {
+  image: ImageData;
+  bytes: number;
+}
+
+export interface EditorOptions {
+  /** Maximum estimated bytes to retain across undo and redo history. */
+  historyMemoryCapBytes?: number;
+}
+
 export class Editor {
   canvas: HTMLCanvasElement;
   ctx: CanvasRenderingContext2D;
-  private undoStack: ImageData[] = [];
-  private redoStack: ImageData[] = [];
+  private undoStack: Snapshot[] = [];
+  private redoStack: Snapshot[] = [];
   private currentTool: Tool | null = null;
   colorPicker: HTMLInputElement;
   lineWidth: HTMLInputElement;
@@ -12,6 +22,10 @@ export class Editor {
   fontFamily: HTMLSelectElement | null;
   fontSize: HTMLInputElement | null;
   private onChange?: () => void;
+  private historyByteUsage = 0;
+  private historyMemoryCapBytes: number;
+
+  static readonly DEFAULT_HISTORY_MEMORY_CAP_BYTES = 64 * 1024 * 1024;
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -21,6 +35,7 @@ export class Editor {
     onChange?: () => void,
     fontFamily?: HTMLSelectElement | null,
     fontSize?: HTMLInputElement | null,
+    options: EditorOptions = {},
   ) {
     this.canvas = canvas;
     const ctx = canvas.getContext("2d");
@@ -32,6 +47,14 @@ export class Editor {
     this.onChange = onChange;
     this.fontFamily = fontFamily ?? null;
     this.fontSize = fontSize ?? null;
+    const cap = options.historyMemoryCapBytes;
+    if (cap === undefined || Number.isNaN(cap)) {
+      this.historyMemoryCapBytes = Editor.DEFAULT_HISTORY_MEMORY_CAP_BYTES;
+    } else if (!Number.isFinite(cap)) {
+      this.historyMemoryCapBytes = Number.POSITIVE_INFINITY;
+    } else {
+      this.historyMemoryCapBytes = Math.max(0, cap);
+    }
     this.adjustForPixelRatio();
     window.addEventListener("resize", this.handleResize);
 
@@ -84,22 +107,26 @@ export class Editor {
   };
 
   saveState() {
-    this.undoStack.push(
+    this.clearStack(this.redoStack);
+    this.pushSnapshot(
+      this.undoStack,
       this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height),
     );
-    if (this.undoStack.length > 50) this.undoStack.shift();
-    this.redoStack.length = 0;
+    this.enforceHistoryCap();
     this.onChange?.();
   }
 
-  private restoreState(stack: ImageData[], opposite: ImageData[]) {
+  private restoreState(stack: Snapshot[], opposite: Snapshot[]) {
     if (!stack.length) return;
-    opposite.push(
+    this.pushSnapshot(
+      opposite,
       this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height),
     );
-    const imageData = stack.pop()!;
+    const snapshot = this.popSnapshot(stack);
+    if (!snapshot) return;
     this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-    this.ctx.putImageData(imageData, 0, 0);
+    this.ctx.putImageData(snapshot.image, 0, 0);
+    this.enforceHistoryCap();
     this.onChange?.();
   }
 
@@ -146,12 +173,65 @@ export class Editor {
   /**
    * Remove all event listeners registered by the editor.
    * Should be called before discarding the instance to prevent leaks.
-   */
+  */
   destroy(): void {
     this.currentTool?.destroy?.();
     window.removeEventListener("resize", this.handleResize);
     this.canvas.removeEventListener("pointerdown", this.handlePointerDown);
     this.canvas.removeEventListener("pointermove", this.handlePointerMove);
     this.canvas.removeEventListener("pointerup", this.handlePointerUp);
+  }
+
+  private pushSnapshot(stack: Snapshot[], imageData: ImageData) {
+    const snapshot: Snapshot = {
+      image: imageData,
+      bytes: imageData.width * imageData.height * 4,
+    };
+    stack.push(snapshot);
+    this.historyByteUsage += snapshot.bytes;
+  }
+
+  private popSnapshot(stack: Snapshot[]) {
+    const snapshot = stack.pop();
+    if (snapshot) this.historyByteUsage -= snapshot.bytes;
+    return snapshot;
+  }
+
+  private shiftSnapshot(stack: Snapshot[]) {
+    const snapshot = stack.shift();
+    if (snapshot) this.historyByteUsage -= snapshot.bytes;
+    return snapshot;
+  }
+
+  private clearStack(stack: Snapshot[]) {
+    if (!stack.length) return;
+    for (const snapshot of stack) {
+      this.historyByteUsage -= snapshot.bytes;
+    }
+    stack.length = 0;
+  }
+
+  private enforceHistoryCap() {
+    if (this.historyMemoryCapBytes <= 0) {
+      if (this.historyByteUsage > 0) {
+        this.clearStack(this.undoStack);
+        this.clearStack(this.redoStack);
+      }
+      return;
+    }
+    if (!Number.isFinite(this.historyMemoryCapBytes)) {
+      return;
+    }
+    while (this.historyByteUsage > this.historyMemoryCapBytes) {
+      if (this.undoStack.length) {
+        this.shiftSnapshot(this.undoStack);
+        continue;
+      }
+      if (this.redoStack.length) {
+        this.shiftSnapshot(this.redoStack);
+        continue;
+      }
+      break;
+    }
   }
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,4 +1,4 @@
-import { Editor } from "./core/Editor.js";
+import { Editor, type EditorOptions } from "./core/Editor.js";
 import { Shortcuts } from "./core/Shortcuts.js";
 import { PencilTool } from "./tools/PencilTool.js";
 import { EraserTool } from "./tools/EraserTool.js";
@@ -30,11 +30,13 @@ export interface EditorHandle {
   destroy(): void;
 }
 
+export type EditorSettings = EditorOptions;
+
 /**
  * Initialize the editor by wiring up DOM controls and returning an
  * {@link EditorHandle} that allows tests or callers to tear down the editor.
  */
-export function initEditor(): EditorHandle {
+export function initEditor(settings: EditorSettings = {}): EditorHandle {
   const canvases = Array.from(
     document.querySelectorAll<HTMLCanvasElement>("canvas"),
   );
@@ -212,6 +214,7 @@ export function initEditor(): EditorHandle {
         },
         fontFamily ?? undefined,
         fontSize ?? undefined,
+        settings,
       );
       editors.push(e);
     } catch {

--- a/tests/historyMemoryCap.test.ts
+++ b/tests/historyMemoryCap.test.ts
@@ -1,0 +1,192 @@
+import { Editor } from "../src/core/Editor.js";
+import { initEditor, type EditorHandle } from "../src/editor.js";
+
+describe("history memory cap", () => {
+  let canvas: HTMLCanvasElement;
+  let colorPicker: HTMLInputElement;
+  let lineWidth: HTMLInputElement;
+  let fillMode: HTMLInputElement;
+  let ctx: Partial<CanvasRenderingContext2D>;
+  let editor: Editor;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <canvas id="canvas"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="1" />
+      <input id="fillMode" type="checkbox" />
+    `;
+    canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
+    lineWidth = document.getElementById("lineWidth") as HTMLInputElement;
+    fillMode = document.getElementById("fillMode") as HTMLInputElement;
+
+    (canvas as any).setPointerCapture = jest.fn();
+    (canvas as any).releasePointerCapture = jest.fn();
+    canvas.getBoundingClientRect = () => ({
+      width: 1,
+      height: 1,
+      top: 0,
+      left: 0,
+      right: 1,
+      bottom: 1,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+
+    ctx = {
+      getImageData: jest.fn(),
+      putImageData: jest.fn(),
+      clearRect: jest.fn(),
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+    };
+    canvas.getContext = jest
+      .fn()
+      .mockReturnValue(ctx as CanvasRenderingContext2D);
+  });
+
+  afterEach(() => {
+    editor?.destroy();
+  });
+
+  it("drops oldest undo snapshots when exceeding cap", () => {
+    const snapshots: ImageData[] = [];
+    (ctx.getImageData as jest.Mock).mockImplementation(() => {
+      const image = {
+        data: new Uint8ClampedArray(4),
+        width: 1,
+        height: 1,
+      } as ImageData;
+      snapshots.push(image);
+      return image;
+    });
+
+    editor = new Editor(
+      canvas,
+      colorPicker,
+      lineWidth,
+      fillMode,
+      undefined,
+      undefined,
+      undefined,
+      { historyMemoryCapBytes: 8 },
+    );
+
+    editor.saveState();
+    editor.saveState();
+    editor.saveState();
+
+    const undoStack = (editor as any).undoStack as Array<{ image: ImageData }>;
+    expect(undoStack).toHaveLength(2);
+    expect(undoStack[0].image).toBe(snapshots[1]);
+    expect(undoStack[1].image).toBe(snapshots[2]);
+  });
+
+  it("clears history when cap is zero", () => {
+    (ctx.getImageData as jest.Mock).mockImplementation(() => ({
+      data: new Uint8ClampedArray(4),
+      width: 1,
+      height: 1,
+    }) as ImageData);
+
+    editor = new Editor(
+      canvas,
+      colorPicker,
+      lineWidth,
+      fillMode,
+      undefined,
+      undefined,
+      undefined,
+      { historyMemoryCapBytes: 0 },
+    );
+
+    editor.saveState();
+    expect(editor.canUndo).toBe(false);
+    expect((editor as any).undoStack).toHaveLength(0);
+  });
+});
+
+describe("initEditor history settings", () => {
+  let handle: EditorHandle | null = null;
+  let canvas: HTMLCanvasElement;
+  let ctx: Partial<CanvasRenderingContext2D>;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="toolbar">
+        <button id="pencil"></button>
+        <button id="eraser"></button>
+        <button id="rectangle"></button>
+        <button id="line"></button>
+        <button id="circle"></button>
+        <button id="text"></button>
+        <button id="bucket"></button>
+        <button id="eyedropper"></button>
+      </div>
+      <canvas id="canvas"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="1" />
+      <input id="fillMode" type="checkbox" />
+      <select id="formatSelect"><option value="png">PNG</option></select>
+      <button id="save"></button>
+      <button id="undo"></button>
+      <button id="redo"></button>
+    `;
+
+    canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    (canvas as any).setPointerCapture = jest.fn();
+    (canvas as any).releasePointerCapture = jest.fn();
+    canvas.getBoundingClientRect = () => ({
+      width: 1,
+      height: 1,
+      top: 0,
+      left: 0,
+      right: 1,
+      bottom: 1,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+
+    ctx = {
+      getImageData: jest.fn(),
+      putImageData: jest.fn(),
+      clearRect: jest.fn(),
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+    };
+
+    canvas.getContext = jest
+      .fn()
+      .mockReturnValue(ctx as CanvasRenderingContext2D);
+    canvas.toDataURL = jest.fn().mockReturnValue("data:image/png;base64,TEST");
+  });
+
+  afterEach(() => {
+    handle?.destroy();
+    handle = null;
+  });
+
+  it("forwards history cap settings to editors", () => {
+    const snapshots: ImageData[] = [];
+    (ctx.getImageData as jest.Mock).mockImplementation(() => {
+      const image = {
+        data: new Uint8ClampedArray(4),
+        width: 1,
+        height: 1,
+      } as ImageData;
+      snapshots.push(image);
+      return image;
+    });
+
+    handle = initEditor({ historyMemoryCapBytes: 4 });
+    handle.editor.saveState();
+    handle.editor.saveState();
+
+    const undoStack = (handle.editor as any).undoStack as Array<{ image: ImageData }>;
+    expect(undoStack).toHaveLength(1);
+    expect(undoStack[0].image).toBe(snapshots[1]);
+  });
+});


### PR DESCRIPTION
## Summary
- track undo/redo snapshot memory usage and enforce a configurable cap in the editor
- allow callers to set the history memory cap through initEditor settings
- add unit tests covering history trimming and initEditor configuration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60d07d79c832884243ca4a10bbeaf