### PR TITLE
Add coverage enforcement and reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,16 @@ jobs:
       - run: npm run lint
       - run: npm run format:check
       - run: npm test
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          path-to-lcov: ./coverage/lcov.info
+          repo-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage/lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Photoshop Clone
 
 [![CI](https://github.com/openai/photoshop-clone/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openai/photoshop-clone/actions/workflows/ci.yml)
+[![Coveralls coverage](https://coveralls.io/repos/github/openai/photoshop-clone/badge.svg?branch=main)](https://coveralls.io/github/openai/photoshop-clone?branch=main)
+[![Codecov](https://codecov.io/gh/openai/photoshop-clone/branch/main/graph/badge.svg)](https://codecov.io/gh/openai/photoshop-clone)
 
 A simple Photoshop-like web application built with HTML5 Canvas, CSS, and JavaScript.
 
@@ -107,7 +109,7 @@ npm run lint
 
 ## Running Tests
 
-Execute the test suite:
+Execute the test suite (coverage thresholds require at least 90% statements/lines/functions and 70% branches):
 
 ```bash
 npm test

--- a/package.json
+++ b/package.json
@@ -26,6 +26,20 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "jsdom",
+    "collectCoverage": true,
+    "coverageDirectory": "coverage",
+    "coverageReporters": [
+      "text",
+      "lcov"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 70,
+        "functions": 90,
+        "lines": 90,
+        "statements": 90
+      }
+    },
     "globals": {
       "ts-jest": {
         "useESM": true,


### PR DESCRIPTION
## Summary
- enable Jest coverage collection with minimum thresholds so the suite fails when coverage drops
- publish coverage results to Coveralls and Codecov from the CI workflow using repository tokens
- document the coverage badges and thresholds in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60d3943b083289458549adbec78f7