### PR TITLE
Build and publish dist directory for Pages releases

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -2,9 +2,10 @@
 name: Deploy static content to Pages
 
 on:
-  # Runs on pushes targeting the default branch
+  # Runs on pushes targeting the default branch or version tags
   push:
     branches: ["main"]
+    tags: ["v*"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -31,13 +32,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.0
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.0.0
+        with:
+          node-version: "20"
+          cache: "npm"
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
       - name: Setup Pages
         uses: actions/configure-pages@v5.0.0
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3.0.0
         with:
-          # Upload entire repository
-          path: '.'
+          # Upload compiled site
+          path: 'dist'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4.0.0

--- a/README.md
+++ b/README.md
@@ -119,6 +119,17 @@ Open `index.html` in your browser to use the app.
 
 Build the project and publish the `dist` directory to the `gh-pages` branch to deploy on GitHub Pages.
 
+### Creating a Release Tag
+
+1. Ensure all desired changes are merged into `main`.
+2. Run `npm ci && npm run build` locally to verify the build succeeds.
+3. Create an annotated tag following the `vX.Y.Z` convention, for example:
+   ```bash
+   git tag -a v1.2.3 -m "Release v1.2.3"
+   git push origin v1.2.3
+   ```
+4. Pushing the tag triggers the Pages deployment workflow, which builds the project and publishes the `dist/` directory.
+
 ## Lifecycle
 
 `initEditor()` returns an object containing the editor instance and a `destroy` function.


### PR DESCRIPTION
## Summary
- trigger the Pages deployment workflow on version tags and install/build before deployment
- publish the built dist/ directory when uploading the Pages artifact
- document the release tagging process in the README

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d60d383c308328896b44b44d68ec47