### PR TITLE
Add accessibility tests for toolbar and dialogs

### DIFF
--- a/dist/editor.js
+++ b/dist/editor.js
@@ -76,6 +76,9 @@ export function initEditor() {
     const saveBtn = document.getElementById("save");
     const formatSelect = document.getElementById("formatSelect");
     const colorHistory = document.getElementById("colorHistory");
+    const shortcutsButton = document.getElementById("openShortcuts");
+    const shortcutsDialog = document.getElementById("shortcutsDialog");
+    const shortcutsCloseButton = shortcutsDialog?.querySelector("[data-dialog-close]") ?? null;
     if (!colorPicker) {
         throw new Error("Missing #colorPicker input");
     }
@@ -130,6 +133,7 @@ export function initEditor() {
             return;
         colorHistory.innerHTML = "";
         recentColors.forEach((color) => {
+            const item = document.createElement("li");
             const btn = document.createElement("button");
             btn.type = "button";
             btn.className = "color-swatch";
@@ -139,7 +143,8 @@ export function initEditor() {
                 colorPicker.value = color;
                 colorPicker.dispatchEvent(new Event("input"));
             });
-            colorHistory.appendChild(btn);
+            item.appendChild(btn);
+            colorHistory.appendChild(item);
         });
     };
     const recordColor = (color) => {
@@ -234,6 +239,45 @@ export function initEditor() {
         a.download = `canvas.${format === "jpeg" ? "jpg" : "png"}`;
         a.click();
     }, listeners);
+    if (shortcutsButton && shortcutsDialog) {
+        const openDialog = () => {
+            if (typeof shortcutsDialog.showModal === "function") {
+                shortcutsDialog.showModal();
+            }
+            else {
+                shortcutsDialog.setAttribute("open", "");
+            }
+            const initialFocus = shortcutsDialog.querySelector("[data-initial-focus]") ??
+                shortcutsCloseButton ??
+                shortcutsDialog;
+            initialFocus?.focus();
+        };
+        listen(shortcutsButton, "click", () => {
+            openDialog();
+        }, listeners);
+        if (shortcutsCloseButton) {
+            listen(shortcutsCloseButton, "click", () => {
+                if (typeof shortcutsDialog.close === "function") {
+                    shortcutsDialog.close();
+                }
+                else {
+                    shortcutsDialog.removeAttribute("open");
+                }
+            }, listeners);
+        }
+        listen(shortcutsDialog, "cancel", (event) => {
+            event.preventDefault();
+            if (typeof shortcutsDialog.close === "function") {
+                shortcutsDialog.close();
+            }
+            else {
+                shortcutsDialog.removeAttribute("open");
+            }
+        }, listeners);
+        listen(shortcutsDialog, "close", () => {
+            shortcutsButton.focus();
+        }, listeners);
+    }
     // image loading
     const imageLoader = document.getElementById("imageLoader");
     listen(imageLoader, "change", (e) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,11 @@
         "@types/jest": "^29.5.11",
         "@typescript-eslint/eslint-plugin": "^6.7.0",
         "@typescript-eslint/parser": "^6.7.0",
+        "axe-core": "^4.8.4",
         "eslint": "^8.48.0",
         "eslint-config-prettier": "^9.0.0",
         "jest": "^29.7.0",
+        "jest-axe": "^7.0.1",
         "jest-environment-jsdom": "^29.7.0",
         "prettier": "^3.0.0",
         "ts-jest": "^29.2.3",
@@ -1880,6 +1882,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -3739,6 +3751,48 @@
         "node-notifier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jest-axe": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-7.0.1.tgz",
+      "integrity": "sha512-1JoEla6gL4rcsTxEWm+VBcWMwOhP3f9w4dH7/YW3H41nU08Dds3gUFqxgdAq/pzBNPpauC3QPr/BuO+0W8eamg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axe-core": "4.5.1",
+        "chalk": "4.1.2",
+        "jest-matcher-utils": "29.2.2",
+        "lodash.merge": "4.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/axe-core": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.1.tgz",
+      "integrity": "sha512-1exVbW0X1O/HSr/WMwnaweyqcWOgZgLiVxdLG34pvSQk4NlYQr9OUy0JLwuhFfuVNQzzqgH57eYzkFBCb3bIsQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jest-axe/node_modules/jest-matcher-utils": {
+      "version": "29.2.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.2.2.tgz",
+      "integrity": "sha512-4DkJ1sDPT+UX2MR7Y3od6KtvRi9Im1ZGLGgdLFLm4lPexbTaCgJW5NN3IOXlQHF7NSHY/VHhflQ+WoKtD/vyCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.2.1",
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.2.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-changed-files": {

--- a/package.json
+++ b/package.json
@@ -21,11 +21,16 @@
     "@types/jest": "^29.5.11",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.3",
-    "jest-environment-jsdom": "^29.7.0"
+    "jest-environment-jsdom": "^29.7.0",
+    "axe-core": "^4.8.4",
+    "jest-axe": "^7.0.1"
   },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "jsdom",
+    "setupFilesAfterEnv": [
+      "<rootDir>/tests/setupAxe.ts"
+    ],
     "globals": {
       "ts-jest": {
         "useESM": true,

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -98,7 +98,16 @@ export function initEditor(): EditorHandle {
     document.getElementById("formatSelect") as HTMLSelectElement | null;
   const colorHistory = document.getElementById(
     "colorHistory",
-  ) as HTMLDivElement | null;
+  ) as HTMLUListElement | null;
+  const shortcutsButton = document.getElementById(
+    "openShortcuts",
+  ) as HTMLButtonElement | null;
+  const shortcutsDialog = document.getElementById(
+    "shortcutsDialog",
+  ) as HTMLDialogElement | null;
+  const shortcutsCloseButton = shortcutsDialog?.querySelector<HTMLButtonElement>(
+    "[data-dialog-close]",
+  ) ?? null;
 
   if (!colorPicker) {
     throw new Error("Missing #colorPicker input");
@@ -162,6 +171,7 @@ export function initEditor(): EditorHandle {
     if (!colorHistory) return;
     colorHistory.innerHTML = "";
     recentColors.forEach((color) => {
+      const item = document.createElement("li");
       const btn = document.createElement("button");
       btn.type = "button";
       btn.className = "color-swatch";
@@ -171,7 +181,8 @@ export function initEditor(): EditorHandle {
         colorPicker.value = color;
         colorPicker.dispatchEvent(new Event("input"));
       });
-      colorHistory.appendChild(btn);
+      item.appendChild(btn);
+      colorHistory.appendChild(item);
     });
   };
 
@@ -310,6 +321,68 @@ export function initEditor(): EditorHandle {
     },
     listeners,
   );
+
+  if (shortcutsButton && shortcutsDialog) {
+    const openDialog = () => {
+      if (typeof shortcutsDialog.showModal === "function") {
+        shortcutsDialog.showModal();
+      } else {
+        shortcutsDialog.setAttribute("open", "");
+      }
+      const initialFocus =
+        shortcutsDialog.querySelector<HTMLElement>("[data-initial-focus]") ??
+        shortcutsCloseButton ??
+        shortcutsDialog;
+      initialFocus?.focus();
+    };
+
+    listen(
+      shortcutsButton,
+      "click",
+      () => {
+        openDialog();
+      },
+      listeners,
+    );
+
+    if (shortcutsCloseButton) {
+      listen(
+        shortcutsCloseButton,
+        "click",
+        () => {
+          if (typeof shortcutsDialog.close === "function") {
+            shortcutsDialog.close();
+          } else {
+            shortcutsDialog.removeAttribute("open");
+          }
+        },
+        listeners,
+      );
+    }
+
+    listen(
+      shortcutsDialog,
+      "cancel",
+      (event: Event) => {
+        event.preventDefault();
+        if (typeof shortcutsDialog.close === "function") {
+          shortcutsDialog.close();
+        } else {
+          shortcutsDialog.removeAttribute("open");
+        }
+      },
+      listeners,
+    );
+
+    listen(
+      shortcutsDialog,
+      "close",
+      () => {
+        shortcutsButton.focus();
+      },
+      listeners,
+    );
+  }
 
   // image loading
   const imageLoader = document.getElementById("imageLoader") as HTMLInputElement | null;

--- a/style.css
+++ b/style.css
@@ -1,3 +1,15 @@
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 button:focus-visible, input:focus-visible {
   outline: 2px solid #1e90ff;
   outline-offset: 2px;
@@ -26,6 +38,13 @@ body {
   display: flex;
   align-items: center;
   gap: 4px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+#colorHistory li {
+  display: contents;
 }
 
 .color-swatch {
@@ -97,6 +116,37 @@ body {
   width: 100%;
   height: 100%;
   box-sizing: border-box;
+}
+
+dialog {
+  border: none;
+  border-radius: 8px;
+  padding: 24px;
+  max-width: 420px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+}
+
+dialog::backdrop {
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.dialog-actions {
+  margin-top: 16px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.dialog-actions button {
+  padding: 6px 12px;
+  border: 1px solid #007bff;
+  background: #007bff;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.dialog-actions button:hover {
+  background: #005bb5;
 }
 
 

--- a/tests/dialog.accessibility.test.ts
+++ b/tests/dialog.accessibility.test.ts
@@ -1,0 +1,53 @@
+import { initEditor, type EditorHandle } from "../src/editor.js";
+import { expectNoAxeViolations } from "./utils/axe.js";
+import { renderAccessibleEditorDom } from "./utils/dom.js";
+
+describe("keyboard shortcuts dialog", () => {
+  let handle: EditorHandle | null = null;
+
+  afterEach(() => {
+    handle?.destroy();
+    handle = null;
+    document.body.innerHTML = "";
+  });
+
+  it("opens and restores focus when closed", () => {
+    renderAccessibleEditorDom();
+    handle = initEditor();
+
+    const dialog = document.getElementById("shortcutsDialog") as HTMLDialogElement;
+    const openButton = document.getElementById("openShortcuts") as HTMLButtonElement;
+    const closeButton = dialog.querySelector<HTMLButtonElement>("[data-dialog-close]");
+    expect(closeButton).not.toBeNull();
+
+    dialog.showModal = jest.fn(() => {
+      dialog.setAttribute("open", "");
+    });
+    dialog.close = jest.fn(() => {
+      dialog.removeAttribute("open");
+      dialog.dispatchEvent(new Event("close"));
+    });
+
+    const focusSpy = jest.spyOn(openButton, "focus");
+
+    openButton.click();
+    expect(dialog.showModal).toHaveBeenCalled();
+    expect(dialog.hasAttribute("open")).toBe(true);
+
+    closeButton!.click();
+    expect(dialog.close).toHaveBeenCalled();
+    expect(dialog.hasAttribute("open")).toBe(false);
+    expect(focusSpy).toHaveBeenCalled();
+  });
+
+  it("has no axe-core violations when displayed", async () => {
+    renderAccessibleEditorDom();
+    handle = initEditor();
+
+    const dialog = document.getElementById("shortcutsDialog");
+    expect(dialog).not.toBeNull();
+    dialog!.setAttribute("open", "");
+
+    await expectNoAxeViolations(dialog!, "keyboard shortcuts dialog");
+  });
+});

--- a/tests/eyedropperTool.test.ts
+++ b/tests/eyedropperTool.test.ts
@@ -137,12 +137,12 @@ describe("EyedropperTool color history", () => {
   });
 
   it("records sampled colors in the color history", () => {
-    const history = document.getElementById("colorHistory") as HTMLDivElement;
-    expect(history.children).toHaveLength(1);
+    const history = document.getElementById("colorHistory") as HTMLUListElement;
+    expect(history.querySelectorAll("button")).toHaveLength(1);
     const tool = new EyedropperTool();
     tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, handle.editor);
-    expect(history.children).toHaveLength(2);
-    const swatch = history.children[0] as HTMLButtonElement;
+    expect(history.querySelectorAll("button")).toHaveLength(2);
+    const swatch = history.querySelector("li:first-child button") as HTMLButtonElement;
     expect(swatch.style.backgroundColor).toBe("rgb(12, 34, 56)");
   });
 });

--- a/tests/setupAxe.ts
+++ b/tests/setupAxe.ts
@@ -1,0 +1,3 @@
+import { toHaveNoViolations } from "jest-axe";
+
+expect.extend(toHaveNoViolations);

--- a/tests/toolbar.accessibility.test.ts
+++ b/tests/toolbar.accessibility.test.ts
@@ -1,0 +1,23 @@
+import { initEditor, type EditorHandle } from "../src/editor.js";
+import { expectNoAxeViolations } from "./utils/axe.js";
+import { renderAccessibleEditorDom } from "./utils/dom.js";
+
+describe("toolbar accessibility", () => {
+  let handle: EditorHandle | null = null;
+
+  afterEach(() => {
+    handle?.destroy();
+    handle = null;
+    document.body.innerHTML = "";
+  });
+
+  it("has no axe-core violations", async () => {
+    renderAccessibleEditorDom();
+
+    handle = initEditor();
+
+    const toolbar = document.getElementById("toolbar");
+    expect(toolbar).not.toBeNull();
+    await expectNoAxeViolations(toolbar!, "toolbar");
+  });
+});

--- a/tests/utils/axe.ts
+++ b/tests/utils/axe.ts
@@ -1,0 +1,31 @@
+import { axe, AxeResults } from "jest-axe";
+
+function formatViolations(results: AxeResults, context: string): string {
+  return results.violations
+    .map((violation) => {
+      const nodes = violation.nodes
+        .map((node) => `    • Affected node(s): ${node.target.join(", ")}`)
+        .join("\n");
+      return [
+        `${violation.id}: ${violation.help}.`,
+        `    Fix guidance: ${violation.helpUrl}`,
+        nodes,
+      ]
+        .filter(Boolean)
+        .join("\n");
+    })
+    .join("\n\n");
+}
+
+export async function expectNoAxeViolations(
+  element: Element | Document,
+  context: string,
+) {
+  const results = await axe(element);
+  if (results.violations.length > 0) {
+    const details = formatViolations(results, context);
+    throw new Error(
+      `Accessibility issues detected in ${context}. Please address the following:\n${details}`,
+    );
+  }
+}

--- a/tests/utils/dom.ts
+++ b/tests/utils/dom.ts
@@ -1,38 +1,17 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Photoshop Clone</title>
-    <link rel="stylesheet" href="style.css" />
-  </head>
-  <body>
+export function renderAccessibleEditorDom() {
+  document.body.innerHTML = `
     <div id="toolbar" role="toolbar" aria-label="Drawing controls">
       <div class="group">
         <label class="visually-hidden" for="colorPicker">Stroke color</label>
-        <input
-          type="color"
-          id="colorPicker"
-          aria-describedby="colorPickerHint"
-        />
-        <span id="colorPickerHint" class="visually-hidden"
-          >Choose the drawing color.</span
-        >
+        <input type="color" id="colorPicker" value="#000000" aria-describedby="colorPickerHint" />
+        <span id="colorPickerHint" class="visually-hidden">Choose the drawing color.</span>
         <p id="colorHistoryLabel" class="visually-hidden">Recent colors</p>
-        <ul
-          id="colorHistory"
-          aria-labelledby="colorHistoryLabel"
-          aria-live="polite"
-        ></ul>
+        <ul id="colorHistory" aria-labelledby="colorHistoryLabel" aria-live="polite"></ul>
       </div>
-
       <div class="group">
-        <label class="visually-hidden" for="lineWidth"
-          >Line width (pixels)</label
-        >
-        <input type="number" id="lineWidth" min="1" value="1" />
+        <label class="visually-hidden" for="lineWidth">Line width (pixels)</label>
+        <input type="number" id="lineWidth" min="1" value="2" />
       </div>
-
       <div class="group">
         <label class="visually-hidden" for="fontFamily">Font family</label>
         <select id="fontFamily">
@@ -41,17 +20,14 @@
           <option value="monospace">Monospace</option>
         </select>
       </div>
-
       <div class="group">
         <label class="visually-hidden" for="fontSize">Font size (pixels)</label>
         <input type="number" id="fontSize" min="1" value="16" />
       </div>
-
       <div class="group">
         <input type="checkbox" id="fillMode" />
         <label for="fillMode">Fill shapes</label>
       </div>
-
       <button id="pencil" class="tool-button" title="Pencil">
         <img src="icons/pencil.svg" alt="Pencil" />
       </button>
@@ -76,26 +52,20 @@
       <button id="bucket" class="tool-button" title="Bucket">
         <img src="icons/paint-bucket.svg" alt="Bucket" />
       </button>
-
       <div class="group">
-        <label class="visually-hidden" for="imageLoader"
-          >Import image</label
-        >
+        <label class="visually-hidden" for="imageLoader">Import image</label>
         <input type="file" id="imageLoader" accept="image/*" />
       </div>
-
       <button id="undo" class="tool-button" title="Undo" disabled>
         <img src="icons/undo.svg" alt="Undo" />
       </button>
       <button id="redo" class="tool-button" title="Redo" disabled>
         <img src="icons/redo.svg" alt="Redo" />
       </button>
-
       <div class="group" role="group" aria-labelledby="layerSelectLabel">
         <label id="layerSelectLabel" for="layerSelect">Layer</label>
         <select id="layerSelect"></select>
       </div>
-
       <div class="group">
         <label class="visually-hidden" for="formatSelect">Export format</label>
         <select id="formatSelect">
@@ -103,32 +73,17 @@
           <option value="jpeg">JPEG</option>
         </select>
       </div>
-
       <button id="save" class="tool-button" title="Save" type="button">
         <img src="icons/save.svg" alt="Save" />
       </button>
-
-      <button
-        id="openShortcuts"
-        class="tool-button"
-        type="button"
-        aria-haspopup="dialog"
-        aria-controls="shortcutsDialog"
-      >
+      <button id="openShortcuts" class="tool-button" type="button" aria-haspopup="dialog" aria-controls="shortcutsDialog">
         Shortcuts
       </button>
     </div>
-    <dialog
-      id="shortcutsDialog"
-      aria-labelledby="shortcutsDialogTitle"
-      aria-describedby="shortcutsDialogDescription"
-      aria-modal="true"
-    >
+    <dialog id="shortcutsDialog" aria-labelledby="shortcutsDialogTitle" aria-describedby="shortcutsDialogDescription" aria-modal="true">
       <form method="dialog">
         <h2 id="shortcutsDialogTitle">Keyboard shortcuts</h2>
-        <p id="shortcutsDialogDescription">
-          Use these keys to quickly switch tools and undo actions.
-        </p>
+        <p id="shortcutsDialogDescription">Use these keys to quickly switch tools and undo actions.</p>
         <dl>
           <div>
             <dt><kbd>P</kbd></dt>
@@ -152,31 +107,41 @@
           </div>
         </dl>
         <div class="dialog-actions">
-          <button
-            type="button"
-            value="close"
-            data-dialog-close
-            data-initial-focus
-          >
-            Close
-          </button>
+          <button type="button" value="close" data-dialog-close data-initial-focus>Close</button>
         </div>
       </form>
     </dialog>
-    <div id="canvasContainer">
-      <canvas
-        id="canvas"
-        width="800"
-        height="600"
-        aria-label="Primary drawing layer"
-      ></canvas>
-      <canvas
-        id="layer2"
-        width="800"
-        height="600"
-        aria-label="Secondary drawing layer"
-      ></canvas>
-    </div>
-    <script type="module" src="dist/index.js"></script>
-  </body>
-</html>
+    <canvas id="canvas" width="800" height="600" aria-label="Primary drawing layer"></canvas>
+    <canvas id="layer2" width="800" height="600" aria-label="Secondary drawing layer"></canvas>
+  `;
+
+  const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+  const canvas2 = document.getElementById("layer2") as HTMLCanvasElement;
+  const ctx = {
+    setTransform: jest.fn(),
+    scale: jest.fn(),
+    getImageData: jest.fn(),
+    putImageData: jest.fn(),
+    clearRect: jest.fn(),
+    drawImage: jest.fn(),
+  } as Partial<CanvasRenderingContext2D>;
+  const ctx2 = { ...ctx } as Partial<CanvasRenderingContext2D>;
+
+  [canvas, canvas2].forEach((c, index) => {
+    c.getContext = jest
+      .fn()
+      .mockReturnValue((index === 0 ? ctx : ctx2) as CanvasRenderingContext2D);
+    c.getBoundingClientRect = () => ({
+      width: 800,
+      height: 600,
+      top: 0,
+      left: 0,
+      bottom: 600,
+      right: 800,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+  });
+  return { canvas, canvas2 };
+}


### PR DESCRIPTION
## Summary
- add axe-core based accessibility tooling to Jest via setup file and shared helper
- improve toolbar markup with accessible labels and add a shortcuts dialog with supporting styles and logic
- add axe-core checks for toolbar and dialog plus update color history tests for the new markup

## Testing
- npm run build
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d60d37007c83289216a904259902f1