### PR TITLE
Add Jest performance harness with budgets for heavy operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "@types/jest": "^29.5.11",
+        "@types/node": "^20.11.30",
         "@typescript-eslint/eslint-plugin": "^6.7.0",
         "@typescript-eslint/parser": "^6.7.0",
         "eslint": "^8.48.0",
@@ -1443,13 +1444,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.2.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
-      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "version": "20.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
+      "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.10.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/semver": {
@@ -5809,9 +5810,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2",
     "@types/jest": "^29.5.11",
+    "@types/node": "^20.11.30",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.3",
     "jest-environment-jsdom": "^29.7.0"

--- a/tests/performance/budgets.ts
+++ b/tests/performance/budgets.ts
@@ -1,0 +1,27 @@
+export interface PerformanceBudget {
+  /**
+   * Human readable description of what the measurement captures.
+   */
+  description: string;
+  /**
+   * Maximum allowed duration in milliseconds.
+   */
+  thresholdMs: number;
+}
+
+export type BudgetName = keyof typeof PERFORMANCE_BUDGETS;
+
+export const PERFORMANCE_BUDGETS = {
+  "bucketFill.largeArea": {
+    description: "Flood filling a 1000x1000 canvas region",
+    thresholdMs: 300,
+  },
+  "editor.resize.4k": {
+    description: "Resizing a 2048x2048 canvas and rehydrating pixels",
+    thresholdMs: 350,
+  },
+} as const satisfies Record<string, PerformanceBudget>;
+
+export function getBudget(name: BudgetName): PerformanceBudget {
+  return PERFORMANCE_BUDGETS[name];
+}

--- a/tests/performance/harness.ts
+++ b/tests/performance/harness.ts
@@ -1,0 +1,73 @@
+import { performance } from "node:perf_hooks";
+import fs from "node:fs";
+import path from "node:path";
+
+import { type BudgetName, getBudget } from "./budgets.js";
+
+export interface PerformanceResult {
+  name: BudgetName;
+  durationMs: number;
+  thresholdMs: number;
+  pass: boolean;
+  description: string;
+  metadata?: Record<string, unknown>;
+}
+
+const results: PerformanceResult[] = [];
+
+function toMillis(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+export async function measurePerformance(
+  name: BudgetName,
+  fn: () => void | Promise<void>,
+  metadata?: Record<string, unknown>,
+): Promise<PerformanceResult> {
+  const budget = getBudget(name);
+  const start = performance.now();
+  await fn();
+  const duration = performance.now() - start;
+  const durationMs = toMillis(duration);
+  const pass = durationMs <= budget.thresholdMs;
+
+  const result: PerformanceResult = {
+    name,
+    durationMs,
+    thresholdMs: budget.thresholdMs,
+    pass,
+    description: budget.description,
+    metadata,
+  };
+
+  results.push(result);
+
+  if (!pass) {
+    const context = metadata ? ` Metadata: ${JSON.stringify(metadata)}.` : "";
+    throw new Error(
+      `[Performance budget exceeded] ${name} took ${durationMs}ms (budget ${budget.thresholdMs}ms). ${budget.description}.${context}`,
+    );
+  }
+
+  return result;
+}
+
+export function flushPerformanceResults(): string | undefined {
+  if (!results.length) return undefined;
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    results,
+  };
+
+  const destination =
+    process.env.PERFORMANCE_REPORT_PATH ??
+    path.join(process.cwd(), "dist", "performance-report.json");
+
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.writeFileSync(destination, JSON.stringify(report, null, 2));
+  console.info(
+    `Performance report written to ${destination}:\n${JSON.stringify(report, null, 2)}`,
+  );
+  return destination;
+}

--- a/tests/performance/performanceBudget.test.ts
+++ b/tests/performance/performanceBudget.test.ts
@@ -1,0 +1,126 @@
+import { Editor } from "../../src/core/Editor.js";
+import { BucketFillTool } from "../../src/tools/BucketFillTool.js";
+import { measurePerformance, flushPerformanceResults } from "./harness.js";
+
+function createCanvas(width: number, height: number) {
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  canvas.getBoundingClientRect = () => ({
+    width,
+    height,
+    top: 0,
+    left: 0,
+    right: width,
+    bottom: height,
+    x: 0,
+    y: 0,
+    toJSON() {
+      return this;
+    },
+  });
+  (canvas as unknown as { setPointerCapture: () => void }).setPointerCapture = () => {};
+  (canvas as unknown as { releasePointerCapture: () => void }).releasePointerCapture = () => {};
+  return canvas;
+}
+
+function createImage(width: number, height: number, color: [number, number, number, number]) {
+  const data = new Uint8ClampedArray(width * height * 4);
+  for (let i = 0; i < width * height; i++) {
+    const idx = i * 4;
+    data[idx] = color[0];
+    data[idx + 1] = color[1];
+    data[idx + 2] = color[2];
+    data[idx + 3] = color[3];
+  }
+  return { data, width, height } as ImageData;
+}
+
+describe("Performance budgets", () => {
+  afterAll(() => {
+    flushPerformanceResults();
+  });
+
+  it("fills large canvases within the bucket fill budget", async () => {
+    const width = 1000;
+    const height = 1000;
+    const canvas = createCanvas(width, height);
+
+    const image = createImage(width, height, [255, 255, 255, 255]);
+    const ctx: Partial<CanvasRenderingContext2D> = {
+      getImageData: jest.fn().mockReturnValue(image),
+      putImageData: jest.fn(),
+      clearRect: jest.fn(),
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+    };
+    canvas.getContext = jest.fn().mockReturnValue(ctx as CanvasRenderingContext2D);
+
+    const colorPicker = document.createElement("input");
+    colorPicker.value = "#1234ff";
+    const lineWidth = document.createElement("input");
+    lineWidth.value = "1";
+    const fillMode = document.createElement("input");
+    fillMode.type = "checkbox";
+
+    const editor = new Editor(canvas, colorPicker, lineWidth, fillMode);
+
+    const tool = new BucketFillTool();
+
+    await measurePerformance(
+      "bucketFill.largeArea",
+      () => {
+        tool.onPointerDown({ offsetX: width / 2, offsetY: height / 2 } as PointerEvent, editor);
+      },
+      { pixels: width * height },
+    );
+
+    const lastPixel = ((width * height - 1) * 4) as number;
+    expect(image.data[lastPixel]).toBe(18);
+    expect(image.data[lastPixel + 1]).toBe(52);
+    expect(image.data[lastPixel + 2]).toBe(255);
+    expect(ctx.putImageData).toHaveBeenCalledWith(image, 0, 0);
+
+    editor.destroy();
+  });
+
+  it("handles 4k resize operations within the transform budget", async () => {
+    const width = 2048;
+    const height = 2048;
+    const canvas = createCanvas(width, height);
+
+    const image = createImage(width, height, [0, 0, 0, 255]);
+    const ctx: Partial<CanvasRenderingContext2D> = {
+      getImageData: jest.fn().mockReturnValue(image),
+      putImageData: jest.fn(),
+      clearRect: jest.fn(),
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+    };
+    canvas.getContext = jest.fn().mockReturnValue(ctx as CanvasRenderingContext2D);
+
+    const colorPicker = document.createElement("input");
+    colorPicker.value = "#000000";
+    const lineWidth = document.createElement("input");
+    lineWidth.value = "1";
+    const fillMode = document.createElement("input");
+    fillMode.type = "checkbox";
+
+    const editor = new Editor(canvas, colorPicker, lineWidth, fillMode);
+
+    const handleResize = (editor as unknown as { handleResize: () => void }).handleResize;
+
+    await measurePerformance(
+      "editor.resize.4k",
+      () => {
+        handleResize.call(editor);
+      },
+      { width, height, pixels: width * height },
+    );
+
+    expect(ctx.getImageData).toHaveBeenCalled();
+    expect(ctx.putImageData).toHaveBeenCalledWith(image, 0, 0);
+
+    editor.destroy();
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable performance budget definitions and harness utilities that record results
- add Jest performance tests covering bucket fill and resize operations with CI-failing budgets
- include Node type definitions needed by the new harness

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60d3521608328a8825f4764eb93a3