### PR TITLE
Add fast-check flood fill fuzz tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@typescript-eslint/parser": "^6.7.0",
         "eslint": "^8.48.0",
         "eslint-config-prettier": "^9.0.0",
+        "fast-check": "^4.3.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "prettier": "^3.0.0",
@@ -2917,6 +2918,46 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/fast-check": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.3.0.tgz",
+      "integrity": "sha512-JVw/DJSxVKl8uhCb7GrwanT9VWsCIdBkK3WpP37B/Au4pyaspriSjtrY2ApbSFwTg3ViPfniT13n75PhzE7VEQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -3,25 +3,24 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-
   "scripts": {
     "build": "tsc",
     "lint": "eslint 'src/**/*.{ts,js}'",
     "test": "jest"
   },
-
   "devDependencies": {
+    "@types/jest": "^29.5.11",
     "@typescript-eslint/eslint-plugin": "^6.7.0",
     "@typescript-eslint/parser": "^6.7.0",
     "eslint": "^8.48.0",
     "eslint-config-prettier": "^9.0.0",
-    "prettier": "^3.0.0",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.2.2",
-    "@types/jest": "^29.5.11",
+    "fast-check": "^4.3.0",
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "prettier": "^3.0.0",
     "ts-jest": "^29.2.3",
-    "jest-environment-jsdom": "^29.7.0"
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
   },
   "jest": {
     "preset": "ts-jest",

--- a/src/core/floodFill.ts
+++ b/src/core/floodFill.ts
@@ -1,0 +1,156 @@
+export type Connectivity = 4 | 8;
+
+export interface FloodFillOptions {
+  /** Maximum per-channel distance (inclusive) allowed between the seed color and a pixel. */
+  tolerance?: number;
+  /** Determines whether diagonal neighbours are considered connected. */
+  connectivity?: Connectivity;
+  /** Hard cap of pixels that may be processed before aborting. */
+  maxPixels?: number;
+}
+
+export interface FloodFillResult {
+  filledPixels: number;
+  aborted: boolean;
+}
+
+const DEFAULT_OPTIONS: Required<Omit<FloodFillOptions, "maxPixels">> & { maxPixels: number } = {
+  tolerance: 0,
+  connectivity: 4,
+  maxPixels: Number.POSITIVE_INFINITY,
+};
+
+export function floodFill(
+  image: ImageData,
+  startX: number,
+  startY: number,
+  fillColor: readonly [number, number, number, number?],
+  options: FloodFillOptions = {},
+): FloodFillResult {
+  const { width, height, data } = image;
+  if (width === 0 || height === 0) {
+    return { filledPixels: 0, aborted: false };
+  }
+
+  const { tolerance, connectivity, maxPixels } = { ...DEFAULT_OPTIONS, ...options };
+  const clampedTolerance = Math.max(0, Math.min(255, Math.floor(tolerance)));
+  const maxProcessable = Number.isFinite(maxPixels) && maxPixels >= 0 ? Math.floor(maxPixels) : DEFAULT_OPTIONS.maxPixels;
+
+  const sx = Math.max(0, Math.min(width - 1, Math.floor(startX)));
+  const sy = Math.max(0, Math.min(height - 1, Math.floor(startY)));
+  const startIndex = sy * width + sx;
+  const startOffset = startIndex * 4;
+
+  const targetR = data[startOffset];
+  const targetG = data[startOffset + 1];
+  const targetB = data[startOffset + 2];
+  const targetA = data[startOffset + 3];
+
+  const fillR = clamp255(fillColor[0]);
+  const fillG = clamp255(fillColor[1]);
+  const fillB = clamp255(fillColor[2]);
+  const fillA = clamp255(fillColor[3] ?? 255);
+
+  if (
+    Math.abs(fillR - targetR) <= clampedTolerance &&
+    Math.abs(fillG - targetG) <= clampedTolerance &&
+    Math.abs(fillB - targetB) <= clampedTolerance &&
+    Math.abs(fillA - targetA) <= clampedTolerance
+  ) {
+    return { filledPixels: 0, aborted: false };
+  }
+
+  const maxPixelsCount = width * height;
+  const queue = new Uint32Array(maxPixelsCount);
+  const visited = new Uint8Array(maxPixelsCount);
+  let head = 0;
+  let tail = 0;
+  let processed = 0;
+  let aborted = false;
+
+  queue[tail++] = startIndex;
+  visited[startIndex] = 1;
+
+  const offsets = connectivity === 8 ? getEightNeighbourOffsets(width) : getFourNeighbourOffsets(width);
+
+  while (head < tail) {
+    const idx = queue[head++];
+    const offset = idx * 4;
+
+    if (!withinTolerance(data, offset, targetR, targetG, targetB, targetA, clampedTolerance)) {
+      continue;
+    }
+
+    data[offset] = fillR;
+    data[offset + 1] = fillG;
+    data[offset + 2] = fillB;
+    data[offset + 3] = fillA;
+    processed++;
+    if (processed > maxPixelsCount || (maxProcessable !== DEFAULT_OPTIONS.maxPixels && processed > maxProcessable)) {
+      aborted = true;
+      break;
+    }
+
+    for (let i = 0; i < offsets.length; i++) {
+      const neighbour = idx + offsets[i];
+      if (neighbour < 0 || neighbour >= maxPixelsCount) continue;
+      if (connectivity === 4) {
+        if (!areFourConnected(idx, neighbour, width)) continue;
+      } else if (!areEightConnected(idx, neighbour, width)) {
+        continue;
+      }
+      if (!visited[neighbour]) {
+        queue[tail++] = neighbour;
+        visited[neighbour] = 1;
+      }
+    }
+  }
+
+  return { filledPixels: processed, aborted };
+}
+
+function withinTolerance(
+  data: Uint8ClampedArray,
+  offset: number,
+  r: number,
+  g: number,
+  b: number,
+  a: number,
+  tolerance: number,
+) {
+  return (
+    Math.abs(data[offset] - r) <= tolerance &&
+    Math.abs(data[offset + 1] - g) <= tolerance &&
+    Math.abs(data[offset + 2] - b) <= tolerance &&
+    Math.abs(data[offset + 3] - a) <= tolerance
+  );
+}
+
+function clamp255(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(255, Math.round(value)));
+}
+
+function getFourNeighbourOffsets(width: number): Int32Array {
+  return new Int32Array([-1, 1, -width, width]);
+}
+
+function getEightNeighbourOffsets(width: number): Int32Array {
+  return new Int32Array([-1, 1, -width, width, -width - 1, -width + 1, width - 1, width + 1]);
+}
+
+function areFourConnected(idx: number, neighbour: number, width: number): boolean {
+  const x = idx % width;
+  const nx = neighbour % width;
+  const diffX = Math.abs(nx - x);
+  const diffY = Math.abs(((neighbour / width) | 0) - ((idx / width) | 0));
+  return diffX + diffY === 1;
+}
+
+function areEightConnected(idx: number, neighbour: number, width: number): boolean {
+  const x = idx % width;
+  const y = (idx / width) | 0;
+  const nx = neighbour % width;
+  const ny = (neighbour / width) | 0;
+  return Math.max(Math.abs(nx - x), Math.abs(ny - y)) === 1;
+}

--- a/src/tools/BucketFillTool.ts
+++ b/src/tools/BucketFillTool.ts
@@ -1,4 +1,5 @@
 import { Editor } from "../core/Editor.js";
+import { floodFill, type FloodFillOptions } from "../core/floodFill.js";
 import { Tool } from "./Tool.js";
 
 /**
@@ -7,6 +8,8 @@ import { Tool } from "./Tool.js";
  */
 export class BucketFillTool implements Tool {
   private static readonly MAX_FILL_PIXELS = 1_000_000;
+
+  constructor(private readonly options: Partial<FloodFillOptions> = {}) {}
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
@@ -22,76 +25,23 @@ export class BucketFillTool implements Tool {
     const dpr = window.devicePixelRatio || 1;
     const sx = Math.max(0, Math.min(width - 1, Math.floor(e.offsetX * dpr)));
     const sy = Math.max(0, Math.min(height - 1, Math.floor(e.offsetY * dpr)));
-    const start = sy * width + sx;
-    const targetOffset = start * 4;
-    const tr = data[targetOffset];
-    const tg = data[targetOffset + 1];
-    const tb = data[targetOffset + 2];
-
     const [fr, fg, fb] = this.hexToRgb(editor.fillStyle);
 
-    // if target already the fill color, nothing to do
-    if (tr === fr && tg === fg && tb === fb) return;
+    const { filledPixels, aborted } = floodFill(
+      image,
+      sx,
+      sy,
+      [fr, fg, fb, 255],
+      { ...this.options, maxPixels: BucketFillTool.MAX_FILL_PIXELS },
+    );
 
-    const queue = new Uint32Array(pixelCount);
-    const visited = new Uint8Array(pixelCount);
-    let head = 0;
-    let tail = 0;
-    let processed = 0;
-
-    queue[tail++] = start;
-    visited[start] = 1;
-
-    while (head < tail) {
-      const idx = queue[head++];
-      const offset = idx * 4;
-      if (data[offset] !== tr || data[offset + 1] !== tg || data[offset + 2] !== tb) {
-        continue;
-      }
-
-      data[offset] = fr;
-      data[offset + 1] = fg;
-      data[offset + 2] = fb;
-      data[offset + 3] = 255;
-      processed++;
-      if (processed > BucketFillTool.MAX_FILL_PIXELS) {
-        console.warn("Bucket fill aborted: exceeded pixel limit");
-        break;
-      }
-
-      const x = idx % width;
-      const y = (idx / width) | 0;
-
-      if (x > 0) {
-        const n = idx - 1;
-        if (!visited[n]) {
-          queue[tail++] = n;
-          visited[n] = 1;
-        }
-      }
-      if (x < width - 1) {
-        const n = idx + 1;
-        if (!visited[n]) {
-          queue[tail++] = n;
-          visited[n] = 1;
-        }
-      }
-      if (y > 0) {
-        const n = idx - width;
-        if (!visited[n]) {
-          queue[tail++] = n;
-          visited[n] = 1;
-        }
-      }
-      if (y < height - 1) {
-        const n = idx + width;
-        if (!visited[n]) {
-          queue[tail++] = n;
-          visited[n] = 1;
-        }
-      }
+    if (aborted) {
+      console.warn("Bucket fill aborted: exceeded pixel limit");
     }
-    ctx.putImageData(image, 0, 0);
+
+    if (filledPixels > 0) {
+      ctx.putImageData(image, 0, 0);
+    }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/tests/bucketFill.fuzz.test.ts
+++ b/tests/bucketFill.fuzz.test.ts
@@ -1,0 +1,165 @@
+import fc from "fast-check";
+import { floodFill } from "../src/core/floodFill.js";
+
+describe("floodFill fuzzing", () => {
+  const gridArb = fc
+    .tuple(fc.integer({ min: 1, max: 8 }), fc.integer({ min: 1, max: 8 }))
+    .chain(([width, height]) =>
+      fc.record({
+        width: fc.constant(width),
+        height: fc.constant(height),
+        pixels: fc.array(fc.integer({ min: 0, max: 255 }), {
+          minLength: width * height * 4,
+          maxLength: width * height * 4,
+        }),
+        startX: fc.integer({ min: 0, max: width - 1 }),
+        startY: fc.integer({ min: 0, max: height - 1 }),
+        fill: fc.tuple(
+          fc.integer({ min: 0, max: 255 }),
+          fc.integer({ min: 0, max: 255 }),
+          fc.integer({ min: 0, max: 255 }),
+          fc.integer({ min: 0, max: 255 }),
+        ),
+        tolerance: fc.integer({ min: 0, max: 128 }),
+        connectivity: fc.constantFrom<4 | 8>(4, 8),
+      }),
+    );
+
+  it("matches the reference implementation across random grids", () => {
+    fc.assert(
+      fc.property(gridArb, ({
+        width,
+        height,
+        pixels,
+        startX,
+        startY,
+        fill,
+        tolerance,
+        connectivity,
+      }) => {
+        const base = new Uint8ClampedArray(pixels);
+        const actualImage = {
+          data: new Uint8ClampedArray(base),
+          width,
+          height,
+        } as ImageData;
+        const expectedData = naiveFloodFill(
+          new Uint8ClampedArray(base),
+          width,
+          height,
+          startX,
+          startY,
+          fill,
+          tolerance,
+          connectivity,
+        );
+
+        const result = floodFill(actualImage, startX, startY, fill, {
+          tolerance,
+          connectivity,
+        });
+
+        expect(Array.from(actualImage.data)).toEqual(Array.from(expectedData.data));
+        expect(result.filledPixels).toBe(expectedData.filledPixels);
+        expect(result.aborted).toBe(false);
+      }),
+      { numRuns: 50 },
+    );
+  });
+});
+
+type FillTuple = readonly [number, number, number, number];
+
+function naiveFloodFill(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number,
+  startX: number,
+  startY: number,
+  fill: FillTuple,
+  tolerance: number,
+  connectivity: 4 | 8,
+) {
+  const sx = clamp(startX, 0, width - 1);
+  const sy = clamp(startY, 0, height - 1);
+  const startIndex = sy * width + sx;
+  const startOffset = startIndex * 4;
+
+  const target = [data[startOffset], data[startOffset + 1], data[startOffset + 2], data[startOffset + 3]] as const;
+  if (withinTolerance(target, fill, tolerance)) {
+    return { data, filledPixels: 0 };
+  }
+
+  const queue = [startIndex];
+  const visited = new Uint8Array(width * height);
+  visited[startIndex] = 1;
+
+  const deltas = connectivity === 8 ? getEightConnectivity() : getFourConnectivity();
+  let processed = 0;
+
+  while (queue.length > 0) {
+    const idx = queue.shift()!;
+    const offset = idx * 4;
+
+    const current = [data[offset], data[offset + 1], data[offset + 2], data[offset + 3]] as const;
+    if (!withinTolerance(current, target, tolerance)) {
+      continue;
+    }
+
+    data[offset] = fill[0];
+    data[offset + 1] = fill[1];
+    data[offset + 2] = fill[2];
+    data[offset + 3] = fill[3];
+    processed++;
+
+    const x = idx % width;
+    const y = (idx / width) | 0;
+
+    for (const [dx, dy] of deltas) {
+      const nx = x + dx;
+      const ny = y + dy;
+      if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
+      const nIdx = ny * width + nx;
+      if (visited[nIdx]) continue;
+      visited[nIdx] = 1;
+      queue.push(nIdx);
+    }
+  }
+
+  return { data, filledPixels: processed };
+}
+
+function withinTolerance(color: FillTuple, target: FillTuple, tolerance: number) {
+  return (
+    Math.abs(color[0] - target[0]) <= tolerance &&
+    Math.abs(color[1] - target[1]) <= tolerance &&
+    Math.abs(color[2] - target[2]) <= tolerance &&
+    Math.abs(color[3] - target[3]) <= tolerance
+  );
+}
+
+function getFourConnectivity() {
+  return [
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1],
+  ] as const;
+}
+
+function getEightConnectivity() {
+  return [
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1],
+    [1, 1],
+    [-1, 1],
+    [1, -1],
+    [-1, -1],
+  ] as const;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}


### PR DESCRIPTION
## Summary
- extract a reusable `floodFill` helper that supports tolerance and connectivity options
- wire the bucket fill tool through the new helper
- add a fast-check based property test that fuzzes random grids against a reference implementation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60d3448d8832883bcfa4633a81b72