### PR TITLE
Add placeholder test suites for upcoming tools

### DIFF
--- a/tests/cloneStampTool.test.ts
+++ b/tests/cloneStampTool.test.ts
@@ -1,0 +1,18 @@
+import { describe, test } from '@jest/globals';
+
+describe('CloneStampTool', () => {
+  describe('handles', () => {
+    test.todo('tracks offset handle between source and destination cursors');
+    test.todo('allows rotation handle to adjust sampled texture orientation');
+  });
+
+  describe('sampling', () => {
+    test.todo('samples from the source point when modifier key is pressed');
+    test.todo('displays sampled preview aligned with brush size');
+  });
+
+  describe('parameter changes', () => {
+    test.todo('updates brush hardness parameter in real time while painting');
+    test.todo('respects flow parameter adjustments across continuous strokes');
+  });
+});

--- a/tests/gradientTool.test.ts
+++ b/tests/gradientTool.test.ts
@@ -1,0 +1,18 @@
+import { describe, test } from '@jest/globals';
+
+describe('GradientTool', () => {
+  describe('handles', () => {
+    test.todo('updates gradient direction when start handle is moved');
+    test.todo('updates gradient length when end handle is dragged');
+  });
+
+  describe('sampling', () => {
+    test.todo('samples the underlying canvas colors to compute gradient stops');
+    test.todo('locks sampling preview when modifier key is held');
+  });
+
+  describe('parameter changes', () => {
+    test.todo('applies color stop adjustments to the rendered gradient');
+    test.todo('toggles between linear and radial modes without losing settings');
+  });
+});

--- a/tests/polygonStarTool.test.ts
+++ b/tests/polygonStarTool.test.ts
@@ -1,0 +1,18 @@
+import { describe, test } from '@jest/globals';
+
+describe('PolygonStarTool', () => {
+  describe('handles', () => {
+    test.todo('updates radius handles to control polygon size dynamically');
+    test.todo('adjusts inner radius handle to morph between polygon and star');
+  });
+
+  describe('sampling', () => {
+    test.todo('respects snap-to-angle sampling when modifier key is held');
+    test.todo('collects center point from cursor sample before drawing shape');
+  });
+
+  describe('parameter changes', () => {
+    test.todo('re-renders preview when number of sides parameter changes');
+    test.todo('preserves star inset ratio after toggling smoothing option');
+  });
+});


### PR DESCRIPTION
## Summary
- add placeholder Jest suites for gradient, polygon/star, and clone stamp tools
- outline key handle, sampling, and parameter behaviors to cover when implementations arrive

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d60d33dd348328b5fa33528a98738a