### PR TITLE
Add Playwright end-to-end test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,15 @@ jobs:
       - run: npm run lint
       - run: npm run format:check
       - run: npm test
+      - run: npx playwright install --with-deps
+      - run: npm run e2e
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: coverage-report
           path: coverage
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+playwright-report/
+test-results/

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "photoshop-clone",
       "version": "1.0.0",
       "devDependencies": {
+        "@playwright/test": "^1.55.1",
         "@types/jest": "^29.5.11",
+        "@types/node": "^24.5.2",
         "@typescript-eslint/eslint-plugin": "^6.7.0",
         "@typescript-eslint/parser": "^6.7.0",
         "eslint": "^8.48.0",
@@ -1265,6 +1267,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1443,13 +1461,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.2.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
-      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.10.0"
+        "undici-types": "~7.12.0"
       }
     },
     "node_modules/@types/semver": {
@@ -5011,6 +5029,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5809,9 +5874,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -3,25 +3,27 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-
   "scripts": {
     "build": "tsc",
     "lint": "eslint 'src/**/*.{ts,js}'",
-    "test": "jest"
+    "test": "jest",
+    "start:e2e": "npm run build && node scripts/serve-static.js",
+    "e2e": "playwright test"
   },
-
   "devDependencies": {
+    "@playwright/test": "^1.55.1",
+    "@types/jest": "^29.5.11",
+    "@types/node": "^24.5.2",
     "@typescript-eslint/eslint-plugin": "^6.7.0",
     "@typescript-eslint/parser": "^6.7.0",
     "eslint": "^8.48.0",
     "eslint-config-prettier": "^9.0.0",
-    "prettier": "^3.0.0",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.2.2",
-    "@types/jest": "^29.5.11",
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "prettier": "^3.0.0",
     "ts-jest": "^29.2.3",
-    "jest-environment-jsdom": "^29.7.0"
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
   },
   "jest": {
     "preset": "ts-jest",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./playwright",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI
+    ? [
+        ["github"],
+        ["html", { outputFolder: "playwright-report", open: "never" }],
+      ]
+    : "list",
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  webServer: {
+    command: "npm run start:e2e",
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/playwright/e2e.spec.ts
+++ b/playwright/e2e.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect, Page } from "@playwright/test";
+
+async function samplePixel(
+  page: Page,
+  selector: string,
+  position: { x: number; y: number },
+): Promise<number[]> {
+  return page.evaluate(({ selector, x, y }) => {
+    const canvas = document.querySelector(selector) as HTMLCanvasElement | null;
+    if (!canvas) throw new Error(`Missing canvas ${selector}`);
+    const rect = canvas.getBoundingClientRect();
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("Missing 2d context");
+    const dpr = window.devicePixelRatio || 1;
+    const data = ctx.getImageData(
+      Math.max(0, Math.floor((x - rect.left) * dpr)),
+      Math.max(0, Math.floor((y - rect.top) * dpr)),
+      1,
+      1,
+    ).data;
+    return Array.from(data);
+  }, { selector, x: position.x, y: position.y });
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+});
+
+test("allows drawing with undo and redo", async ({ page }) => {
+  const canvas = page.locator("#canvas");
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error("Canvas not found");
+
+  const start = { x: box.x + box.width / 2 - 50, y: box.y + box.height / 2 };
+  const mid = { x: start.x + 50, y: start.y };
+  const end = { x: start.x + 100, y: start.y };
+
+  await page.mouse.move(start.x, start.y);
+  await page.mouse.down();
+  await page.mouse.move(mid.x, mid.y);
+  await page.mouse.move(end.x, end.y);
+  await page.mouse.up();
+
+  await expect(page.locator("#undo")).toBeEnabled();
+  await expect(page.locator("#redo")).toBeDisabled();
+
+  const pixel = await samplePixel(page, "#canvas", mid);
+  expect(pixel[3]).toBeGreaterThan(0);
+
+  await page.click("#undo");
+  await expect(page.locator("#redo")).toBeEnabled();
+  const afterUndo = await samplePixel(page, "#canvas", mid);
+  expect(afterUndo[3]).toBe(0);
+
+  await page.click("#redo");
+  const afterRedo = await samplePixel(page, "#canvas", mid);
+  expect(afterRedo[3]).toBeGreaterThan(0);
+});
+
+test("exports the drawing and imports an image", async ({ page }) => {
+  const canvas = page.locator("#canvas");
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error("Canvas not found");
+
+  const drawPoint = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+
+  await page.mouse.move(drawPoint.x - 20, drawPoint.y - 20);
+  await page.mouse.down();
+  await page.mouse.move(drawPoint.x + 20, drawPoint.y + 20);
+  await page.mouse.up();
+
+  await page.selectOption("#formatSelect", "jpeg");
+  const downloadPromise = page.waitForEvent("download");
+  await page.click("#save");
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toMatch(/\.jpg$/i);
+  const downloadPath = await download.path();
+  expect(downloadPath).toBeTruthy();
+
+  const dataUrl = await page.evaluate(() => {
+    const cv = document.createElement("canvas");
+    cv.width = 2;
+    cv.height = 2;
+    const ctx = cv.getContext("2d");
+    if (!ctx) throw new Error("Missing context");
+    ctx.fillStyle = "#ff0000";
+    ctx.fillRect(0, 0, cv.width, cv.height);
+    return cv.toDataURL("image/png");
+  });
+  const base64 = dataUrl.split(",")[1];
+  const buffer = Buffer.from(base64, "base64");
+
+  await page.setInputFiles("#imageLoader", {
+    name: "import.png",
+    mimeType: "image/png",
+    buffer,
+  });
+
+  await page.waitForFunction(() => {
+    const canvasEl = document.querySelector<HTMLCanvasElement>("#canvas");
+    if (!canvasEl) return false;
+    const ctx = canvasEl.getContext("2d");
+    if (!ctx) return false;
+    const dpr = window.devicePixelRatio || 1;
+    const data = ctx.getImageData(0, 0, 1 * dpr, 1 * dpr).data;
+    return data[0] === 255 && data[1] === 0 && data[2] === 0 && data[3] > 0;
+  });
+
+  const importedPixel = await samplePixel(page, "#canvas", { x: box.x + 1, y: box.y + 1 });
+  expect(importedPixel[0]).toBe(255);
+  expect(importedPixel[1]).toBe(0);
+  expect(importedPixel[2]).toBe(0);
+  expect(importedPixel[3]).toBeGreaterThan(0);
+});
+
+test("switching layers toggles interactivity and isolates drawings", async ({ page }) => {
+  const baseCanvas = page.locator("#canvas");
+  const box = await baseCanvas.boundingBox();
+  if (!box) throw new Error("Canvas not found");
+
+  const target = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+  const beforePixel = await samplePixel(page, "#canvas", target);
+  expect(beforePixel[3]).toBe(0);
+
+  await page.selectOption("#layerSelect", "1");
+  const pointerStates = await page.evaluate(() => ({
+    base: getComputedStyle(document.getElementById("canvas")!).pointerEvents,
+    layer2: getComputedStyle(document.getElementById("layer2")!).pointerEvents,
+  }));
+  expect(pointerStates.base).toBe("none");
+  expect(pointerStates.layer2).toBe("auto");
+
+  await page.mouse.move(target.x - 30, target.y - 30);
+  await page.mouse.down();
+  await page.mouse.move(target.x + 30, target.y + 30);
+  await page.mouse.up();
+
+  const baseAfter = await samplePixel(page, "#canvas", target);
+  expect(baseAfter[3]).toBe(0);
+  const layerPixel = await samplePixel(page, "#layer2", target);
+  expect(layerPixel[3]).toBeGreaterThan(0);
+
+  await page.selectOption("#layerSelect", "0");
+  const restoredPointerStates = await page.evaluate(() => ({
+    base: getComputedStyle(document.getElementById("canvas")!).pointerEvents,
+    layer2: getComputedStyle(document.getElementById("layer2")!).pointerEvents,
+  }));
+  expect(restoredPointerStates.base).toBe("auto");
+  expect(restoredPointerStates.layer2).toBe("none");
+});

--- a/scripts/serve-static.js
+++ b/scripts/serve-static.js
@@ -1,0 +1,68 @@
+import http from "node:http";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, "..");
+const port = parseInt(process.env.PORT ?? "4173", 10);
+
+const MIME_TYPES = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".ico": "image/x-icon",
+};
+
+async function serveFile(filePath, res) {
+  try {
+    const data = await fs.readFile(filePath);
+    const ext = path.extname(filePath).toLowerCase();
+    const mime = MIME_TYPES[ext] ?? "application/octet-stream";
+    res.writeHead(200, { "Content-Type": mime });
+    res.end(data);
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("Not found");
+      return;
+    }
+    console.error("Error serving", filePath, error);
+    res.writeHead(500, { "Content-Type": "text/plain; charset=utf-8" });
+    res.end("Internal Server Error");
+  }
+}
+
+const server = http.createServer(async (req, res) => {
+  const requestUrl = new URL(req.url ?? "/", "http://localhost");
+  let pathname = decodeURIComponent(requestUrl.pathname);
+  if (pathname.endsWith("/")) {
+    pathname = path.join(pathname, "index.html");
+  }
+
+  const filePath = path.join(rootDir, pathname);
+  if (!filePath.startsWith(rootDir)) {
+    res.writeHead(403, { "Content-Type": "text/plain; charset=utf-8" });
+    res.end("Forbidden");
+    return;
+  }
+
+  await serveFile(filePath, res);
+});
+
+server.listen(port, () => {
+  console.log(`Static server running at http://127.0.0.1:${port}`);
+});
+
+process.on("SIGINT", () => {
+  server.close(() => process.exit());
+});
+process.on("SIGTERM", () => {
+  server.close(() => process.exit());
+});


### PR DESCRIPTION
## Summary
- add Playwright configuration, npm scripts, and a lightweight static server to run end-to-end tests
- cover drawing, undo/redo, export/import, and layer toggling scenarios with Playwright
- wire the new suite into CI and upload Playwright reports when failures occur

## Testing
- npm run build
- npm run e2e

------
https://chatgpt.com/codex/tasks/task_e_68d60d32960c83288f0f58f6f7935b1d