### PR TITLE
Add WCAG contrast guidance to editor

### DIFF
--- a/dist/core/contrast.js
+++ b/dist/core/contrast.js
@@ -1,0 +1,89 @@
+const HEX_REGEX = /^#?(?<hex>[0-9a-f]{3}|[0-9a-f]{6})$/i;
+const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+function normalizeHex(input) {
+    const match = input.match(HEX_REGEX);
+    if (!match?.groups) {
+        throw new Error(`Invalid hex color: ${input}`);
+    }
+    let { hex } = match.groups;
+    if (hex.length === 3) {
+        hex = hex
+            .split("")
+            .map((ch) => ch + ch)
+            .join("");
+    }
+    return `#${hex.toLowerCase()}`;
+}
+function hexToRgb(hex) {
+    const normalized = normalizeHex(hex).slice(1);
+    const value = parseInt(normalized, 16);
+    return {
+        r: (value >> 16) & 0xff,
+        g: (value >> 8) & 0xff,
+        b: value & 0xff,
+    };
+}
+function rgbToHex({ r, g, b }) {
+    const toHex = (value) => clamp(Math.round(value), 0, 255).toString(16).padStart(2, "0");
+    return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+function srgbChannelToLinear(channel) {
+    const c = channel / 255;
+    return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+}
+function relativeLuminanceFromRgb({ r, g, b }) {
+    const [rl, gl, bl] = [r, g, b].map(srgbChannelToLinear);
+    // WCAG formula
+    return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+}
+export function relativeLuminance(color) {
+    return relativeLuminanceFromRgb(hexToRgb(color));
+}
+export function contrastRatio(colorA, colorB) {
+    const luminances = [relativeLuminance(colorA), relativeLuminance(colorB)].sort((a, b) => b - a);
+    const [lighter, darker] = luminances;
+    const ratio = (lighter + 0.05) / (darker + 0.05);
+    return Math.round(ratio * 100) / 100; // keep two decimal precision
+}
+function mixColors(color, target, amount) {
+    const base = hexToRgb(color);
+    const goal = hexToRgb(target);
+    const mix = (from, to) => from + (to - from) * amount;
+    return rgbToHex({
+        r: mix(base.r, goal.r),
+        g: mix(base.g, goal.g),
+        b: mix(base.b, goal.b),
+    });
+}
+export function suggestContrastColor(foreground, background, threshold = 4.5) {
+    const normalizedForeground = normalizeHex(foreground);
+    const normalizedBackground = normalizeHex(background);
+    const currentRatio = contrastRatio(normalizedForeground, normalizedBackground);
+    if (currentRatio >= threshold) {
+        return null;
+    }
+    const foregroundLum = relativeLuminance(normalizedForeground);
+    const backgroundLum = relativeLuminance(normalizedBackground);
+    const targetColor = backgroundLum > foregroundLum ? "#000000" : "#ffffff";
+    let lower = 0;
+    let upper = 1;
+    let bestColor = normalizedForeground;
+    let bestRatio = currentRatio;
+    for (let i = 0; i < 24; i += 1) {
+        const mid = (lower + upper) / 2;
+        const candidate = mixColors(normalizedForeground, targetColor, mid);
+        const ratio = contrastRatio(candidate, normalizedBackground);
+        if (ratio >= threshold) {
+            bestColor = candidate;
+            bestRatio = ratio;
+            upper = mid;
+        }
+        else {
+            lower = mid;
+        }
+    }
+    if (bestRatio < currentRatio) {
+        return null;
+    }
+    return { color: bestColor, ratio: Math.max(bestRatio, currentRatio) };
+}

--- a/dist/editor.js
+++ b/dist/editor.js
@@ -8,6 +8,7 @@ import { CircleTool } from "./tools/CircleTool.js";
 import { TextTool } from "./tools/TextTool.js";
 import { BucketFillTool } from "./tools/BucketFillTool.js";
 import { EyedropperTool } from "./tools/EyedropperTool.js";
+import { contrastRatio, suggestContrastColor, } from "./core/contrast.js";
 /** Utility to listen to events and auto-remove on destroy. */
 function listen(el, type, handler, list) {
     if (!el)
@@ -76,6 +77,65 @@ export function initEditor() {
     const saveBtn = document.getElementById("save");
     const formatSelect = document.getElementById("formatSelect");
     const colorHistory = document.getElementById("colorHistory");
+    const minTextContrast = 4.5;
+    const minUiContrast = 3;
+    const ensureContrastPanel = () => {
+        const containerId = "contrastInfo";
+        let panel = document.getElementById(containerId);
+        if (!panel) {
+            panel = document.createElement("div");
+            panel.id = containerId;
+            panel.className = "contrast-info";
+            toolbar.appendChild(panel);
+        }
+        panel.setAttribute("role", "group");
+        panel.setAttribute("aria-label", "Contrast guidance");
+        const ensureRow = (key, label, backgroundColor) => {
+            let row = panel.querySelector(`[data-contrast-row="${key}"]`);
+            if (!row) {
+                row = document.createElement("div");
+                row.dataset.contrastRow = key;
+                row.className = "contrast-row";
+                const labelEl = document.createElement("span");
+                labelEl.className = "contrast-label";
+                labelEl.textContent = label;
+                const valueEl = document.createElement("span");
+                valueEl.className = "contrast-value";
+                const button = document.createElement("button");
+                button.type = "button";
+                button.className = "contrast-adjust";
+                button.dataset.backgroundColor = backgroundColor;
+                button.textContent = "Auto-adjust";
+                row.append(labelEl, valueEl, button);
+                panel.appendChild(row);
+            }
+            const valueEl = row.querySelector(".contrast-value");
+            const button = row.querySelector(".contrast-adjust");
+            if (!valueEl || !button) {
+                throw new Error("Contrast row is missing required elements");
+            }
+            return {
+                backgroundLabel: label,
+                backgroundColor,
+                rowEl: row,
+                valueEl,
+                adjustButton: button,
+            };
+        };
+        const lightRow = ensureRow("light", "Light background", "#ffffff");
+        const darkRow = ensureRow("dark", "Dark background", "#1b1b1b");
+        let messageEl = panel.querySelector("[data-role=contrast-message]");
+        if (!messageEl) {
+            messageEl = document.createElement("div");
+            messageEl.dataset.role = "contrast-message";
+            messageEl.className = "contrast-message";
+            messageEl.setAttribute("role", "status");
+            messageEl.setAttribute("aria-live", "polite");
+            panel.appendChild(messageEl);
+        }
+        return { panel, rows: [lightRow, darkRow], messageEl };
+    };
+    const contrastUi = ensureContrastPanel();
     if (!colorPicker) {
         throw new Error("Missing #colorPicker input");
     }
@@ -123,6 +183,65 @@ export function initEditor() {
     const undoBtn = document.getElementById("undo");
     const redoBtn = document.getElementById("redo");
     const listeners = [];
+    const applySuggestedColor = (value) => {
+        colorPicker.value = value;
+        colorPicker.dispatchEvent(new Event("input", { bubbles: true }));
+    };
+    contrastUi.rows.forEach((row) => {
+        const handler = () => {
+            const suggestion = row.adjustButton.dataset.suggestedColor;
+            if (suggestion) {
+                applySuggestedColor(suggestion);
+            }
+        };
+        row.adjustButton.addEventListener("click", handler);
+        listeners.push(() => row.adjustButton.removeEventListener("click", handler));
+    });
+    const formatRatio = (ratio) => `${ratio.toFixed(2)}:1`;
+    const updateContrastFeedback = () => {
+        const warnings = [];
+        contrastUi.rows.forEach((row) => {
+            const ratio = contrastRatio(colorPicker.value, row.backgroundColor);
+            const passesUi = ratio >= minUiContrast;
+            const passesText = ratio >= minTextContrast;
+            const statusLabel = `${formatRatio(ratio)} • ${passesText ? "AA text ✓" : "AA text ✗"} • ${passesUi ? "UI ✓" : "UI ✗"}`;
+            row.valueEl.textContent = statusLabel;
+            row.rowEl.classList.toggle("contrast-pass", passesText);
+            row.rowEl.classList.toggle("contrast-warning", !passesText);
+            row.rowEl.classList.toggle("contrast-critical", !passesUi);
+            let suggestion = null;
+            if (!passesText) {
+                suggestion = suggestContrastColor(colorPicker.value, row.backgroundColor, minTextContrast);
+            }
+            if (suggestion) {
+                row.adjustButton.disabled = false;
+                row.adjustButton.dataset.suggestedColor = suggestion.color;
+                row.adjustButton.textContent = `Adjust to ${suggestion.color.toUpperCase()}`;
+            }
+            else {
+                row.adjustButton.disabled = true;
+                row.adjustButton.dataset.suggestedColor = "";
+                row.adjustButton.textContent = passesText
+                    ? "AA compliant"
+                    : "Adjust to improve";
+            }
+            if (!passesUi) {
+                warnings.push(`${row.backgroundLabel} contrast is ${formatRatio(ratio)}, below the 3:1 minimum for UI elements.`);
+            }
+            else if (!passesText) {
+                warnings.push(`${row.backgroundLabel} contrast is ${formatRatio(ratio)}, below the 4.5:1 WCAG AA text requirement.`);
+            }
+        });
+        if (warnings.length === 0) {
+            contrastUi.messageEl.textContent =
+                "Selected color meets WCAG AA guidance on light and dark backgrounds.";
+            contrastUi.messageEl.classList.remove("contrast-message-warning");
+        }
+        else {
+            contrastUi.messageEl.textContent = warnings.join(" ");
+            contrastUi.messageEl.classList.add("contrast-message-warning");
+        }
+    };
     const recentColors = [];
     const maxRecentColors = 10;
     const renderColorHistory = () => {
@@ -151,9 +270,11 @@ export function initEditor() {
             recentColors.pop();
         renderColorHistory();
     };
-    listen(colorPicker, "input", () => {
+    const handleColorInput = () => {
         recordColor(colorPicker.value);
-    }, listeners);
+        updateContrastFeedback();
+    };
+    listen(colorPicker, "input", handleColorInput, listeners);
     let editor; // set after editors created
     const updateHistoryButtons = () => {
         if (undoBtn)
@@ -296,6 +417,7 @@ export function initEditor() {
         },
     };
     recordColor(colorPicker.value);
+    updateContrastFeedback();
     updateHistoryButtons();
     return handle;
 }

--- a/index.html
+++ b/index.html
@@ -65,6 +65,29 @@
         <img src="icons/save.svg" alt="Save" />
       </button>
 
+      <div id="contrastInfo" class="contrast-info" role="group" aria-label="Contrast guidance">
+        <div class="contrast-row" data-contrast-row="light">
+          <span class="contrast-label">Light background</span>
+          <span class="contrast-value">--</span>
+          <button type="button" class="contrast-adjust" disabled>
+            Auto-adjust
+          </button>
+        </div>
+        <div class="contrast-row" data-contrast-row="dark">
+          <span class="contrast-label">Dark background</span>
+          <span class="contrast-value">--</span>
+          <button type="button" class="contrast-adjust" disabled>
+            Auto-adjust
+          </button>
+        </div>
+        <div
+          class="contrast-message"
+          data-role="contrast-message"
+          role="status"
+          aria-live="polite"
+        ></div>
+      </div>
+
     </div>
     <div id="canvasContainer">
       <canvas id="canvas" width="800" height="600"></canvas>

--- a/src/core/contrast.ts
+++ b/src/core/contrast.ts
@@ -1,0 +1,122 @@
+const HEX_REGEX = /^#?(?<hex>[0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+interface RGB {
+  r: number;
+  g: number;
+  b: number;
+}
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value));
+
+function normalizeHex(input: string): string {
+  const match = input.match(HEX_REGEX);
+  if (!match?.groups) {
+    throw new Error(`Invalid hex color: ${input}`);
+  }
+  let { hex } = match.groups;
+  if (hex.length === 3) {
+    hex = hex
+      .split("")
+      .map((ch) => ch + ch)
+      .join("");
+  }
+  return `#${hex.toLowerCase()}`;
+}
+
+function hexToRgb(hex: string): RGB {
+  const normalized = normalizeHex(hex).slice(1);
+  const value = parseInt(normalized, 16);
+  return {
+    r: (value >> 16) & 0xff,
+    g: (value >> 8) & 0xff,
+    b: value & 0xff,
+  };
+}
+
+function rgbToHex({ r, g, b }: RGB): string {
+  const toHex = (value: number) =>
+    clamp(Math.round(value), 0, 255).toString(16).padStart(2, "0");
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function srgbChannelToLinear(channel: number): number {
+  const c = channel / 255;
+  return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+}
+
+function relativeLuminanceFromRgb({ r, g, b }: RGB): number {
+  const [rl, gl, bl] = [r, g, b].map(srgbChannelToLinear);
+  // WCAG formula
+  return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+}
+
+export function relativeLuminance(color: string): number {
+  return relativeLuminanceFromRgb(hexToRgb(color));
+}
+
+export function contrastRatio(colorA: string, colorB: string): number {
+  const luminances = [relativeLuminance(colorA), relativeLuminance(colorB)].sort(
+    (a, b) => b - a,
+  );
+  const [lighter, darker] = luminances;
+  const ratio = (lighter + 0.05) / (darker + 0.05);
+  return Math.round(ratio * 100) / 100; // keep two decimal precision
+}
+
+function mixColors(color: string, target: string, amount: number): string {
+  const base = hexToRgb(color);
+  const goal = hexToRgb(target);
+  const mix = (from: number, to: number) => from + (to - from) * amount;
+  return rgbToHex({
+    r: mix(base.r, goal.r),
+    g: mix(base.g, goal.g),
+    b: mix(base.b, goal.b),
+  });
+}
+
+export interface ContrastSuggestion {
+  color: string;
+  ratio: number;
+}
+
+export function suggestContrastColor(
+  foreground: string,
+  background: string,
+  threshold = 4.5,
+): ContrastSuggestion | null {
+  const normalizedForeground = normalizeHex(foreground);
+  const normalizedBackground = normalizeHex(background);
+  const currentRatio = contrastRatio(normalizedForeground, normalizedBackground);
+  if (currentRatio >= threshold) {
+    return null;
+  }
+
+  const foregroundLum = relativeLuminance(normalizedForeground);
+  const backgroundLum = relativeLuminance(normalizedBackground);
+  const targetColor = backgroundLum > foregroundLum ? "#000000" : "#ffffff";
+
+  let lower = 0;
+  let upper = 1;
+  let bestColor = normalizedForeground;
+  let bestRatio = currentRatio;
+
+  for (let i = 0; i < 24; i += 1) {
+    const mid = (lower + upper) / 2;
+    const candidate = mixColors(normalizedForeground, targetColor, mid);
+    const ratio = contrastRatio(candidate, normalizedBackground);
+    if (ratio >= threshold) {
+      bestColor = candidate;
+      bestRatio = ratio;
+      upper = mid;
+    } else {
+      lower = mid;
+    }
+  }
+
+  if (bestRatio < currentRatio) {
+    return null;
+  }
+
+  return { color: bestColor, ratio: Math.max(bestRatio, currentRatio) };
+}

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -8,6 +8,11 @@ import { CircleTool } from "./tools/CircleTool.js";
 import { TextTool } from "./tools/TextTool.js";
 import { BucketFillTool } from "./tools/BucketFillTool.js";
 import { EyedropperTool } from "./tools/EyedropperTool.js";
+import {
+  contrastRatio,
+  suggestContrastColor,
+  type ContrastSuggestion,
+} from "./core/contrast.js";
 import type { Tool } from "./tools/Tool.js";
 
 /** Utility to listen to events and auto-remove on destroy. */
@@ -99,6 +104,89 @@ export function initEditor(): EditorHandle {
   const colorHistory = document.getElementById(
     "colorHistory",
   ) as HTMLDivElement | null;
+  const minTextContrast = 4.5;
+  const minUiContrast = 3;
+
+  interface ContrastRow {
+    backgroundLabel: string;
+    backgroundColor: string;
+    rowEl: HTMLDivElement;
+    valueEl: HTMLSpanElement;
+    adjustButton: HTMLButtonElement;
+  }
+
+  const ensureContrastPanel = () => {
+    const containerId = "contrastInfo";
+    let panel = document.getElementById(containerId) as HTMLDivElement | null;
+    if (!panel) {
+      panel = document.createElement("div");
+      panel.id = containerId;
+      panel.className = "contrast-info";
+      toolbar.appendChild(panel);
+    }
+    panel.setAttribute("role", "group");
+    panel.setAttribute("aria-label", "Contrast guidance");
+
+    const ensureRow = (
+      key: string,
+      label: string,
+      backgroundColor: string,
+    ): ContrastRow => {
+      let row = panel!.querySelector<HTMLDivElement>(
+        `[data-contrast-row="${key}"]`,
+      );
+      if (!row) {
+        row = document.createElement("div");
+        row.dataset.contrastRow = key;
+        row.className = "contrast-row";
+        const labelEl = document.createElement("span");
+        labelEl.className = "contrast-label";
+        labelEl.textContent = label;
+        const valueEl = document.createElement("span");
+        valueEl.className = "contrast-value";
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "contrast-adjust";
+        button.dataset.backgroundColor = backgroundColor;
+        button.textContent = "Auto-adjust";
+        row.append(labelEl, valueEl, button);
+        panel!.appendChild(row);
+      }
+
+      const valueEl = row.querySelector<HTMLSpanElement>(".contrast-value");
+      const button = row.querySelector<HTMLButtonElement>(".contrast-adjust");
+      if (!valueEl || !button) {
+        throw new Error("Contrast row is missing required elements");
+      }
+
+      return {
+        backgroundLabel: label,
+        backgroundColor,
+        rowEl: row,
+        valueEl,
+        adjustButton: button,
+      };
+    };
+
+    const lightRow = ensureRow("light", "Light background", "#ffffff");
+    const darkRow = ensureRow("dark", "Dark background", "#1b1b1b");
+
+    let messageEl = panel.querySelector<HTMLDivElement>(
+      "[data-role=contrast-message]",
+    );
+    if (!messageEl) {
+      messageEl = document.createElement("div");
+      messageEl.dataset.role = "contrast-message";
+      messageEl.className = "contrast-message";
+      messageEl.setAttribute("role", "status");
+      messageEl.setAttribute("aria-live", "polite");
+      panel.appendChild(messageEl);
+    }
+
+    return { panel, rows: [lightRow, darkRow], messageEl };
+  };
+
+  const contrastUi = ensureContrastPanel();
 
   if (!colorPicker) {
     throw new Error("Missing #colorPicker input");
@@ -156,6 +244,88 @@ export function initEditor(): EditorHandle {
   const redoBtn = document.getElementById("redo") as HTMLButtonElement | null;
   const listeners: Array<() => void> = [];
 
+  const applySuggestedColor = (value: string) => {
+    colorPicker.value = value;
+    colorPicker.dispatchEvent(new Event("input", { bubbles: true }));
+  };
+
+  contrastUi.rows.forEach((row) => {
+    const handler = () => {
+      const suggestion = row.adjustButton.dataset.suggestedColor;
+      if (suggestion) {
+        applySuggestedColor(suggestion);
+      }
+    };
+    row.adjustButton.addEventListener("click", handler);
+    listeners.push(() =>
+      row.adjustButton.removeEventListener("click", handler),
+    );
+  });
+
+  const formatRatio = (ratio: number) => `${ratio.toFixed(2)}:1`;
+
+  const updateContrastFeedback = () => {
+    const warnings: string[] = [];
+
+    contrastUi.rows.forEach((row) => {
+      const ratio = contrastRatio(colorPicker.value, row.backgroundColor);
+      const passesUi = ratio >= minUiContrast;
+      const passesText = ratio >= minTextContrast;
+      const statusLabel = `${formatRatio(ratio)} • ${
+        passesText ? "AA text ✓" : "AA text ✗"
+      } • ${passesUi ? "UI ✓" : "UI ✗"}`;
+      row.valueEl.textContent = statusLabel;
+
+      row.rowEl.classList.toggle("contrast-pass", passesText);
+      row.rowEl.classList.toggle("contrast-warning", !passesText);
+      row.rowEl.classList.toggle("contrast-critical", !passesUi);
+
+      let suggestion: ContrastSuggestion | null = null;
+      if (!passesText) {
+        suggestion = suggestContrastColor(
+          colorPicker.value,
+          row.backgroundColor,
+          minTextContrast,
+        );
+      }
+
+      if (suggestion) {
+        row.adjustButton.disabled = false;
+        row.adjustButton.dataset.suggestedColor = suggestion.color;
+        row.adjustButton.textContent = `Adjust to ${suggestion.color.toUpperCase()}`;
+      } else {
+        row.adjustButton.disabled = true;
+        row.adjustButton.dataset.suggestedColor = "";
+        row.adjustButton.textContent = passesText
+          ? "AA compliant"
+          : "Adjust to improve";
+      }
+
+      if (!passesUi) {
+        warnings.push(
+          `${row.backgroundLabel} contrast is ${formatRatio(
+            ratio,
+          )}, below the 3:1 minimum for UI elements.`,
+        );
+      } else if (!passesText) {
+        warnings.push(
+          `${row.backgroundLabel} contrast is ${formatRatio(
+            ratio,
+          )}, below the 4.5:1 WCAG AA text requirement.`,
+        );
+      }
+    });
+
+    if (warnings.length === 0) {
+      contrastUi.messageEl.textContent =
+        "Selected color meets WCAG AA guidance on light and dark backgrounds.";
+      contrastUi.messageEl.classList.remove("contrast-message-warning");
+    } else {
+      contrastUi.messageEl.textContent = warnings.join(" ");
+      contrastUi.messageEl.classList.add("contrast-message-warning");
+    }
+  };
+
   const recentColors: string[] = [];
   const maxRecentColors = 10;
   const renderColorHistory = () => {
@@ -183,14 +353,12 @@ export function initEditor(): EditorHandle {
     renderColorHistory();
   };
 
-  listen(
-    colorPicker,
-    "input",
-    () => {
-      recordColor(colorPicker.value);
-    },
-    listeners,
-  );
+  const handleColorInput = () => {
+    recordColor(colorPicker.value);
+    updateContrastFeedback();
+  };
+
+  listen(colorPicker, "input", handleColorInput, listeners);
 
   let editor: Editor; // set after editors created
 
@@ -393,6 +561,7 @@ export function initEditor(): EditorHandle {
     },
   };
   recordColor(colorPicker.value);
+  updateContrastFeedback();
   updateHistoryButtons();
   return handle;
 }

--- a/style.css
+++ b/style.css
@@ -28,6 +28,73 @@ body {
   gap: 4px;
 }
 
+.contrast-info {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px;
+  border: 1px solid #d0d0d0;
+  border-radius: 6px;
+  background: #ffffff;
+  min-width: 260px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+.contrast-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.contrast-label {
+  font-weight: 600;
+  min-width: 120px;
+}
+
+.contrast-value {
+  flex: 1;
+  font-size: 0.85rem;
+}
+
+.contrast-adjust {
+  padding: 4px 8px;
+  font-size: 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #f9f9f9;
+  cursor: pointer;
+}
+
+.contrast-adjust:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.contrast-row.contrast-pass .contrast-value {
+  color: #176f2c;
+  font-weight: 600;
+}
+
+.contrast-row.contrast-warning .contrast-value {
+  color: #b76b00;
+  font-weight: 600;
+}
+
+.contrast-row.contrast-critical .contrast-value {
+  color: #b00020;
+  font-weight: 700;
+}
+
+.contrast-message {
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.contrast-message-warning {
+  color: #b00020;
+  font-weight: 600;
+}
+
 .color-swatch {
   width: 24px;
   height: 24px;

--- a/tests/contrast.test.ts
+++ b/tests/contrast.test.ts
@@ -1,0 +1,27 @@
+import {
+  contrastRatio,
+  relativeLuminance,
+  suggestContrastColor,
+} from "../src/core/contrast.js";
+
+describe("contrast utilities", () => {
+  it("computes relative luminance per WCAG", () => {
+    expect(relativeLuminance("#000000")).toBe(0);
+    expect(relativeLuminance("#ffffff")).toBe(1);
+  });
+
+  it("calculates contrast ratios with two decimal precision", () => {
+    expect(contrastRatio("#000000", "#ffffff")).toBe(21);
+    expect(contrastRatio("#ff0000", "#ffffff")).toBeCloseTo(4, 1);
+  });
+
+  it("suggests adjustments that satisfy the requested threshold", () => {
+    const suggestion = suggestContrastColor("#f2f2f2", "#ffffff");
+    expect(suggestion).not.toBeNull();
+    expect(suggestion?.ratio ?? 0).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("returns null when the color already passes the threshold", () => {
+    expect(suggestContrastColor("#000000", "#ffffff")).toBeNull();
+  });
+});

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -59,9 +59,15 @@ describe("image load and save", () => {
     });
 
     anchor = { href: "", download: "", click: jest.fn() };
+    const nativeCreateElement = Document.prototype.createElement;
     createElementSpy = jest
       .spyOn(document, "createElement")
-      .mockReturnValue(anchor as any);
+      .mockImplementation((tag: string) => {
+        if (tag.toLowerCase() === "a") {
+          return anchor as any;
+        }
+        return nativeCreateElement.call(document, tag);
+      });
 
     class MockFileReader {
       result: string | ArrayBuffer | null = null;

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -38,7 +38,15 @@ describe("save button", () => {
     const click = jest.fn();
     const anchor = { href: "", download: "", click } as any;
 
-    jest.spyOn(document, "createElement").mockReturnValue(anchor);
+    const nativeCreateElement = Document.prototype.createElement;
+    jest
+      .spyOn(document, "createElement")
+      .mockImplementation((tag: string) => {
+        if (tag.toLowerCase() === "a") {
+          return anchor;
+        }
+        return nativeCreateElement.call(document, tag);
+      });
 
     const handle = initEditor();
 
@@ -85,7 +93,15 @@ describe("save button", () => {
 
     const click = jest.fn();
     const anchor = { href: "", download: "", click } as any;
-    jest.spyOn(document, "createElement").mockReturnValue(anchor);
+    const nativeCreateElement = Document.prototype.createElement;
+    jest
+      .spyOn(document, "createElement")
+      .mockImplementation((tag: string) => {
+        if (tag.toLowerCase() === "a") {
+          return anchor;
+        }
+        return nativeCreateElement.call(document, tag);
+      });
 
     const handle = initEditor();
 

--- a/tests/toolbar.test.ts
+++ b/tests/toolbar.test.ts
@@ -132,5 +132,39 @@ describe("toolbar controls", () => {
     redoBtn.click();
     expect(redo).toHaveBeenCalled();
   });
+
+  it("shows contrast warnings when the selected color fails WCAG thresholds", () => {
+    const colorInput = document.getElementById("colorPicker") as HTMLInputElement;
+    colorInput.value = "#f7f7f7";
+    colorInput.dispatchEvent(new Event("input", { bubbles: true }));
+
+    const message = document.querySelector(
+      "[data-role=contrast-message]",
+    ) as HTMLDivElement;
+    expect(message.textContent).toContain("Light background");
+
+    const adjustButton = document.querySelector(
+      '[data-contrast-row="light"] .contrast-adjust',
+    ) as HTMLButtonElement;
+    expect(adjustButton.disabled).toBe(false);
+  });
+
+  it("auto-adjusts the color to meet contrast guidance", () => {
+    const colorInput = document.getElementById("colorPicker") as HTMLInputElement;
+    colorInput.value = "#f8f8f8";
+    colorInput.dispatchEvent(new Event("input", { bubbles: true }));
+
+    const adjustButton = document.querySelector(
+      '[data-contrast-row="light"] .contrast-adjust',
+    ) as HTMLButtonElement;
+    const previousValue = colorInput.value;
+    adjustButton.click();
+    expect(colorInput.value).not.toBe(previousValue);
+
+    const lightRow = document.querySelector(
+      '[data-contrast-row="light"]',
+    ) as HTMLDivElement;
+    expect(lightRow.classList.contains("contrast-warning")).toBe(false);
+  });
 });
 


### PR DESCRIPTION
## Summary
- add a reusable WCAG contrast utility with ratio calculations and contrast suggestions
- surface live contrast feedback in the editor toolbar with warnings and auto-adjust buttons
- extend the test suite to cover contrast guidance flows and stabilize existing DOM-related tests

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d60d2f1a64832897aa1fb6537333d0