### PR TITLE
Add preview overlays for drawing tools

### DIFF
--- a/dist/core/Editor.js
+++ b/dist/core/Editor.js
@@ -1,5 +1,5 @@
 export class Editor {
-    constructor(canvas, colorPicker, lineWidth, fillMode, onChange, fontFamily, fontSize) {
+    constructor(canvas, colorPicker, lineWidth, fillMode, onChange, fontFamily, fontSize, previewToggle) {
         this.undoStack = [];
         this.redoStack = [];
         this.currentTool = null;
@@ -15,6 +15,9 @@ export class Editor {
         this.handlePointerUp = (e) => {
             this.currentTool?.onPointerUp(e, this);
             this.canvas.releasePointerCapture(e.pointerId);
+        };
+        this.handlePointerLeave = () => {
+            this.clearPreview();
         };
         this.handleResize = () => {
             const data = this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height);
@@ -32,16 +35,37 @@ export class Editor {
         this.onChange = onChange;
         this.fontFamily = fontFamily ?? null;
         this.fontSize = fontSize ?? null;
+        this.previewToggle = previewToggle ?? null;
+        this.previewCanvas = this.createPreviewCanvas();
+        const previewCtx = this.previewCanvas.getContext("2d");
+        if (!previewCtx) {
+            throw new Error("Unable to get preview 2D context");
+        }
+        this.previewCtx = previewCtx;
         this.adjustForPixelRatio();
         window.addEventListener("resize", this.handleResize);
         this.canvas.addEventListener("pointerdown", this.handlePointerDown);
         this.canvas.addEventListener("pointermove", this.handlePointerMove);
         this.canvas.addEventListener("pointerup", this.handlePointerUp);
+        this.canvas.addEventListener("pointerleave", this.handlePointerLeave);
+        this.canvas.addEventListener("pointercancel", this.handlePointerLeave);
     }
     setTool(tool) {
         this.currentTool?.destroy?.();
         this.currentTool = tool;
         this.canvas.style.cursor = tool.cursor || "crosshair";
+    }
+    createPreviewCanvas() {
+        const overlay = document.createElement("canvas");
+        overlay.classList.add("preview-overlay");
+        overlay.style.pointerEvents = "none";
+        overlay.width = this.canvas.width;
+        overlay.height = this.canvas.height;
+        const parent = this.canvas.parentElement;
+        if (parent) {
+            parent.appendChild(overlay);
+        }
+        return overlay;
     }
     adjustForPixelRatio() {
         const dpr = window.devicePixelRatio || 1;
@@ -51,6 +75,10 @@ export class Editor {
         this.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
         // Reset any existing transforms
         this.ctx.scale(1, 1);
+        this.previewCanvas.width = rect.width * dpr;
+        this.previewCanvas.height = rect.height * dpr;
+        this.previewCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        this.previewCtx.scale(1, 1);
     }
     saveState() {
         this.undoStack.push(this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height));
@@ -98,6 +126,44 @@ export class Editor {
     get fontSizeValue() {
         return parseInt(this.fontSize?.value ?? "", 10) || 16;
     }
+    get previewEnabled() {
+        return this.previewToggle ? this.previewToggle.checked : true;
+    }
+    clearPreview() {
+        this.previewCtx.clearRect(0, 0, this.previewCanvas.width, this.previewCanvas.height);
+    }
+    withPreviewContext(callback, { clear = true } = {}) {
+        if (!this.previewEnabled) {
+            if (clear) {
+                this.clearPreview();
+            }
+            return;
+        }
+        if (clear) {
+            this.clearPreview();
+        }
+        this.previewCtx.save();
+        try {
+            callback(this.previewCtx);
+        }
+        finally {
+            this.previewCtx.restore();
+        }
+    }
+    showBrushPreview(x, y, options = {}) {
+        const size = options.size ?? this.lineWidthValue;
+        this.withPreviewContext((ctx) => {
+            ctx.globalAlpha = 0.7;
+            ctx.lineWidth = 1;
+            ctx.strokeStyle = options.color ?? this.strokeStyle;
+            if (options.lineDash) {
+                ctx.setLineDash(options.lineDash);
+            }
+            ctx.beginPath();
+            ctx.arc(x, y, size / 2, 0, Math.PI * 2);
+            ctx.stroke();
+        });
+    }
     /**
      * Remove all event listeners registered by the editor.
      * Should be called before discarding the instance to prevent leaks.
@@ -108,5 +174,8 @@ export class Editor {
         this.canvas.removeEventListener("pointerdown", this.handlePointerDown);
         this.canvas.removeEventListener("pointermove", this.handlePointerMove);
         this.canvas.removeEventListener("pointerup", this.handlePointerUp);
+        this.canvas.removeEventListener("pointerleave", this.handlePointerLeave);
+        this.canvas.removeEventListener("pointercancel", this.handlePointerLeave);
+        this.previewCanvas.remove();
     }
 }

--- a/dist/editor.js
+++ b/dist/editor.js
@@ -69,6 +69,7 @@ export function initEditor() {
     const colorPicker = document.getElementById("colorPicker");
     const lineWidth = document.getElementById("lineWidth");
     const fillMode = document.getElementById("fillMode");
+    const showPreviews = document.getElementById("showPreviews");
     const fontFamily = document.getElementById("fontFamily");
     const fontSize = document.getElementById("fontSize");
     const layerSelect = document.getElementById("layerSelect");
@@ -84,6 +85,9 @@ export function initEditor() {
     }
     if (!fillMode) {
         throw new Error("Missing #fillMode input");
+    }
+    if (!showPreviews) {
+        throw new Error("Missing #showPreviews input");
     }
     if (!saveBtn) {
         throw new Error("Missing #save button");
@@ -166,7 +170,7 @@ export function initEditor() {
         try {
             const e = new Editor(c, colorPicker, lineWidth, fillMode, () => {
                 updateHistoryButtons();
-            }, fontFamily ?? undefined, fontSize ?? undefined);
+            }, fontFamily ?? undefined, fontSize ?? undefined, showPreviews);
             editors.push(e);
         }
         catch {
@@ -203,6 +207,11 @@ export function initEditor() {
     listen(redoBtn, "click", () => {
         editor.redo();
         updateHistoryButtons();
+    }, listeners);
+    listen(showPreviews, "change", () => {
+        if (!showPreviews.checked) {
+            editors.forEach((e) => e.clearPreview());
+        }
     }, listeners);
     // saving
     listen(saveBtn, "click", () => {

--- a/dist/tools/CircleTool.js
+++ b/dist/tools/CircleTool.js
@@ -4,49 +4,45 @@ export class CircleTool extends DrawingTool {
         super(...arguments);
         this.startX = 0;
         this.startY = 0;
-        this.imageData = null;
     }
     onPointerDown(e, editor) {
         this.startX = e.offsetX;
         this.startY = e.offsetY;
-        const ctx = editor.ctx;
-        this.applyStroke(ctx, editor);
-        if (typeof ctx.getImageData === "function") {
-            this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
-        }
-        else {
-            this.imageData = null;
-        }
+        editor.clearPreview();
     }
     onPointerMove(e, editor) {
-        if (e.buttons !== 1 || !this.imageData)
+        if (e.buttons !== 1) {
+            editor.clearPreview();
             return;
-        const ctx = editor.ctx;
-        ctx.putImageData(this.imageData, 0, 0);
-        this.applyStroke(ctx, editor);
-        const dx = e.offsetX - this.startX;
-        const dy = e.offsetY - this.startY;
-        let radiusX = Math.abs(dx);
-        let radiusY = Math.abs(dy);
-        if (e.shiftKey) {
-            const radius = Math.max(radiusX, radiusY);
-            radiusX = radius;
-            radiusY = radius;
         }
-        ctx.beginPath();
-        ctx.ellipse(this.startX, this.startY, radiusX, radiusY, 0, 0, Math.PI * 2);
-        ctx.stroke();
-        if (editor.fill) {
-            ctx.fill();
-        }
-        ctx.closePath();
+        const { radiusX, radiusY } = this.calculateRadii(e);
+        editor.withPreviewContext((ctx) => {
+            this.applyStroke(ctx, editor);
+            ctx.globalAlpha = 0.8;
+            ctx.beginPath();
+            ctx.ellipse(this.startX, this.startY, radiusX, radiusY, 0, 0, Math.PI * 2);
+            ctx.stroke();
+            if (editor.fill) {
+                ctx.globalAlpha = 0.3;
+                ctx.fill();
+            }
+            ctx.closePath();
+        });
     }
     onPointerUp(e, editor) {
         const ctx = editor.ctx;
-        if (this.imageData) {
-            ctx.putImageData(this.imageData, 0, 0);
-        }
+        const { radiusX, radiusY } = this.calculateRadii(e);
+        editor.clearPreview();
         this.applyStroke(ctx, editor);
+        ctx.beginPath();
+        ctx.ellipse(this.startX, this.startY, radiusX, radiusY, 0, 0, Math.PI * 2);
+        ctx.stroke();
+        if (editor.fill) {
+            ctx.fill();
+        }
+        ctx.closePath();
+    }
+    calculateRadii(e) {
         const dx = e.offsetX - this.startX;
         const dy = e.offsetY - this.startY;
         let radiusX = Math.abs(dx);
@@ -56,13 +52,6 @@ export class CircleTool extends DrawingTool {
             radiusX = radius;
             radiusY = radius;
         }
-        ctx.beginPath();
-        ctx.ellipse(this.startX, this.startY, radiusX, radiusY, 0, 0, Math.PI * 2);
-        ctx.stroke();
-        if (editor.fill) {
-            ctx.fill();
-        }
-        ctx.closePath();
-        this.imageData = null;
+        return { radiusX, radiusY };
     }
 }

--- a/dist/tools/EraserTool.js
+++ b/dist/tools/EraserTool.js
@@ -7,19 +7,36 @@ export class EraserTool extends DrawingTool {
         ctx.beginPath();
         ctx.moveTo(e.offsetX, e.offsetY);
         ctx.clearRect(e.offsetX - editor.lineWidthValue / 2, e.offsetY - editor.lineWidthValue / 2, editor.lineWidthValue, editor.lineWidthValue);
+        editor.showBrushPreview(e.offsetX, e.offsetY, {
+            color: "#000",
+            lineDash: [4, 4],
+        });
     }
     onPointerMove(e, editor) {
-        if (e.buttons !== 1)
+        if (e.buttons !== 1) {
+            editor.showBrushPreview(e.offsetX, e.offsetY, {
+                color: "#000",
+                lineDash: [4, 4],
+            });
             return;
+        }
         const ctx = editor.ctx;
         this.applyStroke(ctx, editor);
         ctx.lineTo(e.offsetX, e.offsetY);
         ctx.stroke();
         ctx.clearRect(e.offsetX - editor.lineWidthValue / 2, e.offsetY - editor.lineWidthValue / 2, editor.lineWidthValue, editor.lineWidthValue);
+        editor.showBrushPreview(e.offsetX, e.offsetY, {
+            color: "#000",
+            lineDash: [4, 4],
+        });
     }
-    onPointerUp(_e, editor) {
+    onPointerUp(e, editor) {
         const ctx = editor.ctx;
         ctx.closePath();
         ctx.globalCompositeOperation = "source-over";
+        editor.showBrushPreview(e.offsetX, e.offsetY, {
+            color: "#000",
+            lineDash: [4, 4],
+        });
     }
 }

--- a/dist/tools/LineTool.js
+++ b/dist/tools/LineTool.js
@@ -4,46 +4,41 @@ export class LineTool extends DrawingTool {
         super(...arguments);
         this.startX = 0;
         this.startY = 0;
-        this.imageData = null;
     }
     onPointerDown(e, editor) {
-        const ctx = editor.ctx;
         this.startX = e.offsetX;
         this.startY = e.offsetY;
-        this.applyStroke(ctx, editor);
-        this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
+        editor.clearPreview();
     }
     onPointerMove(e, editor) {
-        if (e.buttons !== 1 || !this.imageData)
+        if (e.buttons !== 1) {
+            editor.clearPreview();
             return;
-        const ctx = editor.ctx;
-        ctx.putImageData(this.imageData, 0, 0);
-        this.applyStroke(ctx, editor);
-        ctx.beginPath();
-        ctx.moveTo(this.startX, this.startY);
-        let x = e.offsetX;
-        let y = e.offsetY;
-        if (e.shiftKey) {
-            const dx = x - this.startX;
-            const dy = y - this.startY;
-            const angle = Math.atan2(dy, dx);
-            const snapped = Math.round(angle / (Math.PI / 4)) * (Math.PI / 4);
-            const length = Math.sqrt(dx * dx + dy * dy);
-            x = this.startX + length * Math.cos(snapped);
-            y = this.startY + length * Math.sin(snapped);
         }
-        ctx.lineTo(x, y);
-        ctx.stroke();
-        ctx.closePath();
+        const { x, y } = this.calculateEndPoint(e);
+        editor.withPreviewContext((ctx) => {
+            this.applyStroke(ctx, editor);
+            ctx.globalAlpha = 0.8;
+            ctx.setLineDash([6, 4]);
+            ctx.beginPath();
+            ctx.moveTo(this.startX, this.startY);
+            ctx.lineTo(x, y);
+            ctx.stroke();
+            ctx.closePath();
+        });
     }
     onPointerUp(e, editor) {
         const ctx = editor.ctx;
-        if (this.imageData) {
-            ctx.putImageData(this.imageData, 0, 0);
-        }
+        const { x, y } = this.calculateEndPoint(e);
+        editor.clearPreview();
         this.applyStroke(ctx, editor);
         ctx.beginPath();
         ctx.moveTo(this.startX, this.startY);
+        ctx.lineTo(x, y);
+        ctx.stroke();
+        ctx.closePath();
+    }
+    calculateEndPoint(e) {
         let x = e.offsetX;
         let y = e.offsetY;
         if (e.shiftKey) {
@@ -55,9 +50,6 @@ export class LineTool extends DrawingTool {
             x = this.startX + length * Math.cos(snapped);
             y = this.startY + length * Math.sin(snapped);
         }
-        ctx.lineTo(x, y);
-        ctx.stroke();
-        ctx.closePath();
-        this.imageData = null;
+        return { x, y };
     }
 }

--- a/dist/tools/PencilTool.js
+++ b/dist/tools/PencilTool.js
@@ -5,16 +5,21 @@ export class PencilTool extends DrawingTool {
         const ctx = editor.ctx;
         ctx.beginPath();
         ctx.moveTo(e.offsetX, e.offsetY);
+        editor.showBrushPreview(e.offsetX, e.offsetY);
     }
     onPointerMove(e, editor) {
-        if (e.buttons !== 1)
+        if (e.buttons !== 1) {
+            editor.showBrushPreview(e.offsetX, e.offsetY);
             return;
+        }
         this.applyStroke(editor.ctx, editor);
         const ctx = editor.ctx;
         ctx.lineTo(e.offsetX, e.offsetY);
         ctx.stroke();
+        editor.showBrushPreview(e.offsetX, e.offsetY);
     }
-    onPointerUp(_e, editor) {
+    onPointerUp(e, editor) {
         editor.ctx.closePath();
+        editor.showBrushPreview(e.offsetX, e.offsetY);
     }
 }

--- a/dist/tools/RectangleTool.js
+++ b/dist/tools/RectangleTool.js
@@ -4,41 +4,39 @@ export class RectangleTool extends DrawingTool {
         super(...arguments);
         this.startX = 0;
         this.startY = 0;
-        this.imageData = null;
     }
     onPointerDown(e, editor) {
         this.startX = e.offsetX;
         this.startY = e.offsetY;
-        this.applyStroke(editor.ctx, editor);
-        const ctx = editor.ctx;
-        this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
+        editor.clearPreview();
     }
     onPointerMove(e, editor) {
-        if (e.buttons !== 1 || !this.imageData)
+        if (e.buttons !== 1) {
+            editor.clearPreview();
             return;
-        const ctx = editor.ctx;
-        ctx.putImageData(this.imageData, 0, 0);
-        this.applyStroke(editor.ctx, editor);
-        const x = e.offsetX;
-        const y = e.offsetY;
-        let width = x - this.startX;
-        let height = y - this.startY;
-        if (e.shiftKey) {
-            const size = Math.min(Math.abs(width), Math.abs(height));
-            width = size * Math.sign(width);
-            height = size * Math.sign(height);
         }
-        ctx.strokeRect(this.startX, this.startY, width, height);
-        if (editor.fill) {
-            ctx.fillRect(this.startX, this.startY, width, height);
-        }
+        const { width, height } = this.calculateDimensions(e);
+        editor.withPreviewContext((ctx) => {
+            this.applyStroke(ctx, editor);
+            ctx.globalAlpha = 0.8;
+            ctx.strokeRect(this.startX, this.startY, width, height);
+            if (editor.fill) {
+                ctx.globalAlpha = 0.3;
+                ctx.fillRect(this.startX, this.startY, width, height);
+            }
+        });
     }
     onPointerUp(e, editor) {
         const ctx = editor.ctx;
-        if (this.imageData) {
-            ctx.putImageData(this.imageData, 0, 0);
-        }
+        const { width, height } = this.calculateDimensions(e);
+        editor.clearPreview();
         this.applyStroke(editor.ctx, editor);
+        ctx.strokeRect(this.startX, this.startY, width, height);
+        if (editor.fill) {
+            ctx.fillRect(this.startX, this.startY, width, height);
+        }
+    }
+    calculateDimensions(e) {
         const x = e.offsetX;
         const y = e.offsetY;
         let width = x - this.startX;
@@ -48,10 +46,6 @@ export class RectangleTool extends DrawingTool {
             width = size * Math.sign(width);
             height = size * Math.sign(height);
         }
-        ctx.strokeRect(this.startX, this.startY, width, height);
-        if (editor.fill) {
-            ctx.fillRect(this.startX, this.startY, width, height);
-        }
-        this.imageData = null;
+        return { width, height };
     }
 }

--- a/index.html
+++ b/index.html
@@ -21,6 +21,10 @@
         <input type="checkbox" id="fillMode" />
         Fill
       </label>
+      <label>
+        <input type="checkbox" id="showPreviews" checked />
+        Show previews
+      </label>
       <button id="pencil" class="tool-button" title="Pencil">
         <img src="icons/pencil.svg" alt="Pencil" />
       </button>

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -3,6 +3,8 @@ import { Tool } from "../tools/Tool.js";
 export class Editor {
   canvas: HTMLCanvasElement;
   ctx: CanvasRenderingContext2D;
+  readonly previewCanvas: HTMLCanvasElement;
+  readonly previewCtx: CanvasRenderingContext2D;
   private undoStack: ImageData[] = [];
   private redoStack: ImageData[] = [];
   private currentTool: Tool | null = null;
@@ -11,6 +13,7 @@ export class Editor {
   fillMode: HTMLInputElement;
   fontFamily: HTMLSelectElement | null;
   fontSize: HTMLInputElement | null;
+  private previewToggle: HTMLInputElement | null;
   private onChange?: () => void;
 
   constructor(
@@ -21,6 +24,7 @@ export class Editor {
     onChange?: () => void,
     fontFamily?: HTMLSelectElement | null,
     fontSize?: HTMLInputElement | null,
+    previewToggle?: HTMLInputElement | null,
   ) {
     this.canvas = canvas;
     const ctx = canvas.getContext("2d");
@@ -32,18 +36,41 @@ export class Editor {
     this.onChange = onChange;
     this.fontFamily = fontFamily ?? null;
     this.fontSize = fontSize ?? null;
+    this.previewToggle = previewToggle ?? null;
+
+    this.previewCanvas = this.createPreviewCanvas();
+    const previewCtx = this.previewCanvas.getContext("2d");
+    if (!previewCtx) {
+      throw new Error("Unable to get preview 2D context");
+    }
+    this.previewCtx = previewCtx;
     this.adjustForPixelRatio();
     window.addEventListener("resize", this.handleResize);
 
     this.canvas.addEventListener("pointerdown", this.handlePointerDown);
     this.canvas.addEventListener("pointermove", this.handlePointerMove);
     this.canvas.addEventListener("pointerup", this.handlePointerUp);
+    this.canvas.addEventListener("pointerleave", this.handlePointerLeave);
+    this.canvas.addEventListener("pointercancel", this.handlePointerLeave);
   }
 
   setTool(tool: Tool) {
     this.currentTool?.destroy?.();
     this.currentTool = tool;
     this.canvas.style.cursor = tool.cursor || "crosshair";
+  }
+
+  private createPreviewCanvas(): HTMLCanvasElement {
+    const overlay = document.createElement("canvas");
+    overlay.classList.add("preview-overlay");
+    overlay.style.pointerEvents = "none";
+    overlay.width = this.canvas.width;
+    overlay.height = this.canvas.height;
+    const parent = this.canvas.parentElement;
+    if (parent) {
+      parent.appendChild(overlay);
+    }
+    return overlay;
   }
 
   private handlePointerDown = (e: PointerEvent) => {
@@ -62,6 +89,10 @@ export class Editor {
     this.canvas.releasePointerCapture(e.pointerId);
   };
 
+  private handlePointerLeave = () => {
+    this.clearPreview();
+  };
+
   private adjustForPixelRatio() {
     const dpr = window.devicePixelRatio || 1;
     const rect = this.canvas.getBoundingClientRect();
@@ -70,6 +101,10 @@ export class Editor {
     this.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     // Reset any existing transforms
     this.ctx.scale(1, 1);
+    this.previewCanvas.width = rect.width * dpr;
+    this.previewCanvas.height = rect.height * dpr;
+    this.previewCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    this.previewCtx.scale(1, 1);
   }
 
   private handleResize = () => {
@@ -143,6 +178,58 @@ export class Editor {
     return parseInt(this.fontSize?.value ?? "", 10) || 16;
   }
 
+  get previewEnabled() {
+    return this.previewToggle ? this.previewToggle.checked : true;
+  }
+
+  clearPreview() {
+    this.previewCtx.clearRect(0, 0, this.previewCanvas.width, this.previewCanvas.height);
+  }
+
+  withPreviewContext(
+    callback: (ctx: CanvasRenderingContext2D) => void,
+    { clear = true }: { clear?: boolean } = {},
+  ) {
+    if (!this.previewEnabled) {
+      if (clear) {
+        this.clearPreview();
+      }
+      return;
+    }
+    if (clear) {
+      this.clearPreview();
+    }
+    this.previewCtx.save();
+    try {
+      callback(this.previewCtx);
+    } finally {
+      this.previewCtx.restore();
+    }
+  }
+
+  showBrushPreview(
+    x: number,
+    y: number,
+    options: {
+      size?: number;
+      color?: string;
+      lineDash?: number[];
+    } = {},
+  ) {
+    const size = options.size ?? this.lineWidthValue;
+    this.withPreviewContext((ctx) => {
+      ctx.globalAlpha = 0.7;
+      ctx.lineWidth = 1;
+      ctx.strokeStyle = options.color ?? this.strokeStyle;
+      if (options.lineDash) {
+        ctx.setLineDash(options.lineDash);
+      }
+      ctx.beginPath();
+      ctx.arc(x, y, size / 2, 0, Math.PI * 2);
+      ctx.stroke();
+    });
+  }
+
   /**
    * Remove all event listeners registered by the editor.
    * Should be called before discarding the instance to prevent leaks.
@@ -153,5 +240,8 @@ export class Editor {
     this.canvas.removeEventListener("pointerdown", this.handlePointerDown);
     this.canvas.removeEventListener("pointermove", this.handlePointerMove);
     this.canvas.removeEventListener("pointerup", this.handlePointerUp);
+    this.canvas.removeEventListener("pointerleave", this.handlePointerLeave);
+    this.canvas.removeEventListener("pointercancel", this.handlePointerLeave);
+    this.previewCanvas.remove();
   }
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -89,6 +89,8 @@ export function initEditor(): EditorHandle {
     document.getElementById("colorPicker") as HTMLInputElement | null;
   const lineWidth = document.getElementById("lineWidth") as HTMLInputElement | null;
   const fillMode = document.getElementById("fillMode") as HTMLInputElement | null;
+  const showPreviews =
+    document.getElementById("showPreviews") as HTMLInputElement | null;
   const fontFamily = document.getElementById("fontFamily") as HTMLSelectElement | null;
   const fontSize = document.getElementById("fontSize") as HTMLInputElement | null;
   const layerSelect = document.getElementById("layerSelect") as HTMLSelectElement | null;
@@ -108,6 +110,9 @@ export function initEditor(): EditorHandle {
   }
   if (!fillMode) {
     throw new Error("Missing #fillMode input");
+  }
+  if (!showPreviews) {
+    throw new Error("Missing #showPreviews input");
   }
   if (!saveBtn) {
     throw new Error("Missing #save button");
@@ -212,6 +217,7 @@ export function initEditor(): EditorHandle {
         },
         fontFamily ?? undefined,
         fontSize ?? undefined,
+        showPreviews,
       );
       editors.push(e);
     } catch {
@@ -268,6 +274,17 @@ export function initEditor(): EditorHandle {
     () => {
       editor.redo();
       updateHistoryButtons();
+    },
+    listeners,
+  );
+
+  listen(
+    showPreviews,
+    "change",
+    () => {
+      if (!showPreviews!.checked) {
+        editors.forEach((e) => e.clearPreview());
+      }
     },
     listeners,
   );

--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -4,49 +4,48 @@ import { DrawingTool } from "./DrawingTool.js";
 export class CircleTool extends DrawingTool {
   private startX = 0;
   private startY = 0;
-  private imageData: ImageData | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
     this.startX = e.offsetX;
     this.startY = e.offsetY;
-    const ctx = editor.ctx;
-    this.applyStroke(ctx, editor);
-    if (typeof ctx.getImageData === "function") {
-      this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
-    } else {
-      this.imageData = null;
-    }
+    editor.clearPreview();
   }
 
   onPointerMove(e: PointerEvent, editor: Editor): void {
-    if (e.buttons !== 1 || !this.imageData) return;
-    const ctx = editor.ctx;
-    ctx.putImageData(this.imageData, 0, 0);
-    this.applyStroke(ctx, editor);
-    const dx = e.offsetX - this.startX;
-    const dy = e.offsetY - this.startY;
-    let radiusX = Math.abs(dx);
-    let radiusY = Math.abs(dy);
-    if (e.shiftKey) {
-      const radius = Math.max(radiusX, radiusY);
-      radiusX = radius;
-      radiusY = radius;
+    if (e.buttons !== 1) {
+      editor.clearPreview();
+      return;
     }
-    ctx.beginPath();
-    ctx.ellipse(this.startX, this.startY, radiusX, radiusY, 0, 0, Math.PI * 2);
-    ctx.stroke();
-    if (editor.fill) {
-      ctx.fill();
-    }
-    ctx.closePath();
+    const { radiusX, radiusY } = this.calculateRadii(e);
+    editor.withPreviewContext((ctx) => {
+      this.applyStroke(ctx, editor);
+      ctx.globalAlpha = 0.8;
+      ctx.beginPath();
+      ctx.ellipse(this.startX, this.startY, radiusX, radiusY, 0, 0, Math.PI * 2);
+      ctx.stroke();
+      if (editor.fill) {
+        ctx.globalAlpha = 0.3;
+        ctx.fill();
+      }
+      ctx.closePath();
+    });
   }
 
   onPointerUp(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
-    if (this.imageData) {
-      ctx.putImageData(this.imageData, 0, 0);
-    }
+    const { radiusX, radiusY } = this.calculateRadii(e);
+    editor.clearPreview();
     this.applyStroke(ctx, editor);
+    ctx.beginPath();
+    ctx.ellipse(this.startX, this.startY, radiusX, radiusY, 0, 0, Math.PI * 2);
+    ctx.stroke();
+    if (editor.fill) {
+      ctx.fill();
+    }
+    ctx.closePath();
+  }
+
+  private calculateRadii(e: PointerEvent) {
     const dx = e.offsetX - this.startX;
     const dy = e.offsetY - this.startY;
     let radiusX = Math.abs(dx);
@@ -56,14 +55,7 @@ export class CircleTool extends DrawingTool {
       radiusX = radius;
       radiusY = radius;
     }
-    ctx.beginPath();
-    ctx.ellipse(this.startX, this.startY, radiusX, radiusY, 0, 0, Math.PI * 2);
-    ctx.stroke();
-    if (editor.fill) {
-      ctx.fill();
-    }
-    ctx.closePath();
-    this.imageData = null;
+    return { radiusX, radiusY };
   }
 }
 

--- a/src/tools/EraserTool.ts
+++ b/src/tools/EraserTool.ts
@@ -14,10 +14,20 @@ export class EraserTool extends DrawingTool {
       editor.lineWidthValue,
       editor.lineWidthValue,
     );
+    editor.showBrushPreview(e.offsetX, e.offsetY, {
+      color: "#000",
+      lineDash: [4, 4],
+    });
   }
 
   onPointerMove(e: PointerEvent, editor: Editor) {
-    if (e.buttons !== 1) return;
+    if (e.buttons !== 1) {
+      editor.showBrushPreview(e.offsetX, e.offsetY, {
+        color: "#000",
+        lineDash: [4, 4],
+      });
+      return;
+    }
     const ctx = editor.ctx;
     this.applyStroke(ctx, editor);
     ctx.lineTo(e.offsetX, e.offsetY);
@@ -28,11 +38,19 @@ export class EraserTool extends DrawingTool {
       editor.lineWidthValue,
       editor.lineWidthValue,
     );
+    editor.showBrushPreview(e.offsetX, e.offsetY, {
+      color: "#000",
+      lineDash: [4, 4],
+    });
   }
 
-  onPointerUp(_e: PointerEvent, editor: Editor) {
+  onPointerUp(e: PointerEvent, editor: Editor) {
     const ctx = editor.ctx;
     ctx.closePath();
     ctx.globalCompositeOperation = "source-over";
+    editor.showBrushPreview(e.offsetX, e.offsetY, {
+      color: "#000",
+      lineDash: [4, 4],
+    });
   }
 }

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -4,52 +4,44 @@ import { DrawingTool } from "./DrawingTool.js";
 export class LineTool extends DrawingTool {
   private startX = 0;
   private startY = 0;
-  private imageData: ImageData | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
-    const ctx = editor.ctx;
     this.startX = e.offsetX;
     this.startY = e.offsetY;
-    this.applyStroke(ctx, editor);
-    this.imageData = ctx.getImageData(
-      0,
-      0,
-      editor.canvas.width,
-      editor.canvas.height,
-    );
+    editor.clearPreview();
   }
 
   onPointerMove(e: PointerEvent, editor: Editor): void {
-    if (e.buttons !== 1 || !this.imageData) return;
-    const ctx = editor.ctx;
-    ctx.putImageData(this.imageData, 0, 0);
-    this.applyStroke(ctx, editor);
-    ctx.beginPath();
-    ctx.moveTo(this.startX, this.startY);
-    let x = e.offsetX;
-    let y = e.offsetY;
-    if (e.shiftKey) {
-      const dx = x - this.startX;
-      const dy = y - this.startY;
-      const angle = Math.atan2(dy, dx);
-      const snapped = Math.round(angle / (Math.PI / 4)) * (Math.PI / 4);
-      const length = Math.sqrt(dx * dx + dy * dy);
-      x = this.startX + length * Math.cos(snapped);
-      y = this.startY + length * Math.sin(snapped);
+    if (e.buttons !== 1) {
+      editor.clearPreview();
+      return;
     }
-    ctx.lineTo(x, y);
-    ctx.stroke();
-    ctx.closePath();
+    const { x, y } = this.calculateEndPoint(e);
+    editor.withPreviewContext((ctx) => {
+      this.applyStroke(ctx, editor);
+      ctx.globalAlpha = 0.8;
+      ctx.setLineDash([6, 4]);
+      ctx.beginPath();
+      ctx.moveTo(this.startX, this.startY);
+      ctx.lineTo(x, y);
+      ctx.stroke();
+      ctx.closePath();
+    });
   }
 
   onPointerUp(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
-    if (this.imageData) {
-      ctx.putImageData(this.imageData, 0, 0);
-    }
+    const { x, y } = this.calculateEndPoint(e);
+    editor.clearPreview();
     this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
+    ctx.lineTo(x, y);
+    ctx.stroke();
+    ctx.closePath();
+  }
+
+  private calculateEndPoint(e: PointerEvent) {
     let x = e.offsetX;
     let y = e.offsetY;
     if (e.shiftKey) {
@@ -61,9 +53,6 @@ export class LineTool extends DrawingTool {
       x = this.startX + length * Math.cos(snapped);
       y = this.startY + length * Math.sin(snapped);
     }
-    ctx.lineTo(x, y);
-    ctx.stroke();
-    ctx.closePath();
-    this.imageData = null;
+    return { x, y };
   }
 }

--- a/src/tools/PencilTool.ts
+++ b/src/tools/PencilTool.ts
@@ -7,17 +7,23 @@ export class PencilTool extends DrawingTool {
     const ctx = editor.ctx;
     ctx.beginPath();
     ctx.moveTo(e.offsetX, e.offsetY);
+    editor.showBrushPreview(e.offsetX, e.offsetY);
   }
 
   onPointerMove(e: PointerEvent, editor: Editor) {
-    if (e.buttons !== 1) return;
+    if (e.buttons !== 1) {
+      editor.showBrushPreview(e.offsetX, e.offsetY);
+      return;
+    }
     this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
     ctx.lineTo(e.offsetX, e.offsetY);
     ctx.stroke();
+    editor.showBrushPreview(e.offsetX, e.offsetY);
   }
 
-  onPointerUp(_e: PointerEvent, editor: Editor) {
+  onPointerUp(e: PointerEvent, editor: Editor) {
     editor.ctx.closePath();
+    editor.showBrushPreview(e.offsetX, e.offsetY);
   }
 }

--- a/src/tools/RectangleTool.ts
+++ b/src/tools/RectangleTool.ts
@@ -4,44 +4,42 @@ import { DrawingTool } from "./DrawingTool.js";
 export class RectangleTool extends DrawingTool {
   private startX = 0;
   private startY = 0;
-  private imageData: ImageData | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor) {
     this.startX = e.offsetX;
     this.startY = e.offsetY;
-    this.applyStroke(editor.ctx, editor);
-    const ctx = editor.ctx;
-    this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
+    editor.clearPreview();
   }
 
   onPointerMove(e: PointerEvent, editor: Editor) {
-    if (e.buttons !== 1 || !this.imageData) return;
-    const ctx = editor.ctx;
-    ctx.putImageData(this.imageData, 0, 0);
-    this.applyStroke(editor.ctx, editor);
-
-    const x = e.offsetX;
-    const y = e.offsetY;
-    let width = x - this.startX;
-    let height = y - this.startY;
-    if (e.shiftKey) {
-      const size = Math.min(Math.abs(width), Math.abs(height));
-      width = size * Math.sign(width);
-      height = size * Math.sign(height);
+    if (e.buttons !== 1) {
+      editor.clearPreview();
+      return;
     }
-    ctx.strokeRect(this.startX, this.startY, width, height);
-    if (editor.fill) {
-      ctx.fillRect(this.startX, this.startY, width, height);
-    }
+    const { width, height } = this.calculateDimensions(e);
+    editor.withPreviewContext((ctx) => {
+      this.applyStroke(ctx, editor);
+      ctx.globalAlpha = 0.8;
+      ctx.strokeRect(this.startX, this.startY, width, height);
+      if (editor.fill) {
+        ctx.globalAlpha = 0.3;
+        ctx.fillRect(this.startX, this.startY, width, height);
+      }
+    });
   }
 
   onPointerUp(e: PointerEvent, editor: Editor) {
     const ctx = editor.ctx;
-    if (this.imageData) {
-      ctx.putImageData(this.imageData, 0, 0);
-    }
-
+    const { width, height } = this.calculateDimensions(e);
+    editor.clearPreview();
     this.applyStroke(editor.ctx, editor);
+    ctx.strokeRect(this.startX, this.startY, width, height);
+    if (editor.fill) {
+      ctx.fillRect(this.startX, this.startY, width, height);
+    }
+  }
+
+  private calculateDimensions(e: PointerEvent) {
     const x = e.offsetX;
     const y = e.offsetY;
     let width = x - this.startX;
@@ -51,10 +49,6 @@ export class RectangleTool extends DrawingTool {
       width = size * Math.sign(width);
       height = size * Math.sign(height);
     }
-    ctx.strokeRect(this.startX, this.startY, width, height);
-    if (editor.fill) {
-      ctx.fillRect(this.startX, this.startY, width, height);
-    }
-    this.imageData = null;
+    return { width, height };
   }
 }

--- a/style.css
+++ b/style.css
@@ -99,4 +99,9 @@ body {
   box-sizing: border-box;
 }
 
+#canvasContainer .preview-overlay {
+  pointer-events: none;
+  z-index: 10;
+}
+
 

--- a/tests/bucketFillTool.test.ts
+++ b/tests/bucketFillTool.test.ts
@@ -1,10 +1,12 @@
 import { Editor } from "../src/core/Editor.js";
 import { BucketFillTool } from "../src/tools/BucketFillTool.js";
+import { mockPreviewCanvas, type PreviewCanvasMock } from "./helpers.js";
 
 describe("BucketFillTool", () => {
   let canvas: HTMLCanvasElement;
   let ctx: Partial<CanvasRenderingContext2D>;
   let editor: Editor;
+  let preview: PreviewCanvasMock;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -12,7 +14,9 @@ describe("BucketFillTool", () => {
       <input id="colorPicker" value="#0000ff" />
       <input id="lineWidth" value="1" />
       <input id="fillMode" type="checkbox" />
+      <input id="showPreviews" type="checkbox" checked />
     `;
+    preview = mockPreviewCanvas();
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
     (canvas as any).setPointerCapture = jest.fn();
     (canvas as any).releasePointerCapture = jest.fn();
@@ -45,7 +49,15 @@ describe("BucketFillTool", () => {
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
       document.getElementById("fillMode") as HTMLInputElement,
+      undefined,
+      undefined,
+      undefined,
+      document.getElementById("showPreviews") as HTMLInputElement,
     );
+  });
+
+  afterEach(() => {
+    preview.restore();
   });
 
   it("fills enclosed areas with the selected color", () => {

--- a/tests/bucketIntegration.test.ts
+++ b/tests/bucketIntegration.test.ts
@@ -1,10 +1,12 @@
 import { initEditor, EditorHandle } from "../src/editor.js";
 import { BucketFillTool } from "../src/tools/BucketFillTool.js";
+import { mockPreviewCanvas, type PreviewCanvasMock } from "./helpers.js";
 
 describe("bucket tool integration", () => {
   let handle: EditorHandle;
   let canvas: HTMLCanvasElement;
   let ctx: Partial<CanvasRenderingContext2D>;
+  let preview: PreviewCanvasMock;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -12,6 +14,7 @@ describe("bucket tool integration", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="1" />
       <input id="fillMode" type="checkbox" />
+      <input id="showPreviews" type="checkbox" checked />
       <button id="pencil"></button>
       <button id="eraser"></button>
       <button id="rectangle"></button>
@@ -23,6 +26,7 @@ describe("bucket tool integration", () => {
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>
     `;
+    preview = mockPreviewCanvas();
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
     (canvas as any).setPointerCapture = jest.fn();
     (canvas as any).releasePointerCapture = jest.fn();
@@ -51,6 +55,7 @@ describe("bucket tool integration", () => {
 
   afterEach(() => {
     handle.destroy();
+    preview.restore();
   });
 
   it("activates bucket tool from toolbar", () => {

--- a/tests/circleTool.test.ts
+++ b/tests/circleTool.test.ts
@@ -1,9 +1,11 @@
 import { Editor } from "../src/core/Editor.js";
 import { CircleTool } from "../src/tools/CircleTool.js";
+import { mockPreviewCanvas, type PreviewCanvasMock } from "./helpers.js";
 
 describe("CircleTool", () => {
   let editor: Editor;
   let ctx: Partial<CanvasRenderingContext2D>;
+  let preview: PreviewCanvasMock;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -11,7 +13,9 @@ describe("CircleTool", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
+      <input id="showPreviews" type="checkbox" checked />
     `;
+    preview = mockPreviewCanvas();
     const canvas = document.getElementById("canvas") as HTMLCanvasElement;
     (canvas as any).setPointerCapture = jest.fn();
     (canvas as any).releasePointerCapture = jest.fn();
@@ -35,7 +39,15 @@ describe("CircleTool", () => {
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
       document.getElementById("fillMode") as HTMLInputElement,
+      undefined,
+      undefined,
+      undefined,
+      document.getElementById("showPreviews") as HTMLInputElement,
     );
+  });
+
+  afterEach(() => {
+    preview.restore();
   });
 
   it("previews circle during pointer move", () => {
@@ -47,17 +59,21 @@ describe("CircleTool", () => {
       buttons: 1,
     } as PointerEvent, editor);
 
-    expect(ctx.getImageData).toHaveBeenCalled();
-    const image = (ctx.getImageData as jest.Mock).mock.results[0].value;
-    expect(ctx.putImageData).toHaveBeenCalledWith(image, 0, 0);
     const dx = 5 - 2;
     const dy = 7 - 3;
     const radiusX = Math.abs(dx);
     const radiusY = Math.abs(dy);
-    expect(ctx.beginPath).toHaveBeenCalled();
-    expect(ctx.ellipse).toHaveBeenCalledWith(2, 3, radiusX, radiusY, 0, 0, Math.PI * 2);
-    expect(ctx.stroke).toHaveBeenCalled();
-    expect(ctx.closePath).toHaveBeenCalled();
+    expect(preview.ctx.beginPath).toHaveBeenCalled();
+    expect(preview.ctx.ellipse).toHaveBeenCalledWith(
+      2,
+      3,
+      radiusX,
+      radiusY,
+      0,
+      0,
+      Math.PI * 2,
+    );
+    expect(preview.ctx.stroke).toHaveBeenCalled();
   });
 
   it("fills circle on pointer up when enabled", () => {

--- a/tests/colorRendering.test.ts
+++ b/tests/colorRendering.test.ts
@@ -1,6 +1,7 @@
 import { Editor } from "../src/core/Editor.js";
 import { PencilTool } from "../src/tools/PencilTool.js";
 import { RectangleTool } from "../src/tools/RectangleTool.js";
+import { mockPreviewCanvas, type PreviewCanvasMock } from "./helpers.js";
 
 describe("color rendering", () => {
   let canvas: HTMLCanvasElement;
@@ -10,6 +11,7 @@ describe("color rendering", () => {
     lineWidth: number;
   };
   let editor: Editor;
+  let preview: PreviewCanvasMock;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -17,7 +19,9 @@ describe("color rendering", () => {
       <input id="colorPicker" value="#111111" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
+      <input id="showPreviews" type="checkbox" checked />
     `;
+    preview = mockPreviewCanvas();
 
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
 
@@ -64,11 +68,16 @@ describe("color rendering", () => {
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
       document.getElementById("fillMode") as HTMLInputElement,
+      undefined,
+      undefined,
+      undefined,
+      document.getElementById("showPreviews") as HTMLInputElement,
     );
   });
 
   afterEach(() => {
     editor.destroy();
+    preview.restore();
   });
 
   it("uses the selected color for strokes and fills", () => {

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -1,4 +1,5 @@
 import { initEditor, EditorHandle } from "../src/editor.js";
+import { mockPreviewCanvas, type PreviewCanvasMock } from "./helpers.js";
 
 // Integration tests ensuring toolbar controls are wired to the editor
 // and trigger the expected behavior.
@@ -6,6 +7,7 @@ describe("editor toolbar controls", () => {
   let canvas: HTMLCanvasElement;
   let ctx: Partial<CanvasRenderingContext2D>;
   let handle: EditorHandle;
+  let preview: PreviewCanvasMock;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -13,6 +15,7 @@ describe("editor toolbar controls", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
+      <input id="showPreviews" type="checkbox" checked />
       <button id="pencil"></button>
       <button id="eraser"></button>
       <button id="rectangle"></button>
@@ -28,6 +31,7 @@ describe("editor toolbar controls", () => {
       <button id="save"></button>
     `;
 
+    preview = mockPreviewCanvas();
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
     (canvas as any).setPointerCapture = jest.fn();
     (canvas as any).releasePointerCapture = jest.fn();
@@ -78,6 +82,7 @@ describe("editor toolbar controls", () => {
 
   afterEach(() => {
     handle.destroy();
+    preview.restore();
   });
 
   function dispatch(type: string, x: number, y: number, buttons = 0) {
@@ -130,9 +135,7 @@ describe("editor toolbar controls", () => {
     (document.getElementById("rectangle") as HTMLButtonElement).click();
     dispatch("pointerdown", 1, 1, 1);
     dispatch("pointermove", 3, 4, 1);
-    expect(ctx.getImageData).toHaveBeenCalled();
-    expect(ctx.putImageData).toHaveBeenCalled();
-    expect(ctx.strokeRect).toHaveBeenCalledWith(1, 1, 2, 3);
+    expect(preview.ctx.strokeRect).toHaveBeenCalledWith(1, 1, 2, 3);
   });
 
   it("draws line with line tool", () => {

--- a/tests/eraserTool.test.ts
+++ b/tests/eraserTool.test.ts
@@ -1,9 +1,11 @@
 import { Editor } from "../src/core/Editor.js";
 import { EraserTool } from "../src/tools/EraserTool.js";
+import { mockPreviewCanvas, type PreviewCanvasMock } from "./helpers.js";
 
 describe("EraserTool", () => {
   let editor: Editor;
   let ctx: Partial<CanvasRenderingContext2D>;
+  let preview: PreviewCanvasMock;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -11,7 +13,9 @@ describe("EraserTool", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="10" />
       <input id="fillMode" type="checkbox" />
+      <input id="showPreviews" type="checkbox" checked />
     `;
+    preview = mockPreviewCanvas();
     const canvas = document.getElementById("canvas") as HTMLCanvasElement;
     (canvas as any).setPointerCapture = jest.fn();
     (canvas as any).releasePointerCapture = jest.fn();
@@ -35,7 +39,15 @@ describe("EraserTool", () => {
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
       document.getElementById("fillMode") as HTMLInputElement,
+      undefined,
+      undefined,
+      undefined,
+      document.getElementById("showPreviews") as HTMLInputElement,
     );
+  });
+
+  afterEach(() => {
+    preview.restore();
   });
 
   it("uses destination-out compositing to erase", () => {

--- a/tests/eyedropperTool.test.ts
+++ b/tests/eyedropperTool.test.ts
@@ -1,18 +1,22 @@
 import { Editor } from "../src/core/Editor.js";
 import { EyedropperTool } from "../src/tools/EyedropperTool.js";
 import { initEditor, type EditorHandle } from "../src/editor.js";
+import { mockPreviewCanvas, type PreviewCanvasMock } from "./helpers.js";
 
 describe("EyedropperTool", () => {
   let canvas: HTMLCanvasElement;
   let editor: Editor;
   let ctx: Partial<CanvasRenderingContext2D>;
+  let preview: PreviewCanvasMock;
 
   beforeEach(() => {
+    preview = mockPreviewCanvas();
     document.body.innerHTML = `
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="1" />
       <input id="fillMode" type="checkbox" />
+      <input id="showPreviews" type="checkbox" checked />
       <div id="colorHistory"></div>
     `;
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
@@ -39,7 +43,15 @@ describe("EyedropperTool", () => {
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
       document.getElementById("fillMode") as HTMLInputElement,
+      undefined,
+      undefined,
+      undefined,
+      document.getElementById("showPreviews") as HTMLInputElement,
     );
+  });
+
+  afterEach(() => {
+    preview.restore();
   });
 
   it("updates the color picker based on canvas pixel", () => {
@@ -89,13 +101,16 @@ describe("EyedropperTool color history", () => {
   let handle: EditorHandle;
   let canvas: HTMLCanvasElement;
   let ctx: Partial<CanvasRenderingContext2D>;
+  let preview: PreviewCanvasMock;
 
   beforeEach(() => {
+    preview = mockPreviewCanvas();
     document.body.innerHTML = `
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="1" />
       <input id="fillMode" type="checkbox" />
+      <input id="showPreviews" type="checkbox" checked />
 
       <button id="pencil"></button>
       <button id="eraser"></button>
@@ -134,6 +149,7 @@ describe("EyedropperTool color history", () => {
 
   afterEach(() => {
     handle.destroy();
+    preview.restore();
   });
 
   it("records sampled colors in the color history", () => {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,62 @@
+export interface PreviewCanvasMock {
+  ctx: jest.Mocked<CanvasRenderingContext2D>;
+  spy: jest.SpyInstance;
+  restore(): void;
+}
+
+export function mockPreviewCanvas(): PreviewCanvasMock {
+  const previewCtx = {
+    clearRect: jest.fn(),
+    save: jest.fn(),
+    restore: jest.fn(),
+    setLineDash: jest.fn(),
+    beginPath: jest.fn(),
+    moveTo: jest.fn(),
+    lineTo: jest.fn(),
+    stroke: jest.fn(),
+    fill: jest.fn(),
+    strokeRect: jest.fn(),
+    fillRect: jest.fn(),
+    ellipse: jest.fn(),
+    arc: jest.fn(),
+    closePath: jest.fn(),
+    setTransform: jest.fn(),
+    scale: jest.fn(),
+    globalAlpha: 1,
+    lineWidth: 1,
+    strokeStyle: "#000",
+    fillStyle: "#000",
+  } as unknown as jest.Mocked<CanvasRenderingContext2D>;
+
+  const originalCreateElement = document.createElement.bind(document);
+  const spy = jest
+    .spyOn(document, "createElement")
+    .mockImplementation((tagName: string) => {
+      const element = originalCreateElement(tagName);
+      if (tagName.toLowerCase() === "canvas") {
+        (element as HTMLCanvasElement).getContext = jest
+          .fn()
+          .mockReturnValue(previewCtx);
+        (element as HTMLCanvasElement).getBoundingClientRect = () => ({
+          width: 0,
+          height: 0,
+          top: 0,
+          left: 0,
+          bottom: 0,
+          right: 0,
+          x: 0,
+          y: 0,
+          toJSON: () => {},
+        });
+      }
+      return element;
+    });
+
+  return {
+    ctx: previewCtx,
+    spy,
+    restore() {
+      spy.mockRestore();
+    },
+  };
+}

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -1,4 +1,5 @@
 import { initEditor, EditorHandle } from "../src/editor.js";
+import { mockPreviewCanvas, type PreviewCanvasMock } from "./helpers.js";
 
 describe("image load and save", () => {
   let canvas: HTMLCanvasElement;
@@ -8,6 +9,7 @@ describe("image load and save", () => {
   let createElementSpy: jest.SpyInstance;
   let fileReaderSpy: jest.SpyInstance;
   let imageSpy: jest.SpyInstance;
+  let preview: PreviewCanvasMock;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -15,6 +17,7 @@ describe("image load and save", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
+      <input id="showPreviews" type="checkbox" checked />
       <button id="pencil"></button>
       <button id="eraser"></button>
       <button id="rectangle"></button>
@@ -28,6 +31,7 @@ describe("image load and save", () => {
       <button id="save"></button>
     `;
 
+    preview = mockPreviewCanvas();
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
     const imageData = {
       data: new Uint8ClampedArray(),
@@ -59,9 +63,15 @@ describe("image load and save", () => {
     });
 
     anchor = { href: "", download: "", click: jest.fn() };
-    createElementSpy = jest
-      .spyOn(document, "createElement")
-      .mockReturnValue(anchor as any);
+    const originalCreate = preview.spy.getMockImplementation() as (
+      tagName: string,
+    ) => any;
+    createElementSpy = preview.spy.mockImplementation((tagName: string) => {
+      if (tagName.toLowerCase() === "a") {
+        return anchor as any;
+      }
+      return originalCreate(tagName);
+    });
 
     class MockFileReader {
       result: string | ArrayBuffer | null = null;
@@ -90,7 +100,7 @@ describe("image load and save", () => {
 
   afterEach(() => {
     handle.destroy();
-    createElementSpy.mockRestore();
+    preview.restore();
     fileReaderSpy.mockRestore();
     imageSpy.mockRestore();
   });

--- a/tests/layers.test.ts
+++ b/tests/layers.test.ts
@@ -1,4 +1,5 @@
 import { initEditor, EditorHandle } from "../src/editor.js";
+import { mockPreviewCanvas, type PreviewCanvasMock } from "./helpers.js";
 
 describe("layer-specific undo/redo", () => {
   let handle: EditorHandle;
@@ -8,6 +9,7 @@ describe("layer-specific undo/redo", () => {
   let ctx2: Partial<CanvasRenderingContext2D>;
   let undoBtn: HTMLButtonElement;
   let redoBtn: HTMLButtonElement;
+  let preview: PreviewCanvasMock;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -16,6 +18,7 @@ describe("layer-specific undo/redo", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
+      <input id="showPreviews" type="checkbox" checked />
       <button id="pencil"></button>
       <button id="eraser"></button>
       <button id="rectangle"></button>
@@ -30,6 +33,7 @@ describe("layer-specific undo/redo", () => {
       <button id="redo"></button>
     `;
 
+    preview = mockPreviewCanvas();
     canvas1 = document.getElementById("c1") as HTMLCanvasElement;
     canvas2 = document.getElementById("c2") as HTMLCanvasElement;
 
@@ -81,7 +85,10 @@ describe("layer-specific undo/redo", () => {
     redoBtn = document.getElementById("redo") as HTMLButtonElement;
   });
 
-  afterEach(() => handle.destroy());
+  afterEach(() => {
+    handle.destroy();
+    preview.restore();
+  });
 
   it("targets the active layer and toggles button states", () => {
     // initially disabled

--- a/tests/lineTool.test.ts
+++ b/tests/lineTool.test.ts
@@ -1,9 +1,11 @@
 import { Editor } from "../src/core/Editor.js";
 import { LineTool } from "../src/tools/LineTool.js";
+import { mockPreviewCanvas, type PreviewCanvasMock } from "./helpers.js";
 
 describe("LineTool", () => {
   let editor: Editor;
   let ctx: Partial<CanvasRenderingContext2D>;
+  let preview: PreviewCanvasMock;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -11,7 +13,9 @@ describe("LineTool", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
+      <input id="showPreviews" type="checkbox" checked />
     `;
+    preview = mockPreviewCanvas();
     const canvas = document.getElementById("canvas") as HTMLCanvasElement;
     (canvas as any).setPointerCapture = jest.fn();
     (canvas as any).releasePointerCapture = jest.fn();
@@ -43,7 +47,15 @@ describe("LineTool", () => {
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
       document.getElementById("fillMode") as HTMLInputElement,
+      undefined,
+      undefined,
+      undefined,
+      document.getElementById("showPreviews") as HTMLInputElement,
     );
+  });
+
+  afterEach(() => {
+    preview.restore();
   });
 
   it("renders line preview during drag", () => {
@@ -54,28 +66,17 @@ describe("LineTool", () => {
       offsetY: 4,
       buttons: 1,
     } as PointerEvent, editor);
-    tool.onPointerUp({ offsetX: 3, offsetY: 4 } as PointerEvent, editor);
-
-    expect(ctx.getImageData).toHaveBeenCalled();
-    const image = (ctx.getImageData as jest.Mock).mock.results[0].value;
-    expect(ctx.putImageData).toHaveBeenCalledTimes(2);
-    expect(ctx.putImageData).toHaveBeenNthCalledWith(1, image, 0, 0);
-    expect(ctx.putImageData).toHaveBeenNthCalledWith(2, image, 0, 0);
-    expect(ctx.beginPath).toHaveBeenCalledTimes(2);
-    expect(ctx.moveTo).toHaveBeenCalledWith(1, 2);
-    expect(ctx.lineTo).toHaveBeenCalledWith(3, 4);
-    expect(ctx.stroke).toHaveBeenCalledTimes(2);
-    expect(ctx.closePath).toHaveBeenCalledTimes(2);
-    expect(ctx.strokeStyle).toBe(editor.strokeStyle);
-    expect(ctx.fillStyle).toBe(editor.fillStyle);
-    expect(ctx.lineWidth).toBe(editor.lineWidthValue);
+    expect(preview.ctx.beginPath).toHaveBeenCalled();
+    expect(preview.ctx.moveTo).toHaveBeenCalledWith(1, 2);
+    expect(preview.ctx.lineTo).toHaveBeenCalledWith(3, 4);
+    expect(preview.ctx.stroke).toHaveBeenCalled();
+    expect(ctx.beginPath).not.toHaveBeenCalled();
   });
 
   it("draws line on pointer up", () => {
     const tool = new LineTool();
     tool.onPointerDown({ offsetX: 1, offsetY: 2 } as PointerEvent, editor);
     tool.onPointerUp({ offsetX: 5, offsetY: 6 } as PointerEvent, editor);
-    expect(ctx.putImageData).toHaveBeenCalled();
     expect(ctx.beginPath).toHaveBeenCalled();
     expect(ctx.moveTo).toHaveBeenCalledWith(1, 2);
     expect(ctx.lineTo).toHaveBeenCalledWith(5, 6);
@@ -90,7 +91,7 @@ describe("LineTool", () => {
     tool.onPointerUp({ offsetX: 1, offsetY: 1 } as PointerEvent, editor);
     editor.undo();
     expect(ctx.clearRect).toHaveBeenCalledTimes(1);
-    expect(ctx.putImageData).toHaveBeenCalledTimes(2);
+    expect(ctx.putImageData).toHaveBeenCalledTimes(1);
   });
 
   it("snaps angles to 45° increments when shift is held", () => {
@@ -102,7 +103,7 @@ describe("LineTool", () => {
       buttons: 1,
       shiftKey: true,
     } as PointerEvent, editor);
-    const args = (ctx.lineTo as jest.Mock).mock.calls.pop();
+    const args = (preview.ctx.lineTo as jest.Mock).mock.calls.pop();
     const dx = 10;
     const dy = 5;
     const angle = Math.atan2(dy, dx);

--- a/tests/opacity.test.ts
+++ b/tests/opacity.test.ts
@@ -1,7 +1,9 @@
 import { initEditor, EditorHandle } from "../src/editor.js";
+import { mockPreviewCanvas, type PreviewCanvasMock } from "./helpers.js";
 
 describe("layer opacity", () => {
   let handle: EditorHandle;
+  let preview: PreviewCanvasMock;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -12,6 +14,7 @@ describe("layer opacity", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
+      <input id="showPreviews" type="checkbox" checked />
       <input id="layer2Opacity" value="100" />
       <button id="pencil"></button>
       <button id="eraser"></button>
@@ -25,6 +28,7 @@ describe("layer opacity", () => {
       <button id="save"></button>
     `;
 
+    preview = mockPreviewCanvas();
     const canvas = document.getElementById("canvas") as HTMLCanvasElement;
     const ctx = {
       drawImage: jest.fn(),
@@ -56,6 +60,7 @@ describe("layer opacity", () => {
 
   afterEach(() => {
     handle.destroy();
+    preview.restore();
     jest.restoreAllMocks();
   });
 
@@ -86,12 +91,13 @@ describe("layer opacity", () => {
       toDataURL: jest.fn().mockReturnValue("data"),
     } as any;
     const origCreate = document.createElement.bind(document);
-    const createSpy = jest
-      .spyOn(document, "createElement")
-      .mockImplementation((tag: string) => {
-        if (tag === "canvas") return tempCanvas;
-        return origCreate(tag);
-      });
+    const originalCreate = preview.spy.getMockImplementation() as (
+      tag: string,
+    ) => any;
+    const createSpy = preview.spy.mockImplementation((tag: string) => {
+      if (tag === "canvas") return tempCanvas;
+      return originalCreate(tag);
+    });
 
     const save = document.getElementById("save") as HTMLButtonElement;
     save.click();

--- a/tests/rectangleTool.test.ts
+++ b/tests/rectangleTool.test.ts
@@ -1,10 +1,12 @@
 import { Editor } from "../src/core/Editor.js";
 import { RectangleTool } from "../src/tools/RectangleTool.js";
 import { DrawingTool } from "../src/tools/DrawingTool.js";
+import { mockPreviewCanvas, type PreviewCanvasMock } from "./helpers.js";
 
 describe("RectangleTool", () => {
   let editor: Editor;
   let ctx: Partial<CanvasRenderingContext2D>;
+  let preview: PreviewCanvasMock;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -12,7 +14,10 @@ describe("RectangleTool", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
+      <input id="showPreviews" type="checkbox" checked />
     `;
+
+    preview = mockPreviewCanvas();
 
     const canvas = document.getElementById("canvas") as HTMLCanvasElement;
     (canvas as any).setPointerCapture = jest.fn();
@@ -58,11 +63,16 @@ describe("RectangleTool", () => {
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
       document.getElementById("fillMode") as HTMLInputElement,
+      undefined,
+      undefined,
+      undefined,
+      document.getElementById("showPreviews") as HTMLInputElement,
     );
   });
 
   afterEach(() => {
     editor.destroy();
+    preview.restore();
   });
 
   it("draws a rectangle on pointer up", () => {

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -1,4 +1,5 @@
 import { initEditor } from "../src/editor.js";
+import { mockPreviewCanvas } from "./helpers.js";
 
 describe("save button", () => {
   it("calls toDataURL on click", () => {
@@ -7,6 +8,7 @@ describe("save button", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
+      <input id="showPreviews" type="checkbox" checked />
       <button id="pencil"></button>
       <button id="eraser"></button>
       <button id="rectangle"></button>
@@ -38,7 +40,16 @@ describe("save button", () => {
     const click = jest.fn();
     const anchor = { href: "", download: "", click } as any;
 
-    jest.spyOn(document, "createElement").mockReturnValue(anchor);
+    const preview = mockPreviewCanvas();
+    const originalCreate = preview.spy.getMockImplementation() as (
+      tag: string,
+    ) => any;
+    preview.spy.mockImplementation((tagName: string) => {
+      if (tagName.toLowerCase() === "a") {
+        return anchor;
+      }
+      return originalCreate(tagName);
+    });
 
     const handle = initEditor();
 
@@ -47,6 +58,7 @@ describe("save button", () => {
     expect(click).toHaveBeenCalled();
 
     handle.destroy();
+    preview.restore();
   });
 
   it("supports selecting jpeg format", () => {
@@ -55,6 +67,7 @@ describe("save button", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
+      <input id="showPreviews" type="checkbox" checked />
       <button id="pencil"></button>
       <button id="eraser"></button>
       <button id="rectangle"></button>
@@ -85,7 +98,16 @@ describe("save button", () => {
 
     const click = jest.fn();
     const anchor = { href: "", download: "", click } as any;
-    jest.spyOn(document, "createElement").mockReturnValue(anchor);
+    const preview = mockPreviewCanvas();
+    const originalCreate = preview.spy.getMockImplementation() as (
+      tag: string,
+    ) => any;
+    preview.spy.mockImplementation((tagName: string) => {
+      if (tagName.toLowerCase() === "a") {
+        return anchor;
+      }
+      return originalCreate(tagName);
+    });
 
     const handle = initEditor();
 
@@ -95,5 +117,6 @@ describe("save button", () => {
     expect(click).toHaveBeenCalled();
 
     handle.destroy();
+    preview.restore();
   });
 });

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -1,4 +1,5 @@
 import { initEditor, EditorHandle } from "../src/editor.js";
+import { mockPreviewCanvas, type PreviewCanvasMock } from "./helpers.js";
 import { RectangleTool } from "../src/tools/RectangleTool.js";
 import { PencilTool } from "../src/tools/PencilTool.js";
 import { EraserTool } from "../src/tools/EraserTool.js";
@@ -14,6 +15,7 @@ describe("keyboard shortcuts", () => {
   let handle: EditorHandle;
   let canvas: HTMLCanvasElement;
   let ctx: Partial<CanvasRenderingContext2D>;
+  let preview: PreviewCanvasMock;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -21,6 +23,7 @@ describe("keyboard shortcuts", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
+      <input id="showPreviews" type="checkbox" checked />
       <button id="pencil"></button>
       <button id="eraser"></button>
       <button id="rectangle"></button>
@@ -32,6 +35,7 @@ describe("keyboard shortcuts", () => {
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>
     `;
+    preview = mockPreviewCanvas();
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
     (canvas as any).setPointerCapture = jest.fn();
     (canvas as any).releasePointerCapture = jest.fn();
@@ -59,6 +63,7 @@ describe("keyboard shortcuts", () => {
 
   afterEach(() => {
     handle.destroy();
+    preview.restore();
   });
 
   it("switches tools with letter keys", () => {

--- a/tests/textTool.test.ts
+++ b/tests/textTool.test.ts
@@ -1,11 +1,13 @@
 import { Editor } from "../src/core/Editor.js";
 import { TextTool } from "../src/tools/TextTool.js";
+import { mockPreviewCanvas, type PreviewCanvasMock } from "./helpers.js";
 
 describe("TextTool", () => {
   let editor: Editor;
   let ctx: Partial<CanvasRenderingContext2D>;
   let canvas: HTMLCanvasElement;
   let mockImage: ImageData;
+  let preview: PreviewCanvasMock;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -17,7 +19,9 @@ describe("TextTool", () => {
       <input id="fillMode" type="checkbox" />
       <select id="fontFamily"><option value="serif">serif</option></select>
       <input id="fontSize" value="20" />
+      <input id="showPreviews" type="checkbox" checked />
     `;
+    preview = mockPreviewCanvas();
 
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
     (canvas as any).setPointerCapture = jest.fn();
@@ -73,11 +77,13 @@ describe("TextTool", () => {
       undefined,
       document.getElementById("fontFamily") as HTMLSelectElement,
       document.getElementById("fontSize") as HTMLInputElement,
+      document.getElementById("showPreviews") as HTMLInputElement,
     );
   });
 
   afterEach(() => {
     editor.destroy();
+    preview.restore();
   });
 
   it("creates textarea overlay on pointer down", () => {

--- a/tests/toolbar.test.ts
+++ b/tests/toolbar.test.ts
@@ -6,11 +6,13 @@ import { LineTool } from "../src/tools/LineTool.js";
 import { CircleTool } from "../src/tools/CircleTool.js";
 import { TextTool } from "../src/tools/TextTool.js";
 import { EyedropperTool } from "../src/tools/EyedropperTool.js";
+import { mockPreviewCanvas, type PreviewCanvasMock } from "./helpers.js";
 
 describe("toolbar controls", () => {
   let handle: EditorHandle;
   let canvas: HTMLCanvasElement;
   let ctx: Partial<CanvasRenderingContext2D>;
+  let preview: PreviewCanvasMock;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -19,6 +21,7 @@ describe("toolbar controls", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
+      <input id="showPreviews" type="checkbox" checked />
 
       <button id="pencil"></button>
       <button id="eraser"></button>
@@ -37,6 +40,7 @@ describe("toolbar controls", () => {
       <select id="layerSelect"></select>
     `;
 
+    preview = mockPreviewCanvas();
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
     const canvas2 = document.getElementById("canvas2") as HTMLCanvasElement;
     ctx = {
@@ -70,6 +74,7 @@ describe("toolbar controls", () => {
 
   afterEach(() => {
     handle.destroy();
+    preview.restore();
   });
 
   it("populates layer select", () => {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -3,11 +3,13 @@ import { PencilTool } from "../src/tools/PencilTool.js";
 import { LineTool } from "../src/tools/LineTool.js";
 import { CircleTool } from "../src/tools/CircleTool.js";
 import { TextTool } from "../src/tools/TextTool.js";
+import { mockPreviewCanvas, type PreviewCanvasMock } from "./helpers.js";
 
 describe("additional tools", () => {
   let canvas: HTMLCanvasElement;
   let ctx: Partial<CanvasRenderingContext2D>;
   let editor: Editor;
+  let preview: PreviewCanvasMock;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -15,7 +17,9 @@ describe("additional tools", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
+      <input id="showPreviews" type="checkbox" checked />
     `;
+    preview = mockPreviewCanvas();
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
     (canvas as any).setPointerCapture = jest.fn();
     (canvas as any).releasePointerCapture = jest.fn();
@@ -46,7 +50,15 @@ describe("additional tools", () => {
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
       document.getElementById("fillMode") as HTMLInputElement,
+      undefined,
+      undefined,
+      undefined,
+      document.getElementById("showPreviews") as HTMLInputElement,
     );
+  });
+
+  afterEach(() => {
+    preview.restore();
   });
 
   it("pencil draws lines", () => {


### PR DESCRIPTION
## Summary
- add a preview overlay canvas and toggleable UI control so editors can display tool previews
- update pencil, eraser, and shape tools to render non-destructive previews during pointer movement
- adjust automated tests to mock preview canvases and validate the new behaviors

## Testing
- npm run build
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d60d311c0483288bcd85e75c18f12d