### PR TITLE
Add keyboard navigation and labels to color history swatches

### DIFF
--- a/dist/editor.js
+++ b/dist/editor.js
@@ -125,6 +125,32 @@ export function initEditor() {
     const listeners = [];
     const recentColors = [];
     const maxRecentColors = 10;
+    let activeSwatchIndex = null;
+    const getSwatches = () => colorHistory
+        ? Array.from(colorHistory.querySelectorAll(".color-swatch"))
+        : [];
+    const updateSwatchTabIndexes = () => {
+        const swatches = getSwatches();
+        if (!swatches.length)
+            return;
+        if (activeSwatchIndex === null ||
+            activeSwatchIndex < 0 ||
+            activeSwatchIndex >= swatches.length) {
+            activeSwatchIndex = 0;
+        }
+        swatches.forEach((swatch, index) => {
+            swatch.tabIndex = index === activeSwatchIndex ? 0 : -1;
+        });
+    };
+    const focusSwatch = (index) => {
+        const swatches = getSwatches();
+        if (!swatches.length)
+            return;
+        const normalizedIndex = ((index % swatches.length) + swatches.length) % swatches.length;
+        activeSwatchIndex = normalizedIndex;
+        updateSwatchTabIndexes();
+        swatches[normalizedIndex].focus();
+    };
     const renderColorHistory = () => {
         if (!colorHistory)
             return;
@@ -135,12 +161,41 @@ export function initEditor() {
             btn.className = "color-swatch";
             btn.style.backgroundColor = color;
             btn.setAttribute("aria-label", `Select ${color}`);
+            btn.title = color;
             btn.addEventListener("click", () => {
                 colorPicker.value = color;
                 colorPicker.dispatchEvent(new Event("input"));
             });
+            btn.addEventListener("focus", () => {
+                const swatches = getSwatches();
+                const index = swatches.indexOf(btn);
+                if (index !== -1) {
+                    activeSwatchIndex = index;
+                    updateSwatchTabIndexes();
+                }
+            });
+            btn.addEventListener("keydown", (event) => {
+                const { key } = event;
+                if (key === "ArrowRight" || key === "ArrowDown") {
+                    event.preventDefault();
+                    const swatches = getSwatches();
+                    const index = swatches.indexOf(btn);
+                    if (index !== -1) {
+                        focusSwatch(index + 1);
+                    }
+                }
+                else if (key === "ArrowLeft" || key === "ArrowUp") {
+                    event.preventDefault();
+                    const swatches = getSwatches();
+                    const index = swatches.indexOf(btn);
+                    if (index !== -1) {
+                        focusSwatch(index - 1);
+                    }
+                }
+            });
             colorHistory.appendChild(btn);
         });
+        updateSwatchTabIndexes();
     };
     const recordColor = (color) => {
         const existing = recentColors.indexOf(color);
@@ -149,6 +204,7 @@ export function initEditor() {
         recentColors.unshift(color);
         if (recentColors.length > maxRecentColors)
             recentColors.pop();
+        activeSwatchIndex = 0;
         renderColorHistory();
     };
     listen(colorPicker, "input", () => {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -158,6 +158,38 @@ export function initEditor(): EditorHandle {
 
   const recentColors: string[] = [];
   const maxRecentColors = 10;
+  let activeSwatchIndex: number | null = null;
+
+  const getSwatches = () =>
+    colorHistory
+      ? Array.from(
+          colorHistory.querySelectorAll<HTMLButtonElement>(".color-swatch"),
+        )
+      : [];
+
+  const updateSwatchTabIndexes = () => {
+    const swatches = getSwatches();
+    if (!swatches.length) return;
+    if (
+      activeSwatchIndex === null ||
+      activeSwatchIndex < 0 ||
+      activeSwatchIndex >= swatches.length
+    ) {
+      activeSwatchIndex = 0;
+    }
+    swatches.forEach((swatch, index) => {
+      swatch.tabIndex = index === activeSwatchIndex ? 0 : -1;
+    });
+  };
+
+  const focusSwatch = (index: number) => {
+    const swatches = getSwatches();
+    if (!swatches.length) return;
+    const normalizedIndex = ((index % swatches.length) + swatches.length) % swatches.length;
+    activeSwatchIndex = normalizedIndex;
+    updateSwatchTabIndexes();
+    swatches[normalizedIndex].focus();
+  };
   const renderColorHistory = () => {
     if (!colorHistory) return;
     colorHistory.innerHTML = "";
@@ -167,12 +199,40 @@ export function initEditor(): EditorHandle {
       btn.className = "color-swatch";
       btn.style.backgroundColor = color;
       btn.setAttribute("aria-label", `Select ${color}`);
+      btn.title = color;
       btn.addEventListener("click", () => {
         colorPicker.value = color;
         colorPicker.dispatchEvent(new Event("input"));
       });
+      btn.addEventListener("focus", () => {
+        const swatches = getSwatches();
+        const index = swatches.indexOf(btn);
+        if (index !== -1) {
+          activeSwatchIndex = index;
+          updateSwatchTabIndexes();
+        }
+      });
+      btn.addEventListener("keydown", (event) => {
+        const { key } = event;
+        if (key === "ArrowRight" || key === "ArrowDown") {
+          event.preventDefault();
+          const swatches = getSwatches();
+          const index = swatches.indexOf(btn);
+          if (index !== -1) {
+            focusSwatch(index + 1);
+          }
+        } else if (key === "ArrowLeft" || key === "ArrowUp") {
+          event.preventDefault();
+          const swatches = getSwatches();
+          const index = swatches.indexOf(btn);
+          if (index !== -1) {
+            focusSwatch(index - 1);
+          }
+        }
+      });
       colorHistory.appendChild(btn);
     });
+    updateSwatchTabIndexes();
   };
 
   const recordColor = (color: string) => {
@@ -180,6 +240,7 @@ export function initEditor(): EditorHandle {
     if (existing !== -1) recentColors.splice(existing, 1);
     recentColors.unshift(color);
     if (recentColors.length > maxRecentColors) recentColors.pop();
+    activeSwatchIndex = 0;
     renderColorHistory();
   };
 

--- a/tests/eyedropperTool.test.ts
+++ b/tests/eyedropperTool.test.ts
@@ -145,5 +145,42 @@ describe("EyedropperTool color history", () => {
     const swatch = history.children[0] as HTMLButtonElement;
     expect(swatch.style.backgroundColor).toBe("rgb(12, 34, 56)");
   });
+
+  it("sets tooltip labels for color history swatches", () => {
+    const history = document.getElementById("colorHistory") as HTMLDivElement;
+    const swatch = history.querySelector<HTMLButtonElement>(".color-swatch");
+    expect(swatch).not.toBeNull();
+    expect(swatch?.title).toBe("#000000");
+  });
+
+  it("supports arrow key navigation with roving tab indexes", () => {
+    const history = document.getElementById("colorHistory") as HTMLDivElement;
+    const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
+
+    colorPicker.value = "#112233";
+    colorPicker.dispatchEvent(new Event("input", { bubbles: true }));
+
+    const swatches = history.querySelectorAll<HTMLButtonElement>(".color-swatch");
+    expect(swatches).toHaveLength(2);
+    expect(swatches[0].tabIndex).toBe(0);
+    expect(swatches[1].tabIndex).toBe(-1);
+
+    swatches[0].focus();
+    swatches[0].dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+    );
+
+    expect(document.activeElement).toBe(swatches[1]);
+    expect(swatches[0].tabIndex).toBe(-1);
+    expect(swatches[1].tabIndex).toBe(0);
+
+    swatches[1].dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+    );
+
+    expect(document.activeElement).toBe(swatches[0]);
+    expect(swatches[0].tabIndex).toBe(0);
+    expect(swatches[1].tabIndex).toBe(-1);
+  });
 });
 


### PR DESCRIPTION
## Summary
- add roving tabindex management so color history swatches respond to arrow keys
- expose the color value via the swatch tooltip for sighted users
- cover the new accessibility behaviors with unit tests

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d60d2de1e48328a91bb23a9b8609f0