### PR TITLE
Improve toolbar button aria states

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1,0 +1,7 @@
+# Developer Guide
+
+## Accessibility
+
+- Tool buttons should expose their toggle state via the `aria-pressed` attribute.
+- `src/editor.ts` initializes each toolbar button with `aria-pressed="false"` and updates the value as tools become active so screen readers receive accurate state changes.
+- The styling in `style.css` responds to `[aria-pressed="true"]`, so ensure any new toolbar buttons keep the attribute in sync to preserve both visual and assistive feedback.

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -62,12 +62,19 @@ export function initEditor(): EditorHandle {
     }
     toolButtons[id] = btn;
     constructorToId.set(Ctor, id);
+    btn.setAttribute("aria-pressed", "false");
   });
 
   let activeButton: HTMLButtonElement | null = null;
   const setActiveButton = (btn: HTMLButtonElement | null) => {
-    if (activeButton) activeButton.classList.remove("active");
-    if (btn) btn.classList.add("active");
+    if (activeButton) {
+      activeButton.classList.remove("active");
+      activeButton.setAttribute("aria-pressed", "false");
+    }
+    if (btn) {
+      btn.classList.add("active");
+      btn.setAttribute("aria-pressed", "true");
+    }
     activeButton = btn;
   };
   const buttonForTool = (tool: Tool): HTMLButtonElement | null => {

--- a/style.css
+++ b/style.css
@@ -69,11 +69,13 @@ body {
   background: #f0f0f0;
 }
 
-.tool-button.active {
+.tool-button.active,
+.tool-button[aria-pressed="true"] {
   background: #007bff;
 }
 
-.tool-button.active img {
+.tool-button.active img,
+.tool-button[aria-pressed="true"] img {
   filter: brightness(0) invert(1);
 }
 


### PR DESCRIPTION
## Summary
- initialize toolbar buttons with aria-pressed attributes and keep them in sync when tools change
- align the button styling with the aria-pressed state for consistent visual feedback
- document the accessibility expectations for tool buttons in the developer guide

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60d2d28b88328bd8e563a2729eb6b