### PR TITLE
Improve toolbar accessibility focus management

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <div id="toolbar">
+    <div id="toolbar" role="toolbar">
       <input type="color" id="colorPicker" />
       <div id="colorHistory"></div>
       <input type="number" id="lineWidth" min="1" value="1" />

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -64,10 +64,42 @@ export function initEditor(): EditorHandle {
     constructorToId.set(Ctor, id);
   });
 
+  const toolbarElement = document.getElementById("toolbar");
+  const toolbar = toolbarElement ?? document.body;
+  const rovingButtonCandidates = toolbarElement
+    ? Array.from(
+        toolbarElement.querySelectorAll<HTMLButtonElement>(".tool-button"),
+      )
+    : [];
+  const rovingButtons = (rovingButtonCandidates.length
+    ? rovingButtonCandidates
+    : Object.values(toolButtons)
+  ).filter((btn) => btn.id in toolButtons);
+
+  let rovingButton: HTMLButtonElement | null = null;
+  const setRovingButton = (
+    btn: HTMLButtonElement | null,
+    { shouldFocus = false }: { shouldFocus?: boolean } = {},
+  ) => {
+    if (!btn) return;
+    rovingButtons.forEach((toolBtn) => {
+      toolBtn.tabIndex = toolBtn === btn ? 0 : -1;
+    });
+    rovingButton = btn;
+    if (shouldFocus) {
+      btn.focus();
+    }
+  };
+
   let activeButton: HTMLButtonElement | null = null;
   const setActiveButton = (btn: HTMLButtonElement | null) => {
-    if (activeButton) activeButton.classList.remove("active");
-    if (btn) btn.classList.add("active");
+    if (activeButton) {
+      activeButton.classList.remove("active");
+    }
+    if (btn) {
+      btn.classList.add("active");
+      setRovingButton(btn);
+    }
     activeButton = btn;
   };
   const buttonForTool = (tool: Tool): HTMLButtonElement | null => {
@@ -92,13 +124,22 @@ export function initEditor(): EditorHandle {
   const fontFamily = document.getElementById("fontFamily") as HTMLSelectElement | null;
   const fontSize = document.getElementById("fontSize") as HTMLInputElement | null;
   const layerSelect = document.getElementById("layerSelect") as HTMLSelectElement | null;
-  const toolbar = document.getElementById("toolbar") || document.body;
+  if (toolbarElement) {
+    toolbarElement.setAttribute("role", "toolbar");
+  }
   const saveBtn = document.getElementById("save") as HTMLButtonElement | null;
   const formatSelect =
     document.getElementById("formatSelect") as HTMLSelectElement | null;
   const colorHistory = document.getElementById(
     "colorHistory",
   ) as HTMLDivElement | null;
+
+  if (rovingButtons.length > 0) {
+    rovingButtons.forEach((btn, index) => {
+      btn.tabIndex = index === 0 ? 0 : -1;
+    });
+    rovingButton = rovingButtons[0];
+  }
 
   if (!colorPicker) {
     throw new Error("Missing #colorPicker input");
@@ -246,6 +287,36 @@ export function initEditor(): EditorHandle {
 
   // keyboard shortcuts
   const shortcuts = new Shortcuts(editor);
+
+  listen<KeyboardEvent>(
+    toolbar,
+    "keydown",
+    (event) => {
+      const target = event.target as HTMLButtonElement | null;
+      if (!target) return;
+      const currentIndex = rovingButtons.indexOf(target);
+      if (currentIndex === -1) return;
+      let nextIndex: number | null = null;
+      if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+        nextIndex = (currentIndex + 1) % rovingButtons.length;
+      } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+        nextIndex = (currentIndex - 1 + rovingButtons.length) % rovingButtons.length;
+      } else if (event.key === "Home") {
+        nextIndex = 0;
+      } else if (event.key === "End") {
+        nextIndex = rovingButtons.length - 1;
+      }
+
+      if (nextIndex === null || rovingButtons.length === 0) {
+        return;
+      }
+
+      event.preventDefault();
+      const nextButton = rovingButtons[nextIndex];
+      setRovingButton(nextButton, { shouldFocus: true });
+    },
+    listeners,
+  );
 
   // map button id to tool constructor
   Object.entries(toolConstructors).forEach(([id, ToolCtor]) =>

--- a/tests/toolbar.test.ts
+++ b/tests/toolbar.test.ts
@@ -14,27 +14,29 @@ describe("toolbar controls", () => {
 
   beforeEach(() => {
     document.body.innerHTML = `
+      <div id="toolbar">
+        <input id="colorPicker" value="#000000" />
+        <input id="lineWidth" value="2" />
+        <input id="fillMode" type="checkbox" />
+
+        <button id="pencil" class="tool-button"></button>
+        <button id="eraser" class="tool-button"></button>
+        <button id="rectangle" class="tool-button"></button>
+        <button id="line" class="tool-button"></button>
+        <button id="circle" class="tool-button"></button>
+        <button id="text" class="tool-button"></button>
+        <button id="eyedropper" class="tool-button"></button>
+        <button id="bucket" class="tool-button"></button>
+
+        <select id="formatSelect"><option value="png">PNG</option></select>
+        <button id="save" class="tool-button"></button>
+
+        <button id="undo" class="tool-button"></button>
+        <button id="redo" class="tool-button"></button>
+        <select id="layerSelect"></select>
+      </div>
       <canvas id="canvas"></canvas>
       <canvas id="canvas2"></canvas>
-      <input id="colorPicker" value="#000000" />
-      <input id="lineWidth" value="2" />
-      <input id="fillMode" type="checkbox" />
-
-      <button id="pencil"></button>
-      <button id="eraser"></button>
-      <button id="rectangle"></button>
-      <button id="line"></button>
-      <button id="circle"></button>
-      <button id="text"></button>
-      <button id="eyedropper"></button>
-      <button id="bucket"></button>
-
-      <select id="formatSelect"><option value="png">PNG</option></select>
-      <button id="save"></button>
-
-      <button id="undo"></button>
-      <button id="redo"></button>
-      <select id="layerSelect"></select>
     `;
 
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
@@ -75,6 +77,63 @@ describe("toolbar controls", () => {
   it("populates layer select", () => {
     const select = document.getElementById("layerSelect") as HTMLSelectElement;
     expect(select.options.length).toBe(2);
+  });
+
+  it("marks toolbar as a toolbar and sets roving tabindex", () => {
+    const toolbar = document.getElementById("toolbar");
+    expect(toolbar?.getAttribute("role")).toBe("toolbar");
+
+    const pencil = document.getElementById("pencil") as HTMLButtonElement;
+    const eraser = document.getElementById("eraser") as HTMLButtonElement;
+    const bucket = document.getElementById("bucket") as HTMLButtonElement;
+
+    expect(pencil.tabIndex).toBe(0);
+    expect(eraser.tabIndex).toBe(-1);
+    expect(bucket.tabIndex).toBe(-1);
+  });
+
+  it("moves focus between tool buttons with arrow keys", () => {
+    const pencil = document.getElementById("pencil") as HTMLButtonElement;
+    const eraser = document.getElementById("eraser") as HTMLButtonElement;
+    const bucket = document.getElementById("bucket") as HTMLButtonElement;
+
+    pencil.focus();
+
+    pencil.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+    );
+    expect(document.activeElement).toBe(eraser);
+    expect(eraser.tabIndex).toBe(0);
+    expect(pencil.tabIndex).toBe(-1);
+
+    eraser.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }),
+    );
+    expect(document.activeElement).toBe(pencil);
+
+    pencil.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }),
+    );
+    expect(document.activeElement).toBe(bucket);
+    expect(bucket.tabIndex).toBe(0);
+  });
+
+  it("supports Home and End keys for focus movement", () => {
+    const textBtn = document.getElementById("text") as HTMLButtonElement;
+    const pencil = document.getElementById("pencil") as HTMLButtonElement;
+    const bucket = document.getElementById("bucket") as HTMLButtonElement;
+
+    textBtn.focus();
+
+    textBtn.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Home", bubbles: true }),
+    );
+    expect(document.activeElement).toBe(pencil);
+
+    (document.activeElement as HTMLButtonElement).dispatchEvent(
+      new KeyboardEvent("keydown", { key: "End", bubbles: true }),
+    );
+    expect(document.activeElement).toBe(bucket);
   });
 
     it("switches tools when buttons are clicked", () => {


### PR DESCRIPTION
## Summary
- set the toolbar container to use the toolbar landmark role
- implement roving tabindex and keyboard navigation for tool buttons
- expand toolbar tests to cover focus movement behaviour

## Testing
- npm test -- toolbar

------
https://chatgpt.com/codex/tasks/task_e_68d60d2c18b4832883f0995be6d5e354