### PR TITLE
Add SVG vector import and rasterization support

### DIFF
--- a/dist/core/Editor.js
+++ b/dist/core/Editor.js
@@ -3,6 +3,7 @@ export class Editor {
         this.undoStack = [];
         this.redoStack = [];
         this.currentTool = null;
+        this.vectorLayer = null;
         this.handlePointerDown = (e) => {
             // Capture the pointer once before recording canvas state
             this.canvas.setPointerCapture(e.pointerId);
@@ -97,6 +98,26 @@ export class Editor {
     }
     get fontSizeValue() {
         return parseInt(this.fontSize?.value ?? "", 10) || 16;
+    }
+    setVectorLayer(layer) {
+        this.vectorLayer = layer;
+    }
+    getVectorLayer() {
+        return this.vectorLayer;
+    }
+    hasVectorLayer() {
+        return !!this.vectorLayer && !this.vectorLayer.isEmpty();
+    }
+    rasterizeVectorLayer() {
+        if (!this.vectorLayer || this.vectorLayer.isEmpty()) {
+            return false;
+        }
+        this.saveState();
+        const rect = this.canvas.getBoundingClientRect();
+        this.vectorLayer.render(this.ctx, rect.width, rect.height);
+        this.vectorLayer = null;
+        this.onChange?.();
+        return true;
     }
     /**
      * Remove all event listeners registered by the editor.

--- a/dist/core/VectorLayer.js
+++ b/dist/core/VectorLayer.js
@@ -1,0 +1,128 @@
+export class VectorLayer {
+    constructor(shapes, bounds) {
+        this.shapes = shapes;
+        const width = bounds?.width ?? 1;
+        const height = bounds?.height ?? 1;
+        this.bounds = {
+            minX: bounds?.minX ?? 0,
+            minY: bounds?.minY ?? 0,
+            width: width <= 0 ? 1 : width,
+            height: height <= 0 ? 1 : height,
+        };
+    }
+    isEmpty() {
+        return this.shapes.length === 0;
+    }
+    render(ctx, targetWidth, targetHeight) {
+        if (this.shapes.length === 0) {
+            return;
+        }
+        const width = targetWidth ?? this.bounds.width;
+        const height = targetHeight ?? this.bounds.height;
+        const scaleX = width / this.bounds.width;
+        const scaleY = height / this.bounds.height;
+        ctx.save();
+        ctx.scale(scaleX, scaleY);
+        if (this.bounds.minX !== 0 || this.bounds.minY !== 0) {
+            ctx.translate(-this.bounds.minX, -this.bounds.minY);
+        }
+        for (const shape of this.shapes) {
+            this.drawShape(ctx, shape);
+        }
+        ctx.restore();
+    }
+    drawShape(ctx, shape) {
+        switch (shape.type) {
+            case "rect":
+                this.drawRect(ctx, shape);
+                break;
+            case "circle":
+                this.drawCircle(ctx, shape);
+                break;
+            case "ellipse":
+                this.drawEllipse(ctx, shape);
+                break;
+            case "line":
+                this.drawLine(ctx, shape);
+                break;
+            case "polyline":
+                this.drawPolyline(ctx, shape);
+                break;
+        }
+    }
+    applyStroke(ctx, shape) {
+        if (!shape.stroke || shape.stroke === "none") {
+            return;
+        }
+        const opacity = shape.strokeOpacity ?? shape.opacity ?? 1;
+        if (opacity <= 0) {
+            return;
+        }
+        ctx.save();
+        ctx.strokeStyle = shape.stroke;
+        ctx.globalAlpha = opacity;
+        ctx.lineWidth = shape.strokeWidth ?? 1;
+        if (shape.strokeLineCap) {
+            ctx.lineCap = shape.strokeLineCap;
+        }
+        if (shape.strokeLineJoin) {
+            ctx.lineJoin = shape.strokeLineJoin;
+        }
+        ctx.stroke();
+        ctx.restore();
+    }
+    applyFill(ctx, shape) {
+        if (!shape.fill || shape.fill === "none") {
+            return;
+        }
+        const opacity = shape.fillOpacity ?? shape.opacity ?? 1;
+        if (opacity <= 0) {
+            return;
+        }
+        ctx.save();
+        ctx.fillStyle = shape.fill;
+        ctx.globalAlpha = opacity;
+        ctx.fill();
+        ctx.restore();
+    }
+    drawRect(ctx, shape) {
+        ctx.beginPath();
+        ctx.rect(shape.x, shape.y, shape.width, shape.height);
+        this.applyFill(ctx, shape);
+        this.applyStroke(ctx, shape);
+    }
+    drawCircle(ctx, shape) {
+        ctx.beginPath();
+        ctx.arc(shape.cx, shape.cy, shape.r, 0, Math.PI * 2);
+        this.applyFill(ctx, shape);
+        this.applyStroke(ctx, shape);
+    }
+    drawEllipse(ctx, shape) {
+        ctx.beginPath();
+        ctx.ellipse(shape.cx, shape.cy, shape.rx, shape.ry, 0, 0, Math.PI * 2);
+        this.applyFill(ctx, shape);
+        this.applyStroke(ctx, shape);
+    }
+    drawLine(ctx, shape) {
+        ctx.beginPath();
+        ctx.moveTo(shape.x1, shape.y1);
+        ctx.lineTo(shape.x2, shape.y2);
+        this.applyStroke(ctx, shape);
+    }
+    drawPolyline(ctx, shape) {
+        if (shape.points.length === 0) {
+            return;
+        }
+        ctx.beginPath();
+        const [first, ...rest] = shape.points;
+        ctx.moveTo(first.x, first.y);
+        for (const point of rest) {
+            ctx.lineTo(point.x, point.y);
+        }
+        if (shape.closed) {
+            ctx.closePath();
+        }
+        this.applyFill(ctx, shape);
+        this.applyStroke(ctx, shape);
+    }
+}

--- a/dist/core/svgParser.js
+++ b/dist/core/svgParser.js
@@ -1,0 +1,280 @@
+import { VectorLayer } from "./VectorLayer.js";
+const SUPPORTED_TAGS = new Set([
+    "rect",
+    "circle",
+    "ellipse",
+    "line",
+    "polyline",
+    "polygon",
+    "g",
+]);
+const IGNORE_TAGS = new Set(["defs", "title", "desc", "metadata"]);
+function parseNumber(value) {
+    if (!value) {
+        return undefined;
+    }
+    const numeric = parseFloat(value);
+    return Number.isFinite(numeric) ? numeric : undefined;
+}
+function parseOpacity(value) {
+    const numeric = parseNumber(value);
+    if (numeric === undefined) {
+        return undefined;
+    }
+    if (numeric < 0)
+        return 0;
+    if (numeric > 1)
+        return 1;
+    return numeric;
+}
+function parsePoints(value) {
+    const points = [];
+    const pairs = value
+        .trim()
+        .replace(/\s+/g, " ")
+        .split(/[\s,]+/);
+    if (pairs.length % 2 !== 0) {
+        return undefined;
+    }
+    for (let i = 0; i < pairs.length; i += 2) {
+        const x = parseFloat(pairs[i]);
+        const y = parseFloat(pairs[i + 1]);
+        if (!Number.isFinite(x) || !Number.isFinite(y)) {
+            return undefined;
+        }
+        points.push({ x, y });
+    }
+    return points;
+}
+function parseStrokeLineCap(value) {
+    switch (value) {
+        case "butt":
+        case "round":
+        case "square":
+            return value;
+        default:
+            return undefined;
+    }
+}
+function parseStrokeLineJoin(value) {
+    switch (value) {
+        case "miter":
+        case "round":
+        case "bevel":
+            return value;
+        default:
+            return undefined;
+    }
+}
+function getCommonAttributes(element, warnings) {
+    const fill = element.getAttribute("fill") ?? undefined;
+    const fillOpacity = parseOpacity(element.getAttribute("fill-opacity"));
+    const stroke = element.getAttribute("stroke") ?? undefined;
+    const strokeOpacity = parseOpacity(element.getAttribute("stroke-opacity"));
+    const strokeWidth = parseNumber(element.getAttribute("stroke-width"));
+    const opacity = parseOpacity(element.getAttribute("opacity"));
+    const strokeLineCap = parseStrokeLineCap(element.getAttribute("stroke-linecap"));
+    const strokeLineJoin = parseStrokeLineJoin(element.getAttribute("stroke-linejoin"));
+    if (element.hasAttribute("stroke-dasharray")) {
+        warnings.push(`<${element.tagName}> stroke-dasharray is not supported and was ignored.`);
+    }
+    if (element.hasAttribute("transform")) {
+        warnings.push(`<${element.tagName}> transform attributes are not supported and were ignored.`);
+    }
+    if (element.hasAttribute("style")) {
+        warnings.push(`<${element.tagName}> inline styles are not fully supported and may be ignored.`);
+    }
+    return {
+        fill,
+        fillOpacity,
+        stroke,
+        strokeOpacity,
+        strokeWidth,
+        opacity,
+        strokeLineCap,
+        strokeLineJoin,
+    };
+}
+function parseRect(element, warnings) {
+    const width = parseNumber(element.getAttribute("width"));
+    const height = parseNumber(element.getAttribute("height"));
+    if (width === undefined || height === undefined) {
+        warnings.push("<rect> is missing width or height and was skipped.");
+        return null;
+    }
+    const x = parseNumber(element.getAttribute("x")) ?? 0;
+    const y = parseNumber(element.getAttribute("y")) ?? 0;
+    return {
+        type: "rect",
+        x,
+        y,
+        width,
+        height,
+        ...getCommonAttributes(element, warnings),
+    };
+}
+function parseCircle(element, warnings) {
+    const r = parseNumber(element.getAttribute("r"));
+    if (r === undefined) {
+        warnings.push("<circle> is missing r and was skipped.");
+        return null;
+    }
+    const cx = parseNumber(element.getAttribute("cx")) ?? 0;
+    const cy = parseNumber(element.getAttribute("cy")) ?? 0;
+    return {
+        type: "circle",
+        cx,
+        cy,
+        r,
+        ...getCommonAttributes(element, warnings),
+    };
+}
+function parseEllipse(element, warnings) {
+    const rx = parseNumber(element.getAttribute("rx"));
+    const ry = parseNumber(element.getAttribute("ry"));
+    if (rx === undefined || ry === undefined) {
+        warnings.push("<ellipse> is missing rx or ry and was skipped.");
+        return null;
+    }
+    const cx = parseNumber(element.getAttribute("cx")) ?? 0;
+    const cy = parseNumber(element.getAttribute("cy")) ?? 0;
+    return {
+        type: "ellipse",
+        cx,
+        cy,
+        rx,
+        ry,
+        ...getCommonAttributes(element, warnings),
+    };
+}
+function parseLine(element, warnings) {
+    const x1 = parseNumber(element.getAttribute("x1"));
+    const y1 = parseNumber(element.getAttribute("y1"));
+    const x2 = parseNumber(element.getAttribute("x2"));
+    const y2 = parseNumber(element.getAttribute("y2"));
+    if (x1 === undefined ||
+        y1 === undefined ||
+        x2 === undefined ||
+        y2 === undefined) {
+        warnings.push("<line> is missing coordinates and was skipped.");
+        return null;
+    }
+    return {
+        type: "line",
+        x1,
+        y1,
+        x2,
+        y2,
+        ...getCommonAttributes(element, warnings),
+    };
+}
+function parsePolyline(element, closed, warnings) {
+    const pointsAttr = element.getAttribute("points");
+    if (!pointsAttr) {
+        warnings.push(`<${element.tagName}> is missing points and was skipped.`);
+        return null;
+    }
+    const points = parsePoints(pointsAttr);
+    if (!points) {
+        warnings.push(`<${element.tagName}> points could not be parsed and was skipped.`);
+        return null;
+    }
+    return {
+        type: "polyline",
+        points,
+        closed,
+        ...getCommonAttributes(element, warnings),
+    };
+}
+function walk(element, warnings, out) {
+    const tag = element.tagName.toLowerCase();
+    if (IGNORE_TAGS.has(tag)) {
+        return;
+    }
+    if (!SUPPORTED_TAGS.has(tag)) {
+        warnings.push(`Unsupported <${element.tagName}> was ignored.`);
+        return;
+    }
+    if (tag === "g") {
+        if (element.hasAttribute("transform")) {
+            warnings.push("<g> transform attributes are not supported and were ignored.");
+        }
+        for (const child of Array.from(element.children)) {
+            walk(child, warnings, out);
+        }
+        return;
+    }
+    let shape = null;
+    switch (tag) {
+        case "rect":
+            shape = parseRect(element, warnings);
+            break;
+        case "circle":
+            shape = parseCircle(element, warnings);
+            break;
+        case "ellipse":
+            shape = parseEllipse(element, warnings);
+            break;
+        case "line":
+            shape = parseLine(element, warnings);
+            break;
+        case "polyline":
+            shape = parsePolyline(element, false, warnings);
+            break;
+        case "polygon":
+            shape = parsePolyline(element, true, warnings);
+            break;
+    }
+    if (shape) {
+        out.push(shape);
+    }
+}
+export function parseSvgToVectorLayer(svgText) {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(svgText, "image/svg+xml");
+    const svg = doc.documentElement;
+    const warnings = [];
+    if (!svg || svg.tagName.toLowerCase() !== "svg") {
+        warnings.push("The provided file is not a valid SVG document.");
+        return { layer: new VectorLayer([], { width: 1, height: 1 }), warnings };
+    }
+    const viewBoxAttr = svg.getAttribute("viewBox");
+    let minX = 0;
+    let minY = 0;
+    let viewBoxWidth;
+    let viewBoxHeight;
+    if (viewBoxAttr) {
+        const parts = viewBoxAttr.split(/\s+/).map((part) => parseFloat(part));
+        if (parts.length === 4 && parts.every((part) => Number.isFinite(part))) {
+            [minX, minY, viewBoxWidth, viewBoxHeight] = parts;
+        }
+        else {
+            warnings.push("SVG viewBox could not be parsed. Falling back to width/height.");
+        }
+    }
+    const widthAttr = svg.getAttribute("width");
+    const heightAttr = svg.getAttribute("height");
+    const width = parseNumber(widthAttr ?? "");
+    const height = parseNumber(heightAttr ?? "");
+    const sourceWidth = viewBoxWidth ?? width ?? 1;
+    const sourceHeight = viewBoxHeight ?? height ?? 1;
+    if (!svg.hasAttribute("viewBox") && (!width || !height)) {
+        warnings.push("SVG is missing explicit dimensions; assuming a 1:1 coordinate system.");
+    }
+    const shapes = [];
+    for (const child of Array.from(svg.children)) {
+        walk(child, warnings, shapes);
+    }
+    if (shapes.length === 0) {
+        warnings.push("No supported shapes were found in the SVG.");
+    }
+    return {
+        layer: new VectorLayer(shapes, {
+            minX,
+            minY,
+            width: sourceWidth,
+            height: sourceHeight,
+        }),
+        warnings,
+    };
+}

--- a/dist/editor.js
+++ b/dist/editor.js
@@ -1,5 +1,6 @@
 import { Editor } from "./core/Editor.js";
 import { Shortcuts } from "./core/Shortcuts.js";
+import { parseSvgToVectorLayer } from "./core/svgParser.js";
 import { PencilTool } from "./tools/PencilTool.js";
 import { EraserTool } from "./tools/EraserTool.js";
 import { RectangleTool } from "./tools/RectangleTool.js";
@@ -22,6 +23,22 @@ function listen(el, type, handler, list) {
  */
 export function initEditor() {
     const canvases = Array.from(document.querySelectorAll("canvas"));
+    const canvasContainer = document.getElementById("canvasContainer");
+    const commitVectorBtn = document.getElementById("commitVector");
+    let vectorOverlay = null;
+    let vectorOverlayCtx = null;
+    if (canvasContainer) {
+        vectorOverlay = canvasContainer.querySelector("#vectorOverlay");
+        if (!vectorOverlay) {
+            vectorOverlay = document.createElement("canvas");
+            vectorOverlay.id = "vectorOverlay";
+            canvasContainer.appendChild(vectorOverlay);
+        }
+        vectorOverlay.style.pointerEvents = "none";
+        vectorOverlay.style.display = "none";
+        vectorOverlay.style.zIndex = "10";
+        vectorOverlayCtx = vectorOverlay.getContext("2d");
+    }
     const toolConstructors = {
         pencil: PencilTool,
         eraser: EraserTool,
@@ -37,6 +54,54 @@ export function initEditor() {
     const editorToolConstructors = new Map();
     let activeToolCtor = PencilTool;
     let activeLayerIndex = 0;
+    let editor; // set after editors created
+    const ensureOverlaySize = () => {
+        if (!vectorOverlay || !editor)
+            return;
+        const rect = editor.canvas.getBoundingClientRect();
+        const dpr = window.devicePixelRatio || 1;
+        const width = Math.max(1, Math.round(rect.width * dpr));
+        const height = Math.max(1, Math.round(rect.height * dpr));
+        if (vectorOverlay.width !== width) {
+            vectorOverlay.width = width;
+        }
+        if (vectorOverlay.height !== height) {
+            vectorOverlay.height = height;
+        }
+        vectorOverlay.style.width = `${rect.width}px`;
+        vectorOverlay.style.height = `${rect.height}px`;
+    };
+    const clearOverlay = () => {
+        if (!vectorOverlay || !vectorOverlayCtx)
+            return;
+        vectorOverlayCtx.save();
+        vectorOverlayCtx.setTransform(1, 0, 0, 1, 0, 0);
+        vectorOverlayCtx.clearRect(0, 0, vectorOverlay.width, vectorOverlay.height);
+        vectorOverlayCtx.restore();
+    };
+    const renderVectorOverlay = () => {
+        if (!vectorOverlay || !vectorOverlayCtx || !editor) {
+            if (commitVectorBtn)
+                commitVectorBtn.disabled = true;
+            return;
+        }
+        ensureOverlaySize();
+        clearOverlay();
+        const layer = editor.getVectorLayer();
+        if (!layer || layer.isEmpty()) {
+            vectorOverlay.style.display = "none";
+            if (commitVectorBtn)
+                commitVectorBtn.disabled = true;
+            return;
+        }
+        vectorOverlay.style.display = "block";
+        const dpr = window.devicePixelRatio || 1;
+        vectorOverlayCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        const rect = editor.canvas.getBoundingClientRect();
+        layer.render(vectorOverlayCtx, rect.width, rect.height);
+        if (commitVectorBtn)
+            commitVectorBtn.disabled = false;
+    };
     Object.entries(toolConstructors).forEach(([id, Ctor]) => {
         const btn = document.getElementById(id);
         if (!btn) {
@@ -123,6 +188,14 @@ export function initEditor() {
     const undoBtn = document.getElementById("undo");
     const redoBtn = document.getElementById("redo");
     const listeners = [];
+    if (commitVectorBtn) {
+        commitVectorBtn.disabled = true;
+    }
+    const handleOverlayResize = () => {
+        renderVectorOverlay();
+    };
+    window.addEventListener("resize", handleOverlayResize);
+    listeners.push(() => window.removeEventListener("resize", handleOverlayResize));
     const recentColors = [];
     const maxRecentColors = 10;
     const renderColorHistory = () => {
@@ -154,7 +227,6 @@ export function initEditor() {
     listen(colorPicker, "input", () => {
         recordColor(colorPicker.value);
     }, listeners);
-    let editor; // set after editors created
     const updateHistoryButtons = () => {
         if (undoBtn)
             undoBtn.disabled = !editor?.canUndo;
@@ -188,6 +260,7 @@ export function initEditor() {
     });
     // active editor defaults to the first successfully created editor
     editor = editors[0];
+    renderVectorOverlay();
     // default tool
     editor.setTool(new PencilTool());
     editorToolConstructors.set(editor, PencilTool);
@@ -203,6 +276,12 @@ export function initEditor() {
     listen(redoBtn, "click", () => {
         editor.redo();
         updateHistoryButtons();
+    }, listeners);
+    listen(commitVectorBtn, "click", () => {
+        if (editor.rasterizeVectorLayer()) {
+            renderVectorOverlay();
+            updateHistoryButtons();
+        }
     }, listeners);
     // saving
     listen(saveBtn, "click", () => {
@@ -240,15 +319,43 @@ export function initEditor() {
         const file = e.target.files?.[0];
         if (!file)
             return;
+        const resetInput = () => {
+            if (imageLoader)
+                imageLoader.value = "";
+        };
+        const isSvg = file.type === "image/svg+xml" || file.name.toLowerCase().endsWith(".svg");
+        if (isSvg) {
+            const reader = new FileReader();
+            reader.onload = () => {
+                const text = String(reader.result ?? "");
+                const { layer, warnings } = parseSvgToVectorLayer(text);
+                editor.setVectorLayer(layer.isEmpty() ? null : layer);
+                renderVectorOverlay();
+                if (warnings.length) {
+                    const message = `SVG import warnings:\n- ${warnings.join("\n- ")}`;
+                    console.warn(message);
+                    window.alert(message);
+                }
+                resetInput();
+            };
+            reader.onerror = () => {
+                console.error("Failed to read SVG file.");
+                window.alert("Failed to load the SVG file.");
+                resetInput();
+            };
+            reader.readAsText(file);
+            return;
+        }
         const reader = new FileReader();
         reader.onload = () => {
             const img = new Image();
             img.onload = () => {
                 editor.saveState();
                 editor.ctx.drawImage(img, 0, 0, editor.canvas.width, editor.canvas.height);
+                editor.setVectorLayer(null);
+                renderVectorOverlay();
                 updateHistoryButtons();
-                if (imageLoader)
-                    imageLoader.value = "";
+                resetInput();
             };
             img.src = reader.result;
         };
@@ -284,6 +391,7 @@ export function initEditor() {
         updateHistoryButtons();
         if (layerSelect)
             layerSelect.value = String(index);
+        renderVectorOverlay();
     }
     const handle = {
         editor,

--- a/index.html
+++ b/index.html
@@ -46,6 +46,15 @@
         <img src="icons/paint-bucket.svg" alt="Bucket" />
       </button>
       <input type="file" id="imageLoader" accept="image/*" />
+      <button
+        id="commitVector"
+        class="tool-button"
+        type="button"
+        title="Rasterize vector shapes into the active layer"
+        disabled
+      >
+        Rasterize
+      </button>
       <button id="undo" class="tool-button" title="Undo" disabled>
         <img src="icons/undo.svg" alt="Undo" />
       </button>

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -1,4 +1,5 @@
 import { Tool } from "../tools/Tool.js";
+import type { VectorLayer } from "./VectorLayer.js";
 
 export class Editor {
   canvas: HTMLCanvasElement;
@@ -6,6 +7,7 @@ export class Editor {
   private undoStack: ImageData[] = [];
   private redoStack: ImageData[] = [];
   private currentTool: Tool | null = null;
+  private vectorLayer: VectorLayer | null = null;
   colorPicker: HTMLInputElement;
   lineWidth: HTMLInputElement;
   fillMode: HTMLInputElement;
@@ -141,6 +143,30 @@ export class Editor {
 
   get fontSizeValue() {
     return parseInt(this.fontSize?.value ?? "", 10) || 16;
+  }
+
+  setVectorLayer(layer: VectorLayer | null) {
+    this.vectorLayer = layer;
+  }
+
+  getVectorLayer(): VectorLayer | null {
+    return this.vectorLayer;
+  }
+
+  hasVectorLayer(): boolean {
+    return !!this.vectorLayer && !this.vectorLayer.isEmpty();
+  }
+
+  rasterizeVectorLayer(): boolean {
+    if (!this.vectorLayer || this.vectorLayer.isEmpty()) {
+      return false;
+    }
+    this.saveState();
+    const rect = this.canvas.getBoundingClientRect();
+    this.vectorLayer.render(this.ctx, rect.width, rect.height);
+    this.vectorLayer = null;
+    this.onChange?.();
+    return true;
   }
 
   /**

--- a/src/core/VectorLayer.ts
+++ b/src/core/VectorLayer.ts
@@ -1,0 +1,212 @@
+export interface BaseShape {
+  fill?: string;
+  fillOpacity?: number;
+  stroke?: string;
+  strokeOpacity?: number;
+  strokeWidth?: number;
+  strokeLineCap?: CanvasLineCap;
+  strokeLineJoin?: CanvasLineJoin;
+  opacity?: number;
+}
+
+export interface RectShape extends BaseShape {
+  type: "rect";
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface CircleShape extends BaseShape {
+  type: "circle";
+  cx: number;
+  cy: number;
+  r: number;
+}
+
+export interface EllipseShape extends BaseShape {
+  type: "ellipse";
+  cx: number;
+  cy: number;
+  rx: number;
+  ry: number;
+}
+
+export interface LineShape extends BaseShape {
+  type: "line";
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+export interface PolylineShape extends BaseShape {
+  type: "polyline";
+  points: Array<{ x: number; y: number }>;
+  closed: boolean;
+}
+
+export type VectorShape =
+  | RectShape
+  | CircleShape
+  | EllipseShape
+  | LineShape
+  | PolylineShape;
+
+export interface VectorLayerDimensions {
+  minX: number;
+  minY: number;
+  width: number;
+  height: number;
+}
+
+export class VectorLayer {
+  readonly shapes: VectorShape[];
+  private readonly bounds: VectorLayerDimensions;
+
+  constructor(shapes: VectorShape[], bounds?: Partial<VectorLayerDimensions>) {
+    this.shapes = shapes;
+    const width = bounds?.width ?? 1;
+    const height = bounds?.height ?? 1;
+    this.bounds = {
+      minX: bounds?.minX ?? 0,
+      minY: bounds?.minY ?? 0,
+      width: width <= 0 ? 1 : width,
+      height: height <= 0 ? 1 : height,
+    };
+  }
+
+  isEmpty(): boolean {
+    return this.shapes.length === 0;
+  }
+
+  render(
+    ctx: CanvasRenderingContext2D,
+    targetWidth?: number,
+    targetHeight?: number,
+  ): void {
+    if (this.shapes.length === 0) {
+      return;
+    }
+
+    const width = targetWidth ?? this.bounds.width;
+    const height = targetHeight ?? this.bounds.height;
+
+    const scaleX = width / this.bounds.width;
+    const scaleY = height / this.bounds.height;
+
+    ctx.save();
+    ctx.scale(scaleX, scaleY);
+    if (this.bounds.minX !== 0 || this.bounds.minY !== 0) {
+      ctx.translate(-this.bounds.minX, -this.bounds.minY);
+    }
+
+    for (const shape of this.shapes) {
+      this.drawShape(ctx, shape);
+    }
+
+    ctx.restore();
+  }
+
+  private drawShape(ctx: CanvasRenderingContext2D, shape: VectorShape) {
+    switch (shape.type) {
+      case "rect":
+        this.drawRect(ctx, shape);
+        break;
+      case "circle":
+        this.drawCircle(ctx, shape);
+        break;
+      case "ellipse":
+        this.drawEllipse(ctx, shape);
+        break;
+      case "line":
+        this.drawLine(ctx, shape);
+        break;
+      case "polyline":
+        this.drawPolyline(ctx, shape);
+        break;
+    }
+  }
+
+  private applyStroke(ctx: CanvasRenderingContext2D, shape: BaseShape) {
+    if (!shape.stroke || shape.stroke === "none") {
+      return;
+    }
+    const opacity = shape.strokeOpacity ?? shape.opacity ?? 1;
+    if (opacity <= 0) {
+      return;
+    }
+    ctx.save();
+    ctx.strokeStyle = shape.stroke;
+    ctx.globalAlpha = opacity;
+    ctx.lineWidth = shape.strokeWidth ?? 1;
+    if (shape.strokeLineCap) {
+      ctx.lineCap = shape.strokeLineCap;
+    }
+    if (shape.strokeLineJoin) {
+      ctx.lineJoin = shape.strokeLineJoin;
+    }
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  private applyFill(ctx: CanvasRenderingContext2D, shape: BaseShape) {
+    if (!shape.fill || shape.fill === "none") {
+      return;
+    }
+    const opacity = shape.fillOpacity ?? shape.opacity ?? 1;
+    if (opacity <= 0) {
+      return;
+    }
+    ctx.save();
+    ctx.fillStyle = shape.fill;
+    ctx.globalAlpha = opacity;
+    ctx.fill();
+    ctx.restore();
+  }
+
+  private drawRect(ctx: CanvasRenderingContext2D, shape: RectShape) {
+    ctx.beginPath();
+    ctx.rect(shape.x, shape.y, shape.width, shape.height);
+    this.applyFill(ctx, shape);
+    this.applyStroke(ctx, shape);
+  }
+
+  private drawCircle(ctx: CanvasRenderingContext2D, shape: CircleShape) {
+    ctx.beginPath();
+    ctx.arc(shape.cx, shape.cy, shape.r, 0, Math.PI * 2);
+    this.applyFill(ctx, shape);
+    this.applyStroke(ctx, shape);
+  }
+
+  private drawEllipse(ctx: CanvasRenderingContext2D, shape: EllipseShape) {
+    ctx.beginPath();
+    ctx.ellipse(shape.cx, shape.cy, shape.rx, shape.ry, 0, 0, Math.PI * 2);
+    this.applyFill(ctx, shape);
+    this.applyStroke(ctx, shape);
+  }
+
+  private drawLine(ctx: CanvasRenderingContext2D, shape: LineShape) {
+    ctx.beginPath();
+    ctx.moveTo(shape.x1, shape.y1);
+    ctx.lineTo(shape.x2, shape.y2);
+    this.applyStroke(ctx, shape);
+  }
+
+  private drawPolyline(ctx: CanvasRenderingContext2D, shape: PolylineShape) {
+    if (shape.points.length === 0) {
+      return;
+    }
+    ctx.beginPath();
+    const [first, ...rest] = shape.points;
+    ctx.moveTo(first.x, first.y);
+    for (const point of rest) {
+      ctx.lineTo(point.x, point.y);
+    }
+    if (shape.closed) {
+      ctx.closePath();
+    }
+    this.applyFill(ctx, shape);
+    this.applyStroke(ctx, shape);
+  }
+}

--- a/src/core/svgParser.ts
+++ b/src/core/svgParser.ts
@@ -1,0 +1,337 @@
+import { VectorLayer, VectorShape } from "./VectorLayer.js";
+
+export interface SvgParseResult {
+  layer: VectorLayer;
+  warnings: string[];
+}
+
+const SUPPORTED_TAGS = new Set([
+  "rect",
+  "circle",
+  "ellipse",
+  "line",
+  "polyline",
+  "polygon",
+  "g",
+]);
+
+const IGNORE_TAGS = new Set(["defs", "title", "desc", "metadata"]);
+
+function parseNumber(value: string | null): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const numeric = parseFloat(value);
+  return Number.isFinite(numeric) ? numeric : undefined;
+}
+
+function parseOpacity(value: string | null): number | undefined {
+  const numeric = parseNumber(value);
+  if (numeric === undefined) {
+    return undefined;
+  }
+  if (numeric < 0) return 0;
+  if (numeric > 1) return 1;
+  return numeric;
+}
+
+function parsePoints(
+  value: string,
+): Array<{ x: number; y: number }> | undefined {
+  const points: Array<{ x: number; y: number }> = [];
+  const pairs = value
+    .trim()
+    .replace(/\s+/g, " ")
+    .split(/[\s,]+/);
+  if (pairs.length % 2 !== 0) {
+    return undefined;
+  }
+  for (let i = 0; i < pairs.length; i += 2) {
+    const x = parseFloat(pairs[i]);
+    const y = parseFloat(pairs[i + 1]);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) {
+      return undefined;
+    }
+    points.push({ x, y });
+  }
+  return points;
+}
+
+function parseStrokeLineCap(value: string | null): CanvasLineCap | undefined {
+  switch (value) {
+    case "butt":
+    case "round":
+    case "square":
+      return value;
+    default:
+      return undefined;
+  }
+}
+
+function parseStrokeLineJoin(value: string | null): CanvasLineJoin | undefined {
+  switch (value) {
+    case "miter":
+    case "round":
+    case "bevel":
+      return value;
+    default:
+      return undefined;
+  }
+}
+
+function getCommonAttributes(
+  element: Element,
+  warnings: string[],
+) {
+  const fill = element.getAttribute("fill") ?? undefined;
+  const fillOpacity = parseOpacity(element.getAttribute("fill-opacity"));
+  const stroke = element.getAttribute("stroke") ?? undefined;
+  const strokeOpacity = parseOpacity(element.getAttribute("stroke-opacity"));
+  const strokeWidth = parseNumber(element.getAttribute("stroke-width"));
+  const opacity = parseOpacity(element.getAttribute("opacity"));
+  const strokeLineCap = parseStrokeLineCap(
+    element.getAttribute("stroke-linecap"),
+  );
+  const strokeLineJoin = parseStrokeLineJoin(
+    element.getAttribute("stroke-linejoin"),
+  );
+
+  if (element.hasAttribute("stroke-dasharray")) {
+    warnings.push(
+      `<${element.tagName}> stroke-dasharray is not supported and was ignored.`,
+    );
+  }
+  if (element.hasAttribute("transform")) {
+    warnings.push(
+      `<${element.tagName}> transform attributes are not supported and were ignored.`,
+    );
+  }
+  if (element.hasAttribute("style")) {
+    warnings.push(
+      `<${element.tagName}> inline styles are not fully supported and may be ignored.`,
+    );
+  }
+
+  return {
+    fill,
+    fillOpacity,
+    stroke,
+    strokeOpacity,
+    strokeWidth,
+    opacity,
+    strokeLineCap,
+    strokeLineJoin,
+  };
+}
+
+function parseRect(element: Element, warnings: string[]): VectorShape | null {
+  const width = parseNumber(element.getAttribute("width"));
+  const height = parseNumber(element.getAttribute("height"));
+  if (width === undefined || height === undefined) {
+    warnings.push("<rect> is missing width or height and was skipped.");
+    return null;
+  }
+  const x = parseNumber(element.getAttribute("x")) ?? 0;
+  const y = parseNumber(element.getAttribute("y")) ?? 0;
+
+  return {
+    type: "rect",
+    x,
+    y,
+    width,
+    height,
+    ...getCommonAttributes(element, warnings),
+  };
+}
+
+function parseCircle(element: Element, warnings: string[]): VectorShape | null {
+  const r = parseNumber(element.getAttribute("r"));
+  if (r === undefined) {
+    warnings.push("<circle> is missing r and was skipped.");
+    return null;
+  }
+  const cx = parseNumber(element.getAttribute("cx")) ?? 0;
+  const cy = parseNumber(element.getAttribute("cy")) ?? 0;
+  return {
+    type: "circle",
+    cx,
+    cy,
+    r,
+    ...getCommonAttributes(element, warnings),
+  };
+}
+
+function parseEllipse(element: Element, warnings: string[]): VectorShape | null {
+  const rx = parseNumber(element.getAttribute("rx"));
+  const ry = parseNumber(element.getAttribute("ry"));
+  if (rx === undefined || ry === undefined) {
+    warnings.push("<ellipse> is missing rx or ry and was skipped.");
+    return null;
+  }
+  const cx = parseNumber(element.getAttribute("cx")) ?? 0;
+  const cy = parseNumber(element.getAttribute("cy")) ?? 0;
+  return {
+    type: "ellipse",
+    cx,
+    cy,
+    rx,
+    ry,
+    ...getCommonAttributes(element, warnings),
+  };
+}
+
+function parseLine(element: Element, warnings: string[]): VectorShape | null {
+  const x1 = parseNumber(element.getAttribute("x1"));
+  const y1 = parseNumber(element.getAttribute("y1"));
+  const x2 = parseNumber(element.getAttribute("x2"));
+  const y2 = parseNumber(element.getAttribute("y2"));
+  if (
+    x1 === undefined ||
+    y1 === undefined ||
+    x2 === undefined ||
+    y2 === undefined
+  ) {
+    warnings.push("<line> is missing coordinates and was skipped.");
+    return null;
+  }
+  return {
+    type: "line",
+    x1,
+    y1,
+    x2,
+    y2,
+    ...getCommonAttributes(element, warnings),
+  };
+}
+
+function parsePolyline(
+  element: Element,
+  closed: boolean,
+  warnings: string[],
+): VectorShape | null {
+  const pointsAttr = element.getAttribute("points");
+  if (!pointsAttr) {
+    warnings.push(`<${element.tagName}> is missing points and was skipped.`);
+    return null;
+  }
+  const points = parsePoints(pointsAttr);
+  if (!points) {
+    warnings.push(`<${element.tagName}> points could not be parsed and was skipped.`);
+    return null;
+  }
+  return {
+    type: "polyline",
+    points,
+    closed,
+    ...getCommonAttributes(element, warnings),
+  };
+}
+
+function walk(
+  element: Element,
+  warnings: string[],
+  out: VectorShape[],
+) {
+  const tag = element.tagName.toLowerCase();
+  if (IGNORE_TAGS.has(tag)) {
+    return;
+  }
+
+  if (!SUPPORTED_TAGS.has(tag)) {
+    warnings.push(`Unsupported <${element.tagName}> was ignored.`);
+    return;
+  }
+
+  if (tag === "g") {
+    if (element.hasAttribute("transform")) {
+      warnings.push("<g> transform attributes are not supported and were ignored.");
+    }
+    for (const child of Array.from(element.children)) {
+      walk(child, warnings, out);
+    }
+    return;
+  }
+
+  let shape: VectorShape | null = null;
+  switch (tag) {
+    case "rect":
+      shape = parseRect(element, warnings);
+      break;
+    case "circle":
+      shape = parseCircle(element, warnings);
+      break;
+    case "ellipse":
+      shape = parseEllipse(element, warnings);
+      break;
+    case "line":
+      shape = parseLine(element, warnings);
+      break;
+    case "polyline":
+      shape = parsePolyline(element, false, warnings);
+      break;
+    case "polygon":
+      shape = parsePolyline(element, true, warnings);
+      break;
+  }
+
+  if (shape) {
+    out.push(shape);
+  }
+}
+
+export function parseSvgToVectorLayer(svgText: string): SvgParseResult {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(svgText, "image/svg+xml");
+  const svg = doc.documentElement;
+  const warnings: string[] = [];
+  if (!svg || svg.tagName.toLowerCase() !== "svg") {
+    warnings.push("The provided file is not a valid SVG document.");
+    return { layer: new VectorLayer([], { width: 1, height: 1 }), warnings };
+  }
+
+  const viewBoxAttr = svg.getAttribute("viewBox");
+  let minX = 0;
+  let minY = 0;
+  let viewBoxWidth: number | undefined;
+  let viewBoxHeight: number | undefined;
+  if (viewBoxAttr) {
+    const parts = viewBoxAttr.split(/\s+/).map((part) => parseFloat(part));
+    if (parts.length === 4 && parts.every((part) => Number.isFinite(part))) {
+      [minX, minY, viewBoxWidth, viewBoxHeight] = parts;
+    } else {
+      warnings.push("SVG viewBox could not be parsed. Falling back to width/height.");
+    }
+  }
+
+  const widthAttr = svg.getAttribute("width");
+  const heightAttr = svg.getAttribute("height");
+  const width = parseNumber(widthAttr ?? "");
+  const height = parseNumber(heightAttr ?? "");
+
+  const sourceWidth = viewBoxWidth ?? width ?? 1;
+  const sourceHeight = viewBoxHeight ?? height ?? 1;
+  if (!svg.hasAttribute("viewBox") && (!width || !height)) {
+    warnings.push(
+      "SVG is missing explicit dimensions; assuming a 1:1 coordinate system.",
+    );
+  }
+
+  const shapes: VectorShape[] = [];
+  for (const child of Array.from(svg.children)) {
+    walk(child, warnings, shapes);
+  }
+
+  if (shapes.length === 0) {
+    warnings.push("No supported shapes were found in the SVG.");
+  }
+
+  return {
+    layer: new VectorLayer(shapes, {
+      minX,
+      minY,
+      width: sourceWidth,
+      height: sourceHeight,
+    }),
+    warnings,
+  };
+}

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,5 +1,6 @@
 import { Editor } from "./core/Editor.js";
 import { Shortcuts } from "./core/Shortcuts.js";
+import { parseSvgToVectorLayer } from "./core/svgParser.js";
 import { PencilTool } from "./tools/PencilTool.js";
 import { EraserTool } from "./tools/EraserTool.js";
 import { RectangleTool } from "./tools/RectangleTool.js";
@@ -39,6 +40,30 @@ export function initEditor(): EditorHandle {
     document.querySelectorAll<HTMLCanvasElement>("canvas"),
   );
 
+  const canvasContainer = document.getElementById(
+    "canvasContainer",
+  ) as HTMLDivElement | null;
+  const commitVectorBtn = document.getElementById(
+    "commitVector",
+  ) as HTMLButtonElement | null;
+
+  let vectorOverlay: HTMLCanvasElement | null = null;
+  let vectorOverlayCtx: CanvasRenderingContext2D | null = null;
+  if (canvasContainer) {
+    vectorOverlay = canvasContainer.querySelector<HTMLCanvasElement>(
+      "#vectorOverlay",
+    );
+    if (!vectorOverlay) {
+      vectorOverlay = document.createElement("canvas");
+      vectorOverlay.id = "vectorOverlay";
+      canvasContainer.appendChild(vectorOverlay);
+    }
+    vectorOverlay.style.pointerEvents = "none";
+    vectorOverlay.style.display = "none";
+    vectorOverlay.style.zIndex = "10";
+    vectorOverlayCtx = vectorOverlay.getContext("2d");
+  }
+
   const toolConstructors: Record<string, new () => Tool> = {
     pencil: PencilTool,
     eraser: EraserTool,
@@ -55,6 +80,53 @@ export function initEditor(): EditorHandle {
   const editorToolConstructors = new Map<Editor, new () => Tool>();
   let activeToolCtor: new () => Tool = PencilTool;
   let activeLayerIndex = 0;
+
+  let editor: Editor; // set after editors created
+
+  const ensureOverlaySize = () => {
+    if (!vectorOverlay || !editor) return;
+    const rect = editor.canvas.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+    const width = Math.max(1, Math.round(rect.width * dpr));
+    const height = Math.max(1, Math.round(rect.height * dpr));
+    if (vectorOverlay.width !== width) {
+      vectorOverlay.width = width;
+    }
+    if (vectorOverlay.height !== height) {
+      vectorOverlay.height = height;
+    }
+    vectorOverlay.style.width = `${rect.width}px`;
+    vectorOverlay.style.height = `${rect.height}px`;
+  };
+
+  const clearOverlay = () => {
+    if (!vectorOverlay || !vectorOverlayCtx) return;
+    vectorOverlayCtx.save();
+    vectorOverlayCtx.setTransform(1, 0, 0, 1, 0, 0);
+    vectorOverlayCtx.clearRect(0, 0, vectorOverlay.width, vectorOverlay.height);
+    vectorOverlayCtx.restore();
+  };
+
+  const renderVectorOverlay = () => {
+    if (!vectorOverlay || !vectorOverlayCtx || !editor) {
+      if (commitVectorBtn) commitVectorBtn.disabled = true;
+      return;
+    }
+    ensureOverlaySize();
+    clearOverlay();
+    const layer = editor.getVectorLayer();
+    if (!layer || layer.isEmpty()) {
+      vectorOverlay.style.display = "none";
+      if (commitVectorBtn) commitVectorBtn.disabled = true;
+      return;
+    }
+    vectorOverlay.style.display = "block";
+    const dpr = window.devicePixelRatio || 1;
+    vectorOverlayCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    const rect = editor.canvas.getBoundingClientRect();
+    layer.render(vectorOverlayCtx, rect.width, rect.height);
+    if (commitVectorBtn) commitVectorBtn.disabled = false;
+  };
   Object.entries(toolConstructors).forEach(([id, Ctor]) => {
     const btn = document.getElementById(id) as HTMLButtonElement | null;
     if (!btn) {
@@ -156,6 +228,18 @@ export function initEditor(): EditorHandle {
   const redoBtn = document.getElementById("redo") as HTMLButtonElement | null;
   const listeners: Array<() => void> = [];
 
+  if (commitVectorBtn) {
+    commitVectorBtn.disabled = true;
+  }
+
+  const handleOverlayResize = () => {
+    renderVectorOverlay();
+  };
+  window.addEventListener("resize", handleOverlayResize);
+  listeners.push(() =>
+    window.removeEventListener("resize", handleOverlayResize),
+  );
+
   const recentColors: string[] = [];
   const maxRecentColors = 10;
   const renderColorHistory = () => {
@@ -191,8 +275,6 @@ export function initEditor(): EditorHandle {
     },
     listeners,
   );
-
-  let editor: Editor; // set after editors created
 
   const updateHistoryButtons = () => {
     if (undoBtn) undoBtn.disabled = !editor?.canUndo;
@@ -239,6 +321,8 @@ export function initEditor(): EditorHandle {
   // active editor defaults to the first successfully created editor
   editor = editors[0];
 
+  renderVectorOverlay();
+
   // default tool
   editor.setTool(new PencilTool());
   editorToolConstructors.set(editor, PencilTool);
@@ -268,6 +352,18 @@ export function initEditor(): EditorHandle {
     () => {
       editor.redo();
       updateHistoryButtons();
+    },
+    listeners,
+  );
+
+  listen(
+    commitVectorBtn,
+    "click",
+    () => {
+      if (editor.rasterizeVectorLayer()) {
+        renderVectorOverlay();
+        updateHistoryButtons();
+      }
     },
     listeners,
   );
@@ -319,6 +415,36 @@ export function initEditor(): EditorHandle {
     (e: Event) => {
       const file = (e.target as HTMLInputElement).files?.[0];
       if (!file) return;
+      const resetInput = () => {
+        if (imageLoader) imageLoader.value = "";
+      };
+
+      const isSvg =
+        file.type === "image/svg+xml" || file.name.toLowerCase().endsWith(".svg");
+
+      if (isSvg) {
+        const reader = new FileReader();
+        reader.onload = () => {
+          const text = String(reader.result ?? "");
+          const { layer, warnings } = parseSvgToVectorLayer(text);
+          editor.setVectorLayer(layer.isEmpty() ? null : layer);
+          renderVectorOverlay();
+          if (warnings.length) {
+            const message = `SVG import warnings:\n- ${warnings.join("\n- ")}`;
+            console.warn(message);
+            window.alert(message);
+          }
+          resetInput();
+        };
+        reader.onerror = () => {
+          console.error("Failed to read SVG file.");
+          window.alert("Failed to load the SVG file.");
+          resetInput();
+        };
+        reader.readAsText(file);
+        return;
+      }
+
       const reader = new FileReader();
       reader.onload = () => {
         const img = new Image();
@@ -331,8 +457,10 @@ export function initEditor(): EditorHandle {
             editor.canvas.width,
             editor.canvas.height,
           );
+          editor.setVectorLayer(null);
+          renderVectorOverlay();
           updateHistoryButtons();
-          if (imageLoader) imageLoader.value = "";
+          resetInput();
         };
         img.src = reader.result as string;
       };
@@ -380,6 +508,7 @@ export function initEditor(): EditorHandle {
     editor.setTool(new ToolCtor());
     updateHistoryButtons();
     if (layerSelect) layerSelect.value = String(index);
+    renderVectorOverlay();
   }
 
   const handle: EditorHandle = {

--- a/style.css
+++ b/style.css
@@ -99,4 +99,15 @@ body {
   box-sizing: border-box;
 }
 
+#vectorOverlay {
+  pointer-events: none;
+  display: none;
+  z-index: 10;
+}
+
+#commitVector.tool-button {
+  width: auto;
+  padding: 0 12px;
+}
+
 


### PR DESCRIPTION
## Summary
- parse uploaded SVGs into vector layer models while warning when unsupported features are encountered
- render imported vector content on a dedicated overlay with a commit button to rasterize shapes into the active canvas
- add reusable vector layer drawing utilities to support rasterization and previews

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d60d2a219c8328bd792ab9c552255d