### PR TITLE
Add IndexedDB autosave with restore workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,16 @@
         <img src="icons/save.svg" alt="Save" />
       </button>
 
+      <div class="group">
+        <label for="autosaveInterval">Autosave (s)</label>
+        <input type="number" id="autosaveInterval" min="5" step="5" />
+      </div>
+      <div class="group">
+        <label for="quotaWarning">Quota warning (MB)</label>
+        <input type="number" id="quotaWarning" min="1" step="5" />
+      </div>
+      <div id="autosaveStatus" role="status" aria-live="polite"></div>
+
     </div>
     <div id="canvasContainer">
       <canvas id="canvas" width="800" height="600"></canvas>

--- a/src/core/AutosaveManager.ts
+++ b/src/core/AutosaveManager.ts
@@ -1,0 +1,285 @@
+import type { EditorHandle, SerializedEditorState } from "../editor.js";
+
+const DB_NAME = "photoshop-clone";
+const STORE_NAME = "sessions";
+const SESSION_KEY = "latest";
+const CONFIG_STORAGE_KEY = "autosave-config";
+
+interface AutosaveConfig {
+  intervalSeconds: number;
+  quotaWarningMB: number;
+}
+
+interface StoredSession {
+  timestamp: number;
+  state: SerializedEditorState;
+}
+
+interface AutosaveManagerOptions {
+  intervalInput?: HTMLInputElement | null;
+  quotaWarningInput?: HTMLInputElement | null;
+  statusElement?: HTMLElement | null;
+}
+
+const defaultConfig: AutosaveConfig = {
+  intervalSeconds: 60,
+  quotaWarningMB: 50,
+};
+
+function loadConfig(): AutosaveConfig {
+  try {
+    const stored = localStorage.getItem(CONFIG_STORAGE_KEY);
+    if (!stored) return { ...defaultConfig };
+    const parsed = JSON.parse(stored) as Partial<AutosaveConfig> | null;
+    return {
+      intervalSeconds:
+        typeof parsed?.intervalSeconds === "number" && parsed.intervalSeconds > 0
+          ? parsed.intervalSeconds
+          : defaultConfig.intervalSeconds,
+      quotaWarningMB:
+        typeof parsed?.quotaWarningMB === "number" && parsed.quotaWarningMB > 0
+          ? parsed.quotaWarningMB
+          : defaultConfig.quotaWarningMB,
+    };
+  } catch {
+    return { ...defaultConfig };
+  }
+}
+
+function saveConfig(config: AutosaveConfig) {
+  try {
+    localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(config));
+  } catch {
+    /* ignore storage failures */
+  }
+}
+
+function openDatabase(): Promise<IDBDatabase | null> {
+  if (typeof indexedDB === "undefined") return Promise.resolve(null);
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+    request.onsuccess = () => {
+      resolve(request.result);
+    };
+    request.onerror = () => {
+      reject(request.error ?? new Error("Failed to open IndexedDB"));
+    };
+  }).catch(() => null);
+}
+
+async function withStore<T>(
+  dbPromise: Promise<IDBDatabase | null>,
+  mode: IDBTransactionMode,
+  cb: (store: IDBObjectStore) => void,
+): Promise<T | null> {
+  const db = await dbPromise;
+  if (!db) return null;
+  return new Promise<T | null>((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, mode);
+    const store = tx.objectStore(STORE_NAME);
+    cb(store);
+    tx.oncomplete = () => resolve(null);
+    tx.onerror = () => reject(tx.error ?? new Error("Transaction failed"));
+  }).catch(() => null);
+}
+
+async function getSession(
+  dbPromise: Promise<IDBDatabase | null>,
+): Promise<StoredSession | null> {
+  const db = await dbPromise;
+  if (!db) return null;
+  return new Promise<StoredSession | null>((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readonly");
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.get(SESSION_KEY);
+    request.onsuccess = () => {
+      resolve((request.result as StoredSession | undefined) ?? null);
+    };
+    request.onerror = () => {
+      reject(request.error ?? new Error("Failed to read session"));
+    };
+  }).catch(() => null);
+}
+
+async function putSession(
+  dbPromise: Promise<IDBDatabase | null>,
+  session: StoredSession,
+): Promise<void> {
+  await withStore<void>(dbPromise, "readwrite", (store) => {
+    store.put(session, SESSION_KEY);
+  });
+}
+
+async function deleteSession(dbPromise: Promise<IDBDatabase | null>): Promise<void> {
+  await withStore<void>(dbPromise, "readwrite", (store) => {
+    store.delete(SESSION_KEY);
+  });
+}
+
+export class AutosaveManager {
+  private readonly handle: EditorHandle;
+  private readonly intervalInput?: HTMLInputElement | null;
+  private readonly quotaWarningInput?: HTMLInputElement | null;
+  private readonly statusElement?: HTMLElement | null;
+  private readonly dbPromise: Promise<IDBDatabase | null>;
+  private timer: number | null = null;
+  private lastSaveText = "";
+  private quotaWarningText = "";
+  private config: AutosaveConfig;
+  readonly supported: boolean;
+
+  constructor(handle: EditorHandle, options: AutosaveManagerOptions = {}) {
+    this.handle = handle;
+    this.intervalInput = options.intervalInput ?? null;
+    this.quotaWarningInput = options.quotaWarningInput ?? null;
+    this.statusElement = options.statusElement ?? null;
+    this.dbPromise = openDatabase();
+    this.supported = typeof indexedDB !== "undefined";
+    this.config = loadConfig();
+
+    if (this.intervalInput && !this.intervalInput.value) {
+      this.intervalInput.value = String(this.config.intervalSeconds);
+    }
+    if (this.quotaWarningInput && !this.quotaWarningInput.value) {
+      this.quotaWarningInput.value = String(this.config.quotaWarningMB);
+    }
+
+    this.intervalInput?.addEventListener("change", this.handleConfigChange);
+    this.quotaWarningInput?.addEventListener("change", this.handleConfigChange);
+    this.renderStatus();
+  }
+
+  private get intervalMs(): number {
+    const raw = this.intervalInput?.value;
+    const parsed = raw ? parseInt(raw, 10) : NaN;
+    if (!parsed || parsed < 5) {
+      return this.config.intervalSeconds * 1000;
+    }
+    return parsed * 1000;
+  }
+
+  private get quotaWarningBytes(): number {
+    const raw = this.quotaWarningInput?.value;
+    const parsed = raw ? parseInt(raw, 10) : NaN;
+    const mb = !parsed || parsed <= 0 ? this.config.quotaWarningMB : parsed;
+    return mb * 1024 * 1024;
+  }
+
+  private renderStatus() {
+    if (!this.statusElement) return;
+    const parts = [];
+    if (this.lastSaveText) parts.push(this.lastSaveText);
+    if (this.quotaWarningText) parts.push(this.quotaWarningText);
+    this.statusElement.textContent = parts.join(" · ");
+  }
+
+  private handleConfigChange = () => {
+    const intervalSeconds = (() => {
+      const raw = this.intervalInput?.value;
+      const parsed = raw ? parseInt(raw, 10) : NaN;
+      return !parsed || parsed < 5 ? defaultConfig.intervalSeconds : parsed;
+    })();
+    const quotaWarningMB = (() => {
+      const raw = this.quotaWarningInput?.value;
+      const parsed = raw ? parseInt(raw, 10) : NaN;
+      return !parsed || parsed <= 0 ? defaultConfig.quotaWarningMB : parsed;
+    })();
+    this.config = { intervalSeconds, quotaWarningMB };
+    saveConfig(this.config);
+    if (this.timer !== null) {
+      this.start();
+    }
+  };
+
+  async start(): Promise<void> {
+    if (!this.supported) {
+      this.lastSaveText = "Autosave unavailable";
+      this.renderStatus();
+      return;
+    }
+    this.stop();
+    await this.performSave();
+    this.timer = window.setInterval(() => {
+      void this.performSave();
+    }, this.intervalMs);
+  }
+
+  stop() {
+    if (this.timer !== null) {
+      window.clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  async performSave(): Promise<void> {
+    if (!this.supported) return;
+    try {
+      const state = await this.handle.serializeState();
+      await putSession(this.dbPromise, {
+        timestamp: Date.now(),
+        state,
+      });
+      this.lastSaveText = `Autosaved at ${new Date().toLocaleTimeString()}`;
+      this.renderStatus();
+      await this.updateQuotaWarning();
+    } catch (error) {
+      console.warn("Autosave failed", error);
+      this.lastSaveText = "Autosave failed";
+      this.renderStatus();
+    }
+  }
+
+  async getLatestSession(): Promise<StoredSession | null> {
+    if (!this.supported) return null;
+    return getSession(this.dbPromise);
+  }
+
+  async clearLatestSession(): Promise<void> {
+    if (!this.supported) return;
+    await deleteSession(this.dbPromise);
+  }
+
+  private async updateQuotaWarning(): Promise<void> {
+    if (!navigator.storage?.estimate) {
+      this.quotaWarningText = "";
+      this.renderStatus();
+      return;
+    }
+    try {
+      const { usage = 0, quota } = await navigator.storage.estimate();
+      if (!usage) {
+        this.quotaWarningText = "";
+        this.renderStatus();
+        return;
+      }
+      const usageMB = usage / (1024 * 1024);
+      const quotaMB = quota ? quota / (1024 * 1024) : undefined;
+      const shouldWarn =
+        usage >= this.quotaWarningBytes ||
+        (quota && usage / quota > 0.9);
+      this.quotaWarningText = shouldWarn
+        ? `Storage usage ${usageMB.toFixed(1)}MB${
+            quotaMB ? ` of ${quotaMB.toFixed(1)}MB` : ""
+          }`
+        : "";
+      this.renderStatus();
+    } catch {
+      this.quotaWarningText = "";
+      this.renderStatus();
+    }
+  }
+
+  destroy() {
+    this.stop();
+    this.intervalInput?.removeEventListener("change", this.handleConfigChange);
+    this.quotaWarningInput?.removeEventListener("change", this.handleConfigChange);
+  }
+}
+
+export type { StoredSession };

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -27,7 +27,27 @@ export interface EditorHandle {
   editor: Editor;
   editors: Editor[];
   activateLayer(index: number): void;
+  serializeState(): Promise<SerializedEditorState>;
+  restoreState(state: SerializedEditorState): Promise<void>;
   destroy(): void;
+}
+
+export interface SerializedLayerState {
+  id: string;
+  dataUrl: string;
+  opacity: number;
+}
+
+export interface SerializedEditorState {
+  layers: SerializedLayerState[];
+  activeLayerIndex: number;
+  colorPicker: string;
+  lineWidth: string;
+  fillMode: boolean;
+  fontFamily: string | null;
+  fontSize: string | null;
+  recentColors: string[];
+  timestamp: number;
 }
 
 /**
@@ -158,6 +178,15 @@ export function initEditor(): EditorHandle {
 
   const recentColors: string[] = [];
   const maxRecentColors = 10;
+  const setRecentColors = (colors: string[]) => {
+    recentColors.length = 0;
+    colors.forEach((color) => {
+      if (typeof color === "string" && color.trim()) {
+        recentColors.push(color);
+      }
+    });
+    renderColorHistory();
+  };
   const renderColorHistory = () => {
     if (!colorHistory) return;
     colorHistory.innerHTML = "";
@@ -386,6 +415,75 @@ export function initEditor(): EditorHandle {
     editor,
     editors,
     activateLayer,
+    async serializeState(): Promise<SerializedEditorState> {
+      const layers: SerializedLayerState[] = await Promise.all(
+        editors.map(async (e) => ({
+          id: e.canvas.id,
+          dataUrl: e.canvas.toDataURL("image/png"),
+          opacity: parseFloat(e.canvas.style.opacity || "1") || 1,
+        })),
+      );
+      return {
+        layers,
+        activeLayerIndex,
+        colorPicker: colorPicker.value,
+        lineWidth: lineWidth.value,
+        fillMode: fillMode.checked,
+        fontFamily: fontFamily?.value ?? null,
+        fontSize: fontSize?.value ?? null,
+        recentColors: [...recentColors],
+        timestamp: Date.now(),
+      };
+    },
+    async restoreState(state: SerializedEditorState): Promise<void> {
+      if (!state) return;
+      if (!Array.isArray(state.layers)) return;
+      if (typeof state.colorPicker === "string") {
+        colorPicker.value = state.colorPicker;
+        colorPicker.dispatchEvent(new Event("input"));
+      }
+      if (typeof state.lineWidth === "string") {
+        lineWidth.value = state.lineWidth;
+      }
+      if (typeof state.fillMode === "boolean") {
+        fillMode.checked = state.fillMode;
+      }
+      if (fontFamily && typeof state.fontFamily === "string") {
+        fontFamily.value = state.fontFamily;
+      }
+      if (fontSize && typeof state.fontSize === "string") {
+        fontSize.value = state.fontSize;
+      }
+      if (Array.isArray(state.recentColors)) {
+        setRecentColors(state.recentColors);
+      }
+
+      const loadPromises = state.layers.map((layerState, index) => {
+        const targetCanvas = canvases[index];
+        if (!targetCanvas) return Promise.resolve();
+        return new Promise<void>((resolve) => {
+          const img = new Image();
+          img.onload = () => {
+            const ctx = targetCanvas.getContext("2d");
+            if (ctx) {
+              ctx.clearRect(0, 0, targetCanvas.width, targetCanvas.height);
+              ctx.drawImage(img, 0, 0, targetCanvas.width, targetCanvas.height);
+            }
+            targetCanvas.style.opacity = String(layerState.opacity ?? 1);
+            resolve();
+          };
+          img.onerror = () => resolve();
+          img.src = layerState.dataUrl;
+        });
+      });
+
+      await Promise.all(loadPromises);
+
+      if (typeof state.activeLayerIndex === "number") {
+        activateLayer(state.activeLayerIndex);
+      }
+      updateHistoryButtons();
+    },
     destroy() {
       listeners.forEach((fn) => fn());
       shortcuts.destroy();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,45 @@
 import { initEditor } from "./editor.js";
+import { AutosaveManager } from "./core/AutosaveManager.js";
 
 const handle = initEditor();
-window.addEventListener("beforeunload", () => handle.destroy());
+
+const autosaveIntervalInput = document.getElementById(
+  "autosaveInterval",
+) as HTMLInputElement | null;
+const quotaWarningInput = document.getElementById(
+  "quotaWarning",
+) as HTMLInputElement | null;
+const autosaveStatus = document.getElementById(
+  "autosaveStatus",
+) as HTMLElement | null;
+
+const autosave = new AutosaveManager(handle, {
+  intervalInput: autosaveIntervalInput,
+  quotaWarningInput,
+  statusElement: autosaveStatus,
+});
+
+async function restoreSession() {
+  const session = await autosave.getLatestSession();
+  if (!session?.state) return;
+  const resume = window.confirm("Restore your last editing session?");
+  if (resume) {
+    await handle.restoreState(session.state);
+    if (autosaveStatus) {
+      autosaveStatus.textContent = "Session restored";
+    }
+  } else {
+    await autosave.clearLatestSession();
+  }
+}
+
+void (async () => {
+  await restoreSession();
+  await autosave.start();
+})();
+
+window.addEventListener("beforeunload", () => {
+  void autosave.performSave();
+  autosave.destroy();
+  handle.destroy();
+});

--- a/style.css
+++ b/style.css
@@ -47,6 +47,12 @@ body {
   gap: 8px;
 }
 
+#autosaveStatus {
+  flex: 1 1 100%;
+  font-size: 0.9rem;
+  color: #555;
+}
+
 .tool-button {
   width: 32px;
   height: 32px;


### PR DESCRIPTION
## Summary
- add an IndexedDB-backed autosave manager with configurable interval and quota warning support
- expose editor state serialization/restoration to persist layers, tool settings, and color history
- update the toolbar UI to surface autosave controls and status messaging

## Testing
- npm test *(fails: npm command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d60d29963483288c5cf8e9f27e71e6