### PR TITLE
Add dynamic export format detection and JPEG quality controls

### DIFF
--- a/dist/editor.js
+++ b/dist/editor.js
@@ -75,6 +75,9 @@ export function initEditor() {
     const toolbar = document.getElementById("toolbar") || document.body;
     const saveBtn = document.getElementById("save");
     const formatSelect = document.getElementById("formatSelect");
+    const jpegQualityGroup = document.getElementById("jpegQualityGroup");
+    const jpegQuality = document.getElementById("jpegQuality");
+    const jpegQualityValue = document.getElementById("jpegQualityValue");
     const colorHistory = document.getElementById("colorHistory");
     if (!colorPicker) {
         throw new Error("Missing #colorPicker input");
@@ -91,6 +94,101 @@ export function initEditor() {
     if (!formatSelect) {
         throw new Error("Missing #formatSelect select");
     }
+    if (!jpegQualityGroup || !jpegQuality || !jpegQualityValue) {
+        throw new Error("Missing JPEG quality controls");
+    }
+    const detectCanvasFormatSupport = (mime) => {
+        const testCanvas = document.createElement("canvas");
+        try {
+            return testCanvas.toDataURL(mime).startsWith(`data:${mime}`);
+        }
+        catch {
+            return false;
+        }
+    };
+    const baseFormats = [
+        { id: "png", label: "PNG", mime: "image/png", extension: "png" },
+        {
+            id: "jpeg",
+            label: "JPEG",
+            mime: "image/jpeg",
+            extension: "jpg",
+            supportsQuality: true,
+        },
+    ];
+    const optionalFormats = [
+        { id: "webp", label: "WebP", mime: "image/webp", extension: "webp" },
+        { id: "avif", label: "AVIF", mime: "image/avif", extension: "avif" },
+    ];
+    const formats = baseFormats.slice();
+    optionalFormats.forEach((format) => {
+        if (detectCanvasFormatSupport(format.mime)) {
+            formats.push(format);
+        }
+    });
+    const formatConfigs = new Map();
+    formatSelect.innerHTML = "";
+    formats.forEach((format) => {
+        const option = document.createElement("option");
+        option.value = format.id;
+        option.textContent = format.label;
+        formatSelect.appendChild(option);
+        formatConfigs.set(format.id, format);
+    });
+    if (!formatConfigs.has(formatSelect.value)) {
+        formatSelect.value = formats[0]?.id ?? "png";
+    }
+    const listeners = [];
+    const defaultJpegQuality = 90;
+    const clampQuality = (value) => {
+        const min = Number.parseFloat(jpegQuality.min || "0");
+        const max = Number.parseFloat(jpegQuality.max || "100");
+        const safeValue = Number.isNaN(value)
+            ? defaultJpegQuality
+            : Math.round(value);
+        return Math.min(Math.max(safeValue, min), max);
+    };
+    const readStoredJpegQuality = () => {
+        try {
+            const stored = window.localStorage.getItem("editor.jpegQuality");
+            if (!stored)
+                return defaultJpegQuality;
+            const parsed = Number.parseInt(stored, 10);
+            if (Number.isNaN(parsed))
+                return defaultJpegQuality;
+            return clampQuality(parsed);
+        }
+        catch {
+            return defaultJpegQuality;
+        }
+    };
+    const writeStoredJpegQuality = (value) => {
+        try {
+            window.localStorage.setItem("editor.jpegQuality", String(value));
+        }
+        catch {
+            /* ignore storage failures */
+        }
+    };
+    const updateQualityDisplay = (percent) => {
+        jpegQualityValue.textContent = `${Math.round(percent)}%`;
+    };
+    const updateFormatDependentControls = () => {
+        jpegQualityGroup.hidden = formatSelect.value !== "jpeg";
+    };
+    const initialQuality = readStoredJpegQuality();
+    jpegQuality.value = String(initialQuality);
+    updateQualityDisplay(initialQuality);
+    updateFormatDependentControls();
+    listen(formatSelect, "change", () => {
+        updateFormatDependentControls();
+    }, listeners);
+    listen(jpegQuality, "input", () => {
+        const quality = clampQuality(Number.parseFloat(jpegQuality.value));
+        jpegQuality.value = String(quality);
+        updateQualityDisplay(quality);
+        writeStoredJpegQuality(quality);
+    }, listeners);
     if (layerSelect) {
         layerSelect.innerHTML = "";
     }
@@ -122,7 +220,6 @@ export function initEditor() {
     });
     const undoBtn = document.getElementById("undo");
     const redoBtn = document.getElementById("redo");
-    const listeners = [];
     const recentColors = [];
     const maxRecentColors = 10;
     const renderColorHistory = () => {
@@ -206,9 +303,17 @@ export function initEditor() {
     }, listeners);
     // saving
     listen(saveBtn, "click", () => {
-        const format = formatSelect.value.toLowerCase() === "jpeg" ? "jpeg" : "png";
-        const mime = format === "jpeg" ? "image/jpeg" : "image/png";
-        const quality = format === "jpeg" ? 0.9 : undefined;
+        const fallbackFormat = formatConfigs.get("png");
+        const selectedFormat = formatConfigs.get(formatSelect.value) ?? fallbackFormat;
+        if (!selectedFormat) {
+            throw new Error("No export formats available");
+        }
+        let mime = selectedFormat.mime;
+        let extension = selectedFormat.extension;
+        const qualityPercent = selectedFormat.supportsQuality
+            ? clampQuality(Number.parseFloat(jpegQuality.value))
+            : undefined;
+        const quality = qualityPercent !== undefined ? qualityPercent / 100 : undefined;
         let exportCanvas;
         if (canvases.length > 1) {
             // composite all layers respecting their opacity
@@ -226,12 +331,26 @@ export function initEditor() {
         else {
             exportCanvas = editor.canvas;
         }
-        const data = quality !== undefined
-            ? exportCanvas.toDataURL(mime, quality)
-            : exportCanvas.toDataURL(mime);
+        const ensureDataUrl = (targetMime, targetQuality) => {
+            return targetQuality !== undefined
+                ? exportCanvas.toDataURL(targetMime, targetQuality)
+                : exportCanvas.toDataURL(targetMime);
+        };
+        let data = ensureDataUrl(mime, quality);
+        if (!data.startsWith(`data:${mime}`)) {
+            const fallback = ensureDataUrl("image/png");
+            if (!fallbackFormat) {
+                throw new Error("PNG format is required for fallback");
+            }
+            data = fallback;
+            mime = fallbackFormat.mime;
+            extension = fallbackFormat.extension;
+            formatSelect.value = fallbackFormat.id;
+            updateFormatDependentControls();
+        }
         const a = document.createElement("a");
         a.href = data;
-        a.download = `canvas.${format === "jpeg" ? "jpg" : "png"}`;
+        a.download = `canvas.${extension}`;
         a.click();
     }, listeners);
     // image loading

--- a/index.html
+++ b/index.html
@@ -57,10 +57,19 @@
         <label for="layerSelect">Layer</label>
         <select id="layerSelect"></select>
       </div>
-      <select id="formatSelect">
-        <option value="png">PNG</option>
-        <option value="jpeg">JPEG</option>
-      </select>
+      <select id="formatSelect"></select>
+      <div class="group" id="jpegQualityGroup" hidden>
+        <label for="jpegQuality">JPEG Quality</label>
+        <input
+          type="range"
+          id="jpegQuality"
+          min="10"
+          max="100"
+          step="5"
+          value="90"
+        />
+        <output id="jpegQualityValue" for="jpegQuality">90%</output>
+      </div>
       <button id="save" class="tool-button" title="Save">
         <img src="icons/save.svg" alt="Save" />
       </button>

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "jsdom",
+    "setupFilesAfterEnv": ["<rootDir>/tests/setupEnv.ts"],
     "globals": {
       "ts-jest": {
         "useESM": true,

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -96,6 +96,13 @@ export function initEditor(): EditorHandle {
   const saveBtn = document.getElementById("save") as HTMLButtonElement | null;
   const formatSelect =
     document.getElementById("formatSelect") as HTMLSelectElement | null;
+  const jpegQualityGroup =
+    document.getElementById("jpegQualityGroup") as HTMLDivElement | null;
+  const jpegQuality =
+    document.getElementById("jpegQuality") as HTMLInputElement | null;
+  const jpegQualityValue = document.getElementById(
+    "jpegQualityValue",
+  ) as HTMLOutputElement | null;
   const colorHistory = document.getElementById(
     "colorHistory",
   ) as HTMLDivElement | null;
@@ -115,6 +122,117 @@ export function initEditor(): EditorHandle {
   if (!formatSelect) {
     throw new Error("Missing #formatSelect select");
   }
+  if (!jpegQualityGroup || !jpegQuality || !jpegQualityValue) {
+    throw new Error("Missing JPEG quality controls");
+  }
+
+  type ExportFormat = {
+    id: string;
+    label: string;
+    mime: string;
+    extension: string;
+    supportsQuality?: boolean;
+  };
+
+  const detectCanvasFormatSupport = (mime: string): boolean => {
+    const testCanvas = document.createElement("canvas");
+    try {
+      return testCanvas.toDataURL(mime).startsWith(`data:${mime}`);
+    } catch {
+      return false;
+    }
+  };
+
+  const baseFormats: ExportFormat[] = [
+    { id: "png", label: "PNG", mime: "image/png", extension: "png" },
+    {
+      id: "jpeg",
+      label: "JPEG",
+      mime: "image/jpeg",
+      extension: "jpg",
+      supportsQuality: true,
+    },
+  ];
+  const optionalFormats: ExportFormat[] = [
+    { id: "webp", label: "WebP", mime: "image/webp", extension: "webp" },
+    { id: "avif", label: "AVIF", mime: "image/avif", extension: "avif" },
+  ];
+
+  const formats: ExportFormat[] = baseFormats.slice();
+  optionalFormats.forEach((format) => {
+    if (detectCanvasFormatSupport(format.mime)) {
+      formats.push(format);
+    }
+  });
+
+  const formatConfigs = new Map<string, ExportFormat>();
+  formatSelect.innerHTML = "";
+  formats.forEach((format) => {
+    const option = document.createElement("option");
+    option.value = format.id;
+    option.textContent = format.label;
+    formatSelect.appendChild(option);
+    formatConfigs.set(format.id, format);
+  });
+  if (!formatConfigs.has(formatSelect.value)) {
+    formatSelect.value = formats[0]?.id ?? "png";
+  }
+
+  const listeners: Array<() => void> = [];
+
+  const defaultJpegQuality = 90;
+  const clampQuality = (value: number): number => {
+    const min = Number.parseFloat(jpegQuality.min || "0");
+    const max = Number.parseFloat(jpegQuality.max || "100");
+    const safeValue = Number.isNaN(value)
+      ? defaultJpegQuality
+      : Math.round(value);
+    return Math.min(Math.max(safeValue, min), max);
+  };
+
+  const readStoredJpegQuality = (): number => {
+    try {
+      const stored = window.localStorage.getItem("editor.jpegQuality");
+      if (!stored) return defaultJpegQuality;
+      const parsed = Number.parseInt(stored, 10);
+      if (Number.isNaN(parsed)) return defaultJpegQuality;
+      return clampQuality(parsed);
+    } catch {
+      return defaultJpegQuality;
+    }
+  };
+
+  const writeStoredJpegQuality = (value: number) => {
+    try {
+      window.localStorage.setItem("editor.jpegQuality", String(value));
+    } catch {
+      /* ignore storage failures */
+    }
+  };
+
+  const updateQualityDisplay = (percent: number) => {
+    jpegQualityValue.textContent = `${Math.round(percent)}%`;
+  };
+
+  const updateFormatDependentControls = () => {
+    jpegQualityGroup.hidden = formatSelect.value !== "jpeg";
+  };
+
+  const initialQuality = readStoredJpegQuality();
+  jpegQuality.value = String(initialQuality);
+  updateQualityDisplay(initialQuality);
+  updateFormatDependentControls();
+
+  listen<Event>(formatSelect, "change", () => {
+    updateFormatDependentControls();
+  }, listeners);
+
+  listen<Event>(jpegQuality, "input", () => {
+    const quality = clampQuality(Number.parseFloat(jpegQuality.value));
+    jpegQuality.value = String(quality);
+    updateQualityDisplay(quality);
+    writeStoredJpegQuality(quality);
+  }, listeners);
 
   if (layerSelect) {
     layerSelect.innerHTML = "";
@@ -154,7 +272,6 @@ export function initEditor(): EditorHandle {
 
   const undoBtn = document.getElementById("undo") as HTMLButtonElement | null;
   const redoBtn = document.getElementById("redo") as HTMLButtonElement | null;
-  const listeners: Array<() => void> = [];
 
   const recentColors: string[] = [];
   const maxRecentColors = 10;
@@ -277,10 +394,19 @@ export function initEditor(): EditorHandle {
     saveBtn,
     "click",
     () => {
-      const format =
-        formatSelect.value.toLowerCase() === "jpeg" ? "jpeg" : "png";
-      const mime = format === "jpeg" ? "image/jpeg" : "image/png";
-      const quality = format === "jpeg" ? 0.9 : undefined;
+      const fallbackFormat = formatConfigs.get("png");
+      const selectedFormat =
+        formatConfigs.get(formatSelect.value) ?? fallbackFormat;
+      if (!selectedFormat) {
+        throw new Error("No export formats available");
+      }
+      let mime = selectedFormat.mime;
+      let extension = selectedFormat.extension;
+      const qualityPercent = selectedFormat.supportsQuality
+        ? clampQuality(Number.parseFloat(jpegQuality.value))
+        : undefined;
+      const quality =
+        qualityPercent !== undefined ? qualityPercent / 100 : undefined;
 
       let exportCanvas: HTMLCanvasElement;
       if (canvases.length > 1) {
@@ -299,13 +425,27 @@ export function initEditor(): EditorHandle {
         exportCanvas = editor.canvas;
       }
 
-      const data =
-        quality !== undefined
-          ? exportCanvas.toDataURL(mime, quality)
-          : exportCanvas.toDataURL(mime);
+      const ensureDataUrl = (targetMime: string, targetQuality?: number) => {
+        return targetQuality !== undefined
+          ? exportCanvas.toDataURL(targetMime, targetQuality)
+          : exportCanvas.toDataURL(targetMime);
+      };
+
+      let data = ensureDataUrl(mime, quality);
+      if (!data.startsWith(`data:${mime}`)) {
+        const fallback = ensureDataUrl("image/png");
+        if (!fallbackFormat) {
+          throw new Error("PNG format is required for fallback");
+        }
+        data = fallback;
+        mime = fallbackFormat.mime;
+        extension = fallbackFormat.extension;
+        formatSelect.value = fallbackFormat.id;
+        updateFormatDependentControls();
+      }
       const a = document.createElement("a");
       a.href = data;
-      a.download = `canvas.${format === "jpeg" ? "jpg" : "png"}`;
+      a.download = `canvas.${extension}`;
       a.click();
     },
     listeners,

--- a/tests/bucketIntegration.test.ts
+++ b/tests/bucketIntegration.test.ts
@@ -7,6 +7,7 @@ describe("bucket tool integration", () => {
   let ctx: Partial<CanvasRenderingContext2D>;
 
   beforeEach(() => {
+    window.localStorage.clear();
     document.body.innerHTML = `
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
@@ -20,7 +21,18 @@ describe("bucket tool integration", () => {
       <button id="text"></button>
       <button id="bucket">Bucket</button>
       <button id="eyedropper"></button>
-      <select id="formatSelect"><option value="png">PNG</option></select>
+      <select id="formatSelect"></select>
+      <div id="jpegQualityGroup" hidden>
+        <input
+          id="jpegQuality"
+          type="range"
+          min="10"
+          max="100"
+          step="5"
+          value="90"
+        />
+        <output id="jpegQualityValue">90%</output>
+      </div>
       <button id="save"></button>
     `;
     canvas = document.getElementById("canvas") as HTMLCanvasElement;

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -8,6 +8,7 @@ describe("editor toolbar controls", () => {
   let handle: EditorHandle;
 
   beforeEach(() => {
+    window.localStorage.clear();
     document.body.innerHTML = `
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
@@ -21,7 +22,18 @@ describe("editor toolbar controls", () => {
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
-      <select id="formatSelect"><option value="png">PNG</option></select>
+      <select id="formatSelect"></select>
+      <div id="jpegQualityGroup" hidden>
+        <input
+          id="jpegQuality"
+          type="range"
+          min="10"
+          max="100"
+          step="5"
+          value="90"
+        />
+        <output id="jpegQualityValue">90%</output>
+      </div>
       <input id="imageLoader" type="file" />
       <button id="undo"></button>
       <button id="redo"></button>

--- a/tests/eyedropperTool.test.ts
+++ b/tests/eyedropperTool.test.ts
@@ -8,6 +8,7 @@ describe("EyedropperTool", () => {
   let ctx: Partial<CanvasRenderingContext2D>;
 
   beforeEach(() => {
+    window.localStorage.clear();
     document.body.innerHTML = `
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
@@ -91,6 +92,7 @@ describe("EyedropperTool color history", () => {
   let ctx: Partial<CanvasRenderingContext2D>;
 
   beforeEach(() => {
+    window.localStorage.clear();
     document.body.innerHTML = `
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
@@ -106,7 +108,18 @@ describe("EyedropperTool color history", () => {
       <button id="bucket"></button>
       <button id="eyedropper"></button>
 
-      <select id="formatSelect"><option value="png">PNG</option></select>
+      <select id="formatSelect"></select>
+      <div id="jpegQualityGroup" hidden>
+        <input
+          id="jpegQuality"
+          type="range"
+          min="10"
+          max="100"
+          step="5"
+          value="90"
+        />
+        <output id="jpegQualityValue">90%</output>
+      </div>
       <button id="save"></button>
       <div id="colorHistory"></div>
     `;

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -10,6 +10,7 @@ describe("image load and save", () => {
   let imageSpy: jest.SpyInstance;
 
   beforeEach(() => {
+    window.localStorage.clear();
     document.body.innerHTML = `
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
@@ -24,7 +25,18 @@ describe("image load and save", () => {
       <button id="bucket"></button>
       <button id="eyedropper"></button>
       <input id="imageLoader" type="file" />
-      <select id="formatSelect"><option value="png">PNG</option></select>
+      <select id="formatSelect"></select>
+      <div id="jpegQualityGroup" hidden>
+        <input
+          id="jpegQuality"
+          type="range"
+          min="10"
+          max="100"
+          step="5"
+          value="90"
+        />
+        <output id="jpegQualityValue">90%</output>
+      </div>
       <button id="save"></button>
     `;
 
@@ -59,9 +71,17 @@ describe("image load and save", () => {
     });
 
     anchor = { href: "", download: "", click: jest.fn() };
+    const originalCreateElement = document.createElement.bind(document);
     createElementSpy = jest
       .spyOn(document, "createElement")
-      .mockReturnValue(anchor as any);
+      .mockImplementation((
+        (tagName: string, options?: ElementCreationOptions) => {
+          if (tagName === "a") {
+            return anchor as unknown as HTMLElement;
+          }
+          return originalCreateElement(tagName, options);
+        }
+      ) as typeof document.createElement);
 
     class MockFileReader {
       result: string | ArrayBuffer | null = null;

--- a/tests/layers.test.ts
+++ b/tests/layers.test.ts
@@ -10,6 +10,7 @@ describe("layer-specific undo/redo", () => {
   let redoBtn: HTMLButtonElement;
 
   beforeEach(() => {
+    window.localStorage.clear();
     document.body.innerHTML = `
       <canvas id="c1"></canvas>
       <canvas id="c2"></canvas>
@@ -24,7 +25,18 @@ describe("layer-specific undo/redo", () => {
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
-      <select id="formatSelect"><option value="png">PNG</option></select>
+      <select id="formatSelect"></select>
+      <div id="jpegQualityGroup" hidden>
+        <input
+          id="jpegQuality"
+          type="range"
+          min="10"
+          max="100"
+          step="5"
+          value="90"
+        />
+        <output id="jpegQualityValue">90%</output>
+      </div>
       <button id="save"></button>
       <button id="undo"></button>
       <button id="redo"></button>

--- a/tests/opacity.test.ts
+++ b/tests/opacity.test.ts
@@ -4,6 +4,7 @@ describe("layer opacity", () => {
   let handle: EditorHandle;
 
   beforeEach(() => {
+    window.localStorage.clear();
     document.body.innerHTML = `
       <div id="canvasContainer">
         <canvas id="canvas"></canvas>
@@ -21,7 +22,18 @@ describe("layer opacity", () => {
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
-      <select id="formatSelect"><option value="png">PNG</option></select>
+      <select id="formatSelect"></select>
+      <div id="jpegQualityGroup" hidden>
+        <input
+          id="jpegQuality"
+          type="range"
+          min="10"
+          max="100"
+          step="5"
+          value="90"
+        />
+        <output id="jpegQualityValue">90%</output>
+      </div>
       <button id="save"></button>
     `;
 

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -2,6 +2,7 @@ import { initEditor } from "../src/editor.js";
 
 describe("save button", () => {
   it("calls toDataURL on click", () => {
+    window.localStorage.clear();
     document.body.innerHTML = `
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
@@ -15,7 +16,18 @@ describe("save button", () => {
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
-      <select id="formatSelect"><option value="png">PNG</option></select>
+      <select id="formatSelect"></select>
+      <div id="jpegQualityGroup" hidden>
+        <input
+          id="jpegQuality"
+          type="range"
+          min="10"
+          max="100"
+          step="5"
+          value="90"
+        />
+        <output id="jpegQualityValue">90%</output>
+      </div>
       <button id="save"></button>
     `;
 
@@ -37,8 +49,17 @@ describe("save button", () => {
 
     const click = jest.fn();
     const anchor = { href: "", download: "", click } as any;
-
-    jest.spyOn(document, "createElement").mockReturnValue(anchor);
+    const originalCreateElement = document.createElement.bind(document);
+    const createElementSpy = jest
+      .spyOn(document, "createElement")
+      .mockImplementation((
+        (tagName: string, options?: ElementCreationOptions) => {
+          if (tagName === "a") {
+            return anchor as unknown as HTMLElement;
+          }
+          return originalCreateElement(tagName, options);
+        }
+      ) as typeof document.createElement);
 
     const handle = initEditor();
 
@@ -47,9 +68,11 @@ describe("save button", () => {
     expect(click).toHaveBeenCalled();
 
     handle.destroy();
+    createElementSpy.mockRestore();
   });
 
   it("supports selecting jpeg format", () => {
+    window.localStorage.clear();
     document.body.innerHTML = `
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
@@ -63,7 +86,18 @@ describe("save button", () => {
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
-      <select id="formatSelect"><option value="png">PNG</option><option value="jpeg" selected>JPEG</option></select>
+      <select id="formatSelect"></select>
+      <div id="jpegQualityGroup" hidden>
+        <input
+          id="jpegQuality"
+          type="range"
+          min="10"
+          max="100"
+          step="5"
+          value="90"
+        />
+        <output id="jpegQualityValue">90%</output>
+      </div>
       <button id="save"></button>
     `;
 
@@ -85,9 +119,23 @@ describe("save button", () => {
 
     const click = jest.fn();
     const anchor = { href: "", download: "", click } as any;
-    jest.spyOn(document, "createElement").mockReturnValue(anchor);
+    const originalCreateElement = document.createElement.bind(document);
+    const createElementSpy = jest
+      .spyOn(document, "createElement")
+      .mockImplementation((
+        (tagName: string, options?: ElementCreationOptions) => {
+          if (tagName === "a") {
+            return anchor as unknown as HTMLElement;
+          }
+          return originalCreateElement(tagName, options);
+        }
+      ) as typeof document.createElement);
 
     const handle = initEditor();
+
+    const select = document.getElementById("formatSelect") as HTMLSelectElement;
+    select.value = "jpeg";
+    select.dispatchEvent(new Event("change"));
 
     (document.getElementById("save") as HTMLButtonElement).click();
     expect(canvas.toDataURL).toHaveBeenCalledWith("image/jpeg", 0.9);
@@ -95,5 +143,6 @@ describe("save button", () => {
     expect(click).toHaveBeenCalled();
 
     handle.destroy();
+    createElementSpy.mockRestore();
   });
 });

--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -1,0 +1,18 @@
+const originalToDataURL = HTMLCanvasElement.prototype.toDataURL;
+
+beforeAll(() => {
+  HTMLCanvasElement.prototype.toDataURL = function (
+    this: HTMLCanvasElement,
+    type?: string,
+  ): string {
+    const mime = typeof type === "string" ? type : "image/png";
+    if (mime === "image/webp" || mime === "image/avif") {
+      return "data:image/png;base64,MOCK";
+    }
+    return `data:${mime};base64,MOCK`;
+  };
+});
+
+afterAll(() => {
+  HTMLCanvasElement.prototype.toDataURL = originalToDataURL;
+});

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -16,6 +16,7 @@ describe("keyboard shortcuts", () => {
   let ctx: Partial<CanvasRenderingContext2D>;
 
   beforeEach(() => {
+    window.localStorage.clear();
     document.body.innerHTML = `
       <canvas id="canvas"></canvas>
       <input id="colorPicker" value="#000000" />
@@ -29,7 +30,18 @@ describe("keyboard shortcuts", () => {
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
-      <select id="formatSelect"><option value="png">PNG</option></select>
+      <select id="formatSelect"></select>
+      <div id="jpegQualityGroup" hidden>
+        <input
+          id="jpegQuality"
+          type="range"
+          min="10"
+          max="100"
+          step="5"
+          value="90"
+        />
+        <output id="jpegQualityValue">90%</output>
+      </div>
       <button id="save"></button>
     `;
     canvas = document.getElementById("canvas") as HTMLCanvasElement;

--- a/tests/toolbar.test.ts
+++ b/tests/toolbar.test.ts
@@ -13,6 +13,7 @@ describe("toolbar controls", () => {
   let ctx: Partial<CanvasRenderingContext2D>;
 
   beforeEach(() => {
+    window.localStorage.clear();
     document.body.innerHTML = `
       <canvas id="canvas"></canvas>
       <canvas id="canvas2"></canvas>
@@ -29,7 +30,18 @@ describe("toolbar controls", () => {
       <button id="eyedropper"></button>
       <button id="bucket"></button>
 
-      <select id="formatSelect"><option value="png">PNG</option></select>
+      <select id="formatSelect"></select>
+      <div id="jpegQualityGroup" hidden>
+        <input
+          id="jpegQuality"
+          type="range"
+          min="10"
+          max="100"
+          step="5"
+          value="90"
+        />
+        <output id="jpegQualityValue">90%</output>
+      </div>
       <button id="save"></button>
 
       <button id="undo"></button>


### PR DESCRIPTION
## Summary
- detect optional WebP and AVIF support at runtime and build the export format list accordingly
- add a persistent JPEG quality slider and update the export flow to honor the selected format with PNG fallback when unsupported
- refresh the test DOM fixtures and add a canvas data URL stub to cover the new controls

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60d2777448328a3148f22d9ca5af5