### PR TITLE
Add drag-and-drop image import support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A simple Photoshop-like web application built with HTML5 Canvas, CSS, and JavaSc
 - Bucket fill tool for coloring regions
 - Eyedropper tool for sampling colors
 - Image import/export
+- Drag-and-drop image import directly onto the canvas area
 - Multi-layer support
 
 
@@ -113,7 +114,9 @@ Execute the test suite:
 npm test
 ```
 
-Open `index.html` in your browser to use the app.
+Open `index.html` in your browser to use the app. You can import artwork by
+selecting a file with the toolbar input or by dragging an image file over the
+canvas area until the drop indicator appears.
 
 ## Deployment
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -313,30 +313,89 @@ export function initEditor(): EditorHandle {
 
   // image loading
   const imageLoader = document.getElementById("imageLoader") as HTMLInputElement | null;
+  const canvasContainer = document.getElementById(
+    "canvasContainer",
+  ) as HTMLDivElement | null;
+
+  const loadImageFile = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        editor.saveState();
+        editor.ctx.drawImage(
+          img,
+          0,
+          0,
+          editor.canvas.width,
+          editor.canvas.height,
+        );
+        updateHistoryButtons();
+        if (imageLoader) imageLoader.value = "";
+      };
+      img.src = reader.result as string;
+    };
+    reader.readAsDataURL(file);
+  };
+
   listen(
     imageLoader,
     "change",
     (e: Event) => {
       const file = (e.target as HTMLInputElement).files?.[0];
       if (!file) return;
-      const reader = new FileReader();
-      reader.onload = () => {
-        const img = new Image();
-        img.onload = () => {
-          editor.saveState();
-          editor.ctx.drawImage(
-            img,
-            0,
-            0,
-            editor.canvas.width,
-            editor.canvas.height,
-          );
-          updateHistoryButtons();
-          if (imageLoader) imageLoader.value = "";
-        };
-        img.src = reader.result as string;
-      };
-      reader.readAsDataURL(file);
+      loadImageFile(file);
+    },
+    listeners,
+  );
+
+  const setDragState = (active: boolean) => {
+    if (!canvasContainer) return;
+    canvasContainer.classList.toggle("drag-over", active);
+  };
+
+  listen<DragEvent>(
+    canvasContainer,
+    "dragenter",
+    (event) => {
+      event.preventDefault();
+      setDragState(true);
+    },
+    listeners,
+  );
+
+  listen<DragEvent>(
+    canvasContainer,
+    "dragover",
+    (event) => {
+      event.preventDefault();
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = "copy";
+      }
+      setDragState(true);
+    },
+    listeners,
+  );
+
+  listen<DragEvent>(
+    canvasContainer,
+    "dragleave",
+    () => {
+      setDragState(false);
+    },
+    listeners,
+  );
+
+  listen<DragEvent>(
+    canvasContainer,
+    "drop",
+    (event) => {
+      event.preventDefault();
+      setDragState(false);
+      const file = event.dataTransfer?.files?.[0];
+      if (file) {
+        loadImageFile(file);
+      }
     },
     listeners,
   );

--- a/style.css
+++ b/style.css
@@ -88,6 +88,11 @@ body {
   background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
 }
 
+#canvasContainer.drag-over {
+  outline: 4px solid #1e90ff;
+  outline-offset: -4px;
+}
+
 #canvasContainer canvas {
   position: absolute;
   top: 0;

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -11,7 +11,9 @@ describe("image load and save", () => {
 
   beforeEach(() => {
     document.body.innerHTML = `
-      <canvas id="canvas"></canvas>
+      <div id="canvasContainer">
+        <canvas id="canvas"></canvas>
+      </div>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
@@ -152,6 +154,49 @@ describe("image load and save", () => {
 
     await selectFile();
     expect(ctx.drawImage).toHaveBeenCalledTimes(2);
+  });
+
+  it("highlights the canvas container during drag interactions", () => {
+    const container = document.getElementById(
+      "canvasContainer",
+    ) as HTMLDivElement;
+
+    const dragEnter = new Event("dragenter", {
+      bubbles: true,
+      cancelable: true,
+    });
+    container.dispatchEvent(dragEnter);
+    expect(dragEnter.defaultPrevented).toBe(true);
+    expect(container.classList.contains("drag-over")).toBe(true);
+
+    const dragLeave = new Event("dragleave", { bubbles: true });
+    container.dispatchEvent(dragLeave);
+    expect(container.classList.contains("drag-over")).toBe(false);
+  });
+
+  it("imports an image when a file is dropped", async () => {
+    const container = document.getElementById(
+      "canvasContainer",
+    ) as HTMLDivElement;
+    const file = new File([""], "drop.png", { type: "image/png" });
+
+    const dropEvent = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(dropEvent, "dataTransfer", {
+      value: {
+        files: [file],
+        items: [],
+        types: ["Files"],
+        dropEffect: "",
+      },
+      configurable: true,
+    });
+
+    container.dispatchEvent(dropEvent);
+
+    expect(dropEvent.defaultPrevented).toBe(true);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(ctx.drawImage).toHaveBeenCalled();
+    expect(container.classList.contains("drag-over")).toBe(false);
   });
 
   it("saves the canvas as an image", () => {


### PR DESCRIPTION
## Summary
- add drag-and-drop listeners to the canvas container that reuse the existing import pipeline and provide visual feedback
- document the new drag-and-drop workflow and update canvas styles
- cover drag events with new Jest tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60d26a14083289ec87cf329569e5b