### PR TITLE
feat: lazy-load infrequent tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ For additional layers, opacity inputs with IDs like `layer2Opacity` control
 the transparency of each canvas; these are created automatically if absent.
 
 Call `initEditor()` only after the DOM has been populated with these elements;
-the function returns an {@link EditorHandle} with a `destroy` method for
-cleanup.
+the function returns an {@link EditorHandle} with helpers such as `loadTool`
+for preloading lazily bundled tools and a `destroy` method for cleanup.
 
 Layer selectors and opacity sliders are generated dynamically, enabling
 switching between layers and adjusting their transparency on the fly.

--- a/dist/core/Editor.js
+++ b/dist/core/Editor.js
@@ -1,26 +1,16 @@
 export class Editor {
+    canvas;
+    ctx;
+    undoStack = [];
+    redoStack = [];
+    currentTool = null;
+    colorPicker;
+    lineWidth;
+    fillMode;
+    fontFamily;
+    fontSize;
+    onChange;
     constructor(canvas, colorPicker, lineWidth, fillMode, onChange, fontFamily, fontSize) {
-        this.undoStack = [];
-        this.redoStack = [];
-        this.currentTool = null;
-        this.handlePointerDown = (e) => {
-            // Capture the pointer once before recording canvas state
-            this.canvas.setPointerCapture(e.pointerId);
-            this.saveState();
-            this.currentTool?.onPointerDown(e, this);
-        };
-        this.handlePointerMove = (e) => {
-            this.currentTool?.onPointerMove(e, this);
-        };
-        this.handlePointerUp = (e) => {
-            this.currentTool?.onPointerUp(e, this);
-            this.canvas.releasePointerCapture(e.pointerId);
-        };
-        this.handleResize = () => {
-            const data = this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height);
-            this.adjustForPixelRatio();
-            this.ctx.putImageData(data, 0, 0);
-        };
         this.canvas = canvas;
         const ctx = canvas.getContext("2d");
         if (!ctx)
@@ -43,6 +33,19 @@ export class Editor {
         this.currentTool = tool;
         this.canvas.style.cursor = tool.cursor || "crosshair";
     }
+    handlePointerDown = (e) => {
+        // Capture the pointer once before recording canvas state
+        this.canvas.setPointerCapture(e.pointerId);
+        this.saveState();
+        this.currentTool?.onPointerDown(e, this);
+    };
+    handlePointerMove = (e) => {
+        this.currentTool?.onPointerMove(e, this);
+    };
+    handlePointerUp = (e) => {
+        this.currentTool?.onPointerUp(e, this);
+        this.canvas.releasePointerCapture(e.pointerId);
+    };
     adjustForPixelRatio() {
         const dpr = window.devicePixelRatio || 1;
         const rect = this.canvas.getBoundingClientRect();
@@ -52,6 +55,11 @@ export class Editor {
         // Reset any existing transforms
         this.ctx.scale(1, 1);
     }
+    handleResize = () => {
+        const data = this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height);
+        this.adjustForPixelRatio();
+        this.ctx.putImageData(data, 0, 0);
+    };
     saveState() {
         this.undoStack.push(this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height));
         if (this.undoStack.length > 50)

--- a/dist/core/Shortcuts.js
+++ b/dist/core/Shortcuts.js
@@ -1,26 +1,34 @@
-import { PencilTool } from "../tools/PencilTool.js";
-import { RectangleTool } from "../tools/RectangleTool.js";
-import { LineTool } from "../tools/LineTool.js";
-import { CircleTool } from "../tools/CircleTool.js";
-import { TextTool } from "../tools/TextTool.js";
-import { EraserTool } from "../tools/EraserTool.js";
-import { BucketFillTool } from "../tools/BucketFillTool.js";
-import { EyedropperTool } from "../tools/EyedropperTool.js";
+const keyToToolId = {
+    p: "pencil",
+    r: "rectangle",
+    l: "line",
+    c: "circle",
+    e: "eraser",
+    t: "text",
+    b: "bucket",
+    i: "eyedropper",
+};
 /**
  * Keyboard shortcuts handler for the editor.
  * Maps specific key presses to tool changes or editor actions.
  */
 export class Shortcuts {
-    constructor(editor) {
+    handler;
+    editor;
+    loadTool;
+    constructor(editor, loadTool) {
         this.editor = editor;
-        this.handler = (e) => this.onKeyDown(e);
+        this.loadTool = loadTool;
+        this.handler = (e) => {
+            void this.onKeyDown(e);
+        };
         document.addEventListener("keydown", this.handler);
     }
     /** Swap the editor that receives subsequent shortcut actions. */
     switchEditor(newEditor) {
         this.editor = newEditor;
     }
-    onKeyDown(e) {
+    async onKeyDown(e) {
         if (e.ctrlKey || e.metaKey) {
             const key = e.key.toLowerCase();
             if (key === "z") {
@@ -38,39 +46,17 @@ export class Shortcuts {
             }
             return;
         }
-        switch (e.key.toLowerCase()) {
-            case "p":
-                e.preventDefault();
-                this.editor.setTool(new PencilTool());
-                break;
-            case "r":
-                e.preventDefault();
-                this.editor.setTool(new RectangleTool());
-                break;
-            case "l":
-                e.preventDefault();
-                this.editor.setTool(new LineTool());
-                break;
-            case "c":
-                e.preventDefault();
-                this.editor.setTool(new CircleTool());
-                break;
-            case "e":
-                e.preventDefault();
-                this.editor.setTool(new EraserTool());
-                break;
-            case "t":
-                e.preventDefault();
-                this.editor.setTool(new TextTool());
-                break;
-            case "b":
-                e.preventDefault();
-                this.editor.setTool(new BucketFillTool());
-                break;
-            case "i":
-                e.preventDefault();
-                this.editor.setTool(new EyedropperTool());
-                break;
+        const key = e.key.toLowerCase();
+        const toolId = keyToToolId[key];
+        if (toolId) {
+            e.preventDefault();
+            try {
+                const ToolCtor = await this.loadTool(toolId);
+                this.editor.setTool(new ToolCtor());
+            }
+            catch {
+                /* ignore failed dynamic import */
+            }
         }
     }
     /** Remove keyboard listeners. */

--- a/dist/editor.js
+++ b/dist/editor.js
@@ -5,9 +5,6 @@ import { EraserTool } from "./tools/EraserTool.js";
 import { RectangleTool } from "./tools/RectangleTool.js";
 import { LineTool } from "./tools/LineTool.js";
 import { CircleTool } from "./tools/CircleTool.js";
-import { TextTool } from "./tools/TextTool.js";
-import { BucketFillTool } from "./tools/BucketFillTool.js";
-import { EyedropperTool } from "./tools/EyedropperTool.js";
 /** Utility to listen to events and auto-remove on destroy. */
 function listen(el, type, handler, list) {
     if (!el)
@@ -22,29 +19,90 @@ function listen(el, type, handler, list) {
  */
 export function initEditor() {
     const canvases = Array.from(document.querySelectorAll("canvas"));
-    const toolConstructors = {
+    const eagerToolConstructors = {
         pencil: PencilTool,
         eraser: EraserTool,
         rectangle: RectangleTool,
         line: LineTool,
         circle: CircleTool,
-        text: TextTool,
-        bucket: BucketFillTool,
-        eyedropper: EyedropperTool,
+    };
+    const toolLoaders = {
+        pencil: async () => PencilTool,
+        eraser: async () => EraserTool,
+        rectangle: async () => RectangleTool,
+        line: async () => LineTool,
+        circle: async () => CircleTool,
+        text: async () => (await import("./tools/TextTool.js")).TextTool,
+        bucket: async () => (await import("./tools/BucketFillTool.js")).BucketFillTool,
+        eyedropper: async () => (await import("./tools/EyedropperTool.js")).EyedropperTool,
     };
     const toolButtons = {};
     const constructorToId = new Map();
     const editorToolConstructors = new Map();
+    const loadedToolConstructors = new Map();
+    const loadingToolConstructors = new Map();
     let activeToolCtor = PencilTool;
     let activeLayerIndex = 0;
-    Object.entries(toolConstructors).forEach(([id, Ctor]) => {
+    Object.entries(toolLoaders).forEach(([id]) => {
         const btn = document.getElementById(id);
         if (!btn) {
             throw new Error(`Missing #${id} button`);
         }
         toolButtons[id] = btn;
+        if (!(id in eagerToolConstructors)) {
+            btn.dataset.placeholder = btn.dataset.placeholder ?? "Loads on demand";
+        }
+    });
+    Object.entries(eagerToolConstructors).forEach(([id, Ctor]) => {
+        loadedToolConstructors.set(id, Ctor);
         constructorToId.set(Ctor, id);
     });
+    async function ensureToolLoaded(id) {
+        const cached = loadedToolConstructors.get(id);
+        if (cached) {
+            return cached;
+        }
+        const existingPromise = loadingToolConstructors.get(id);
+        if (existingPromise) {
+            return existingPromise;
+        }
+        const loader = toolLoaders[id];
+        if (!loader) {
+            throw new Error(`Unknown tool: ${id}`);
+        }
+        const btn = toolButtons[id];
+        const originalLabel = btn?.textContent ?? null;
+        if (btn) {
+            btn.disabled = true;
+            btn.dataset.loading = "true";
+            if (!btn.dataset.loadingText) {
+                btn.dataset.loadingText = "Loading...";
+            }
+            btn.textContent = btn.dataset.loadingText;
+        }
+        const promise = loader()
+            .then((Ctor) => {
+            loadedToolConstructors.set(id, Ctor);
+            constructorToId.set(Ctor, id);
+            return Ctor;
+        })
+            .catch((error) => {
+            loadingToolConstructors.delete(id);
+            throw error;
+        })
+            .finally(() => {
+            loadingToolConstructors.delete(id);
+            if (btn) {
+                btn.disabled = false;
+                btn.dataset.loading = "false";
+                if (originalLabel !== null) {
+                    btn.textContent = originalLabel;
+                }
+            }
+        });
+        loadingToolConstructors.set(id, promise);
+        return promise;
+    }
     let activeButton = null;
     const setActiveButton = (btn) => {
         if (activeButton)
@@ -54,12 +112,8 @@ export function initEditor() {
         activeButton = btn;
     };
     const buttonForTool = (tool) => {
-        for (const [id, ToolCtor] of Object.entries(toolConstructors)) {
-            if (tool instanceof ToolCtor) {
-                return toolButtons[id];
-            }
-        }
-        return null;
+        const id = constructorToId.get(tool.constructor);
+        return id ? toolButtons[id] ?? null : null;
     };
     const updateLayerInteractivity = () => {
         canvases.forEach((canvas, index) => {
@@ -193,9 +247,17 @@ export function initEditor() {
     editorToolConstructors.set(editor, PencilTool);
     updateLayerInteractivity();
     // keyboard shortcuts
-    const shortcuts = new Shortcuts(editor);
+    const shortcuts = new Shortcuts(editor, ensureToolLoaded);
     // map button id to tool constructor
-    Object.entries(toolConstructors).forEach(([id, ToolCtor]) => listen(toolButtons[id], "click", () => editor.setTool(new ToolCtor()), listeners));
+    Object.keys(toolLoaders).forEach((id) => listen(toolButtons[id], "click", async () => {
+        const cachedCtor = loadedToolConstructors.get(id);
+        if (cachedCtor) {
+            editor.setTool(new cachedCtor());
+            return;
+        }
+        const ToolCtor = await ensureToolLoaded(id);
+        editor.setTool(new ToolCtor());
+    }, listeners));
     listen(undoBtn, "click", () => {
         editor.undo();
         updateHistoryButtons();
@@ -289,6 +351,9 @@ export function initEditor() {
         editor,
         editors,
         activateLayer,
+        async loadTool(id) {
+            await ensureToolLoaded(id);
+        },
         destroy() {
             listeners.forEach((fn) => fn());
             shortcuts.destroy();

--- a/dist/tools/BucketFillTool.js
+++ b/dist/tools/BucketFillTool.js
@@ -3,6 +3,7 @@
  * Uses an iterative flood fill with typed-array backed queue to reduce memory churn.
  */
 export class BucketFillTool {
+    static MAX_FILL_PIXELS = 1_000_000;
     onPointerDown(e, editor) {
         const ctx = editor.ctx;
         const image = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
@@ -96,4 +97,3 @@ export class BucketFillTool {
         return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
     }
 }
-BucketFillTool.MAX_FILL_PIXELS = 1000000;

--- a/dist/tools/CircleTool.js
+++ b/dist/tools/CircleTool.js
@@ -1,11 +1,8 @@
 import { DrawingTool } from "./DrawingTool.js";
 export class CircleTool extends DrawingTool {
-    constructor() {
-        super(...arguments);
-        this.startX = 0;
-        this.startY = 0;
-        this.imageData = null;
-    }
+    startX = 0;
+    startY = 0;
+    imageData = null;
     onPointerDown(e, editor) {
         this.startX = e.offsetX;
         this.startY = e.offsetY;

--- a/dist/tools/EyedropperTool.js
+++ b/dist/tools/EyedropperTool.js
@@ -3,9 +3,7 @@
  * the editor's color picker to the sampled value.
  */
 export class EyedropperTool {
-    constructor() {
-        this.cursor = "crosshair";
-    }
+    cursor = "crosshair";
     onPointerDown(e, editor) {
         const { width, height } = editor.canvas;
         const dpr = window.devicePixelRatio || 1;

--- a/dist/tools/LineTool.js
+++ b/dist/tools/LineTool.js
@@ -1,11 +1,8 @@
 import { DrawingTool } from "./DrawingTool.js";
 export class LineTool extends DrawingTool {
-    constructor() {
-        super(...arguments);
-        this.startX = 0;
-        this.startY = 0;
-        this.imageData = null;
-    }
+    startX = 0;
+    startY = 0;
+    imageData = null;
     onPointerDown(e, editor) {
         const ctx = editor.ctx;
         this.startX = e.offsetX;

--- a/dist/tools/RectangleTool.js
+++ b/dist/tools/RectangleTool.js
@@ -1,11 +1,8 @@
 import { DrawingTool } from "./DrawingTool.js";
 export class RectangleTool extends DrawingTool {
-    constructor() {
-        super(...arguments);
-        this.startX = 0;
-        this.startY = 0;
-        this.imageData = null;
-    }
+    startX = 0;
+    startY = 0;
+    imageData = null;
     onPointerDown(e, editor) {
         this.startX = e.offsetX;
         this.startY = e.offsetY;

--- a/dist/tools/TextTool.js
+++ b/dist/tools/TextTool.js
@@ -1,9 +1,7 @@
 export class TextTool {
-    constructor() {
-        this.textarea = null;
-        this.blurListener = null;
-        this.keydownListener = null;
-    }
+    textarea = null;
+    blurListener = null;
+    keydownListener = null;
     onPointerDown(e, editor) {
         this.cleanup();
         const textarea = document.createElement("textarea");

--- a/src/core/Shortcuts.ts
+++ b/src/core/Shortcuts.ts
@@ -1,12 +1,18 @@
 import { Editor } from "./Editor.js";
-import { PencilTool } from "../tools/PencilTool.js";
-import { RectangleTool } from "../tools/RectangleTool.js";
-import { LineTool } from "../tools/LineTool.js";
-import { CircleTool } from "../tools/CircleTool.js";
-import { TextTool } from "../tools/TextTool.js";
-import { EraserTool } from "../tools/EraserTool.js";
-import { BucketFillTool } from "../tools/BucketFillTool.js";
-import { EyedropperTool } from "../tools/EyedropperTool.js";
+import type { Tool } from "../tools/Tool.js";
+
+type ToolLoader = (id: string) => Promise<new () => Tool>;
+
+const keyToToolId: Record<string, string> = {
+  p: "pencil",
+  r: "rectangle",
+  l: "line",
+  c: "circle",
+  e: "eraser",
+  t: "text",
+  b: "bucket",
+  i: "eyedropper",
+};
 
 
 /**
@@ -16,10 +22,14 @@ import { EyedropperTool } from "../tools/EyedropperTool.js";
 export class Shortcuts {
   private readonly handler: (e: KeyboardEvent) => void;
   private editor: Editor;
+  private readonly loadTool: ToolLoader;
 
-  constructor(editor: Editor) {
+  constructor(editor: Editor, loadTool: ToolLoader) {
     this.editor = editor;
-    this.handler = (e: KeyboardEvent) => this.onKeyDown(e);
+    this.loadTool = loadTool;
+    this.handler = (e: KeyboardEvent) => {
+      void this.onKeyDown(e);
+    };
     document.addEventListener("keydown", this.handler);
   }
 
@@ -28,8 +38,8 @@ export class Shortcuts {
     this.editor = newEditor;
   }
 
-  private onKeyDown(e: KeyboardEvent) {
-
+  private async onKeyDown(e: KeyboardEvent) {
+    
     if (e.ctrlKey || e.metaKey) {
       const key = e.key.toLowerCase();
       if (key === "z") {
@@ -46,39 +56,16 @@ export class Shortcuts {
       return;
     }
 
-    switch (e.key.toLowerCase()) {
-      case "p":
-        e.preventDefault();
-        this.editor.setTool(new PencilTool());
-        break;
-      case "r":
-        e.preventDefault();
-        this.editor.setTool(new RectangleTool());
-        break;
-      case "l":
-        e.preventDefault();
-        this.editor.setTool(new LineTool());
-        break;
-      case "c":
-        e.preventDefault();
-        this.editor.setTool(new CircleTool());
-        break;
-      case "e":
-        e.preventDefault();
-        this.editor.setTool(new EraserTool());
-        break;
-      case "t":
-        e.preventDefault();
-        this.editor.setTool(new TextTool());
-        break;
-      case "b":
-        e.preventDefault();
-        this.editor.setTool(new BucketFillTool());
-        break;
-      case "i":
-        e.preventDefault();
-        this.editor.setTool(new EyedropperTool());
-        break;
+    const key = e.key.toLowerCase();
+    const toolId = keyToToolId[key];
+    if (toolId) {
+      e.preventDefault();
+      try {
+        const ToolCtor = await this.loadTool(toolId);
+        this.editor.setTool(new ToolCtor());
+      } catch {
+        /* ignore failed dynamic import */
+      }
     }
   }
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -5,16 +5,13 @@ import { EraserTool } from "./tools/EraserTool.js";
 import { RectangleTool } from "./tools/RectangleTool.js";
 import { LineTool } from "./tools/LineTool.js";
 import { CircleTool } from "./tools/CircleTool.js";
-import { TextTool } from "./tools/TextTool.js";
-import { BucketFillTool } from "./tools/BucketFillTool.js";
-import { EyedropperTool } from "./tools/EyedropperTool.js";
 import type { Tool } from "./tools/Tool.js";
 
 /** Utility to listen to events and auto-remove on destroy. */
 function listen<T extends Event>(
   el: HTMLElement | null,
   type: string,
-  handler: (e: T) => void,
+  handler: (e: T) => void | Promise<void>,
   list: Array<() => void>,
 ) {
   if (!el) return;
@@ -23,10 +20,13 @@ function listen<T extends Event>(
   list.push(() => el.removeEventListener(type, wrapped));
 }
 
+type ToolCtor = new () => Tool;
+
 export interface EditorHandle {
   editor: Editor;
   editors: Editor[];
   activateLayer(index: number): void;
+  loadTool(id: string): Promise<void>;
   destroy(): void;
 }
 
@@ -39,30 +39,95 @@ export function initEditor(): EditorHandle {
     document.querySelectorAll<HTMLCanvasElement>("canvas"),
   );
 
-  const toolConstructors: Record<string, new () => Tool> = {
+  const eagerToolConstructors: Record<string, ToolCtor> = {
     pencil: PencilTool,
     eraser: EraserTool,
     rectangle: RectangleTool,
     line: LineTool,
     circle: CircleTool,
-    text: TextTool,
-    bucket: BucketFillTool,
-    eyedropper: EyedropperTool,
+  };
+
+  const toolLoaders: Record<string, () => Promise<ToolCtor>> = {
+    pencil: async () => PencilTool,
+    eraser: async () => EraserTool,
+    rectangle: async () => RectangleTool,
+    line: async () => LineTool,
+    circle: async () => CircleTool,
+    text: async () => (await import("./tools/TextTool.js")).TextTool,
+    bucket: async () => (await import("./tools/BucketFillTool.js")).BucketFillTool,
+    eyedropper: async () =>
+      (await import("./tools/EyedropperTool.js")).EyedropperTool,
   };
 
   const toolButtons: Record<string, HTMLButtonElement> = {};
-  const constructorToId = new Map<new () => Tool, string>();
-  const editorToolConstructors = new Map<Editor, new () => Tool>();
-  let activeToolCtor: new () => Tool = PencilTool;
+  const constructorToId = new Map<ToolCtor, string>();
+  const editorToolConstructors = new Map<Editor, ToolCtor>();
+  const loadedToolConstructors = new Map<string, ToolCtor>();
+  const loadingToolConstructors = new Map<string, Promise<ToolCtor>>();
+  let activeToolCtor: ToolCtor = PencilTool;
   let activeLayerIndex = 0;
-  Object.entries(toolConstructors).forEach(([id, Ctor]) => {
+  Object.entries(toolLoaders).forEach(([id]) => {
     const btn = document.getElementById(id) as HTMLButtonElement | null;
     if (!btn) {
       throw new Error(`Missing #${id} button`);
     }
     toolButtons[id] = btn;
+    if (!(id in eagerToolConstructors)) {
+      btn.dataset.placeholder = btn.dataset.placeholder ?? "Loads on demand";
+    }
+  });
+
+  Object.entries(eagerToolConstructors).forEach(([id, Ctor]) => {
+    loadedToolConstructors.set(id, Ctor);
     constructorToId.set(Ctor, id);
   });
+
+  async function ensureToolLoaded(id: string): Promise<ToolCtor> {
+    const cached = loadedToolConstructors.get(id);
+    if (cached) {
+      return cached;
+    }
+    const existingPromise = loadingToolConstructors.get(id);
+    if (existingPromise) {
+      return existingPromise;
+    }
+    const loader = toolLoaders[id];
+    if (!loader) {
+      throw new Error(`Unknown tool: ${id}`);
+    }
+    const btn = toolButtons[id];
+    const originalLabel = btn?.textContent ?? null;
+    if (btn) {
+      btn.disabled = true;
+      btn.dataset.loading = "true";
+      if (!btn.dataset.loadingText) {
+        btn.dataset.loadingText = "Loading...";
+      }
+      btn.textContent = btn.dataset.loadingText;
+    }
+    const promise = loader()
+      .then((Ctor) => {
+        loadedToolConstructors.set(id, Ctor);
+        constructorToId.set(Ctor, id);
+        return Ctor;
+      })
+      .catch((error) => {
+        loadingToolConstructors.delete(id);
+        throw error;
+      })
+      .finally(() => {
+        loadingToolConstructors.delete(id);
+        if (btn) {
+          btn.disabled = false;
+          btn.dataset.loading = "false";
+          if (originalLabel !== null) {
+            btn.textContent = originalLabel;
+          }
+        }
+      });
+    loadingToolConstructors.set(id, promise);
+    return promise;
+  }
 
   let activeButton: HTMLButtonElement | null = null;
   const setActiveButton = (btn: HTMLButtonElement | null) => {
@@ -71,12 +136,8 @@ export function initEditor(): EditorHandle {
     activeButton = btn;
   };
   const buttonForTool = (tool: Tool): HTMLButtonElement | null => {
-    for (const [id, ToolCtor] of Object.entries(toolConstructors)) {
-      if (tool instanceof ToolCtor) {
-        return toolButtons[id];
-      }
-    }
-    return null;
+    const id = constructorToId.get(tool.constructor as ToolCtor);
+    return id ? toolButtons[id] ?? null : null;
   };
 
   const updateLayerInteractivity = () => {
@@ -245,11 +306,19 @@ export function initEditor(): EditorHandle {
   updateLayerInteractivity();
 
   // keyboard shortcuts
-  const shortcuts = new Shortcuts(editor);
+  const shortcuts = new Shortcuts(editor, ensureToolLoaded);
 
   // map button id to tool constructor
-  Object.entries(toolConstructors).forEach(([id, ToolCtor]) =>
-    listen(toolButtons[id], "click", () => editor.setTool(new ToolCtor()), listeners),
+  Object.keys(toolLoaders).forEach((id) =>
+    listen(toolButtons[id], "click", async () => {
+      const cachedCtor = loadedToolConstructors.get(id);
+      if (cachedCtor) {
+        editor.setTool(new cachedCtor());
+        return;
+      }
+      const ToolCtor = await ensureToolLoaded(id);
+      editor.setTool(new ToolCtor());
+    }, listeners),
   );
 
   listen(
@@ -386,6 +455,9 @@ export function initEditor(): EditorHandle {
     editor,
     editors,
     activateLayer,
+    async loadTool(id: string) {
+      await ensureToolLoaded(id);
+    },
     destroy() {
       listeners.forEach((fn) => fn());
       shortcuts.destroy();

--- a/tests/bucketIntegration.test.ts
+++ b/tests/bucketIntegration.test.ts
@@ -53,15 +53,24 @@ describe("bucket tool integration", () => {
     handle.destroy();
   });
 
-  it("activates bucket tool from toolbar", () => {
+  const flushPromises = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+
+  it("activates bucket tool from toolbar", async () => {
     const spy = jest.spyOn(handle.editor, "setTool");
+    await handle.loadTool("bucket");
     (document.getElementById("bucket") as HTMLButtonElement).click();
+    await flushPromises();
     expect(spy.mock.calls[0][0]).toBeInstanceOf(BucketFillTool);
   });
 
-  it("activates bucket tool via shortcut", () => {
+  it("activates bucket tool via shortcut", async () => {
     const spy = jest.spyOn(handle.editor, "setTool");
+    await handle.loadTool("bucket");
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "b" }));
+    await flushPromises();
     expect(spy.mock.calls[0][0]).toBeInstanceOf(BucketFillTool);
   });
 });

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -152,8 +152,15 @@ describe("editor toolbar controls", () => {
     expect(ctx.ellipse).toHaveBeenCalled();
   });
 
-  it("writes text with text tool", () => {
+  const flushPromises = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+
+  it("writes text with text tool", async () => {
+    await handle.loadTool("text");
     (document.getElementById("text") as HTMLButtonElement).click();
+    await flushPromises();
     dispatch("pointerdown", 10, 10, 1);
     const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
     textarea.value = "hi";

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -61,27 +61,39 @@ describe("keyboard shortcuts", () => {
     handle.destroy();
   });
 
-  it("switches tools with letter keys", () => {
+  const flushPromises = async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  };
+
+  it("switches tools with letter keys", async () => {
     const spy = jest.spyOn(handle.editor, "setTool");
-    const cases: [string, any][] = [
-      ["r", RectangleTool],
-      ["p", PencilTool],
-      ["e", EraserTool],
-      ["i", EyedropperTool],
-      ["l", LineTool],
-      ["c", CircleTool],
-      ["t", TextTool],
-      ["b", BucketFillTool],
+    const cases: Array<[string, any, string]> = [
+      ["r", RectangleTool, "rectangle"],
+      ["p", PencilTool, "pencil"],
+      ["e", EraserTool, "eraser"],
+      ["i", EyedropperTool, "eyedropper"],
+      ["l", LineTool, "line"],
+      ["c", CircleTool, "circle"],
+      ["t", TextTool, "text"],
+      ["b", BucketFillTool, "bucket"],
     ];
 
-    cases.forEach(([key, ToolClass], index) => {
+    const lazyToolIds = new Set(["text", "bucket", "eyedropper"]);
+
+    for (const [key, ToolClass, toolId] of cases) {
+      if (lazyToolIds.has(toolId)) {
+        await handle.loadTool(toolId);
+      }
       const event = new KeyboardEvent("keydown", { key, cancelable: true });
       const prevent = jest.spyOn(event, "preventDefault");
       document.dispatchEvent(event);
-      expect(spy.mock.calls[index][0]).toBeInstanceOf(ToolClass);
+      await flushPromises();
+      const lastCall = spy.mock.calls[spy.mock.calls.length - 1];
+      expect(lastCall?.[0]).toBeInstanceOf(ToolClass);
       expect(prevent).toHaveBeenCalled();
       expect(event.defaultPrevented).toBe(true);
-    });
+    }
   });
 
   it("performs undo and redo with shortcuts", () => {
@@ -127,7 +139,7 @@ describe("keyboard shortcuts", () => {
     expect(redoEventCmdShiftZ.defaultPrevented).toBe(true);
   });
 
-  it("switches active editor when requested", () => {
+  it("switches active editor when requested", async () => {
     const e1 = {
       setTool: jest.fn(),
       undo: jest.fn(),
@@ -139,12 +151,14 @@ describe("keyboard shortcuts", () => {
       redo: jest.fn(),
     } as unknown as Editor;
 
-    const shortcuts = new Shortcuts(e1);
+    const shortcuts = new Shortcuts(e1, async () => PencilTool);
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "p" }));
+    await flushPromises();
     expect(e1.setTool).toHaveBeenCalled();
 
     shortcuts.switchEditor(e2);
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "p" }));
+    await flushPromises();
     expect(e2.setTool).toHaveBeenCalled();
     shortcuts.destroy();
   });

--- a/tests/toolbar.test.ts
+++ b/tests/toolbar.test.ts
@@ -63,8 +63,6 @@ describe("toolbar controls", () => {
         toJSON: () => {},
       });
     });
-
-
     handle = initEditor();
   });
 
@@ -77,45 +75,47 @@ describe("toolbar controls", () => {
     expect(select.options.length).toBe(2);
   });
 
-    it("switches tools when buttons are clicked", () => {
-      const spy = jest.spyOn(handle.editor, "setTool");
-      (document.getElementById("pencil") as HTMLButtonElement).click();
-      expect(spy.mock.calls[0][0]).toBeInstanceOf(PencilTool);
+  it("switches tools when buttons are clicked", async () => {
+    const spy = jest.spyOn(handle.editor, "setTool");
+    (document.getElementById("pencil") as HTMLButtonElement).click();
+    expect(spy.mock.calls[0][0]).toBeInstanceOf(PencilTool);
 
-      (document.getElementById("eraser") as HTMLButtonElement).click();
-      expect(spy.mock.calls[1][0]).toBeInstanceOf(EraserTool);
+    (document.getElementById("eraser") as HTMLButtonElement).click();
+    expect(spy.mock.calls[1][0]).toBeInstanceOf(EraserTool);
 
-      (document.getElementById("rectangle") as HTMLButtonElement).click();
-      expect(spy.mock.calls[2][0]).toBeInstanceOf(RectangleTool);
+    (document.getElementById("rectangle") as HTMLButtonElement).click();
+    expect(spy.mock.calls[2][0]).toBeInstanceOf(RectangleTool);
 
-      (document.getElementById("line") as HTMLButtonElement).click();
-      expect(spy.mock.calls[3][0]).toBeInstanceOf(LineTool);
+    (document.getElementById("line") as HTMLButtonElement).click();
+    expect(spy.mock.calls[3][0]).toBeInstanceOf(LineTool);
 
-      (document.getElementById("circle") as HTMLButtonElement).click();
-      expect(spy.mock.calls[4][0]).toBeInstanceOf(CircleTool);
+    (document.getElementById("circle") as HTMLButtonElement).click();
+    expect(spy.mock.calls[4][0]).toBeInstanceOf(CircleTool);
 
-      (document.getElementById("text") as HTMLButtonElement).click();
-      expect(spy.mock.calls[5][0]).toBeInstanceOf(TextTool);
+    await handle.loadTool("text");
+    (document.getElementById("text") as HTMLButtonElement).click();
+    expect(spy.mock.calls[5][0]).toBeInstanceOf(TextTool);
 
-      (document.getElementById("eyedropper") as HTMLButtonElement).click();
-      expect(spy.mock.calls[6][0]).toBeInstanceOf(EyedropperTool);
-    });
+    await handle.loadTool("eyedropper");
+    (document.getElementById("eyedropper") as HTMLButtonElement).click();
+    expect(spy.mock.calls[6][0]).toBeInstanceOf(EyedropperTool);
+  });
 
-    it("routes tool changes to the selected layer", () => {
-      const firstSpy = jest.spyOn(handle.editors[0], "setTool");
-      const secondSpy = jest.spyOn(handle.editors[1], "setTool");
+  it("routes tool changes to the selected layer", () => {
+    const firstSpy = jest.spyOn(handle.editors[0], "setTool");
+    const secondSpy = jest.spyOn(handle.editors[1], "setTool");
 
-      (document.getElementById("pencil") as HTMLButtonElement).click();
-      expect(firstSpy).toHaveBeenCalled();
-      expect(secondSpy).not.toHaveBeenCalled();
+    (document.getElementById("pencil") as HTMLButtonElement).click();
+    expect(firstSpy).toHaveBeenCalled();
+    expect(secondSpy).not.toHaveBeenCalled();
 
-      const select = document.getElementById("layerSelect") as HTMLSelectElement;
-      select.value = "1";
-      select.dispatchEvent(new Event("change"));
+    const select = document.getElementById("layerSelect") as HTMLSelectElement;
+    select.value = "1";
+    select.dispatchEvent(new Event("change"));
 
-      (document.getElementById("eraser") as HTMLButtonElement).click();
-      expect(secondSpy).toHaveBeenCalled();
-    });
+    (document.getElementById("eraser") as HTMLButtonElement).click();
+    expect(secondSpy).toHaveBeenCalled();
+  });
 
   it("triggers undo and redo when buttons are clicked", () => {
     const undo = jest.spyOn(handle.editor, "undo").mockImplementation(() => {});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ES2020",
+    "target": "ES2022",
+    "module": "ES2022",
     "moduleResolution": "bundler",
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
## Summary
- lazily import text, bucket fill, and eyedropper tools when activated and expose a loadTool helper
- update shortcuts and UI buttons to support on-demand loading with placeholders and modern bundling output
- refresh TypeScript build targets and tests to await dynamic tool setup

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60d2549f483288aaebfe6d012571a