### PR TITLE
Add profiling instrumentation and HUD overlay

### DIFF
--- a/dist/core/Editor.js
+++ b/dist/core/Editor.js
@@ -1,20 +1,47 @@
+import { profiler } from "./Profiler.js";
 export class Editor {
     constructor(canvas, colorPicker, lineWidth, fillMode, onChange, fontFamily, fontSize) {
         this.undoStack = [];
         this.redoStack = [];
         this.currentTool = null;
+        this.activeStrokeToken = null;
         this.handlePointerDown = (e) => {
             // Capture the pointer once before recording canvas state
             this.canvas.setPointerCapture(e.pointerId);
             this.saveState();
-            this.currentTool?.onPointerDown(e, this);
+            if (this.activeStrokeToken) {
+                this.finishStroke();
+            }
+            this.activeStrokeToken = profiler.begin("stroke");
+            try {
+                this.currentTool?.onPointerDown(e, this);
+            }
+            catch (error) {
+                this.finishStroke();
+                this.canvas.releasePointerCapture(e.pointerId);
+                throw error;
+            }
         };
         this.handlePointerMove = (e) => {
             this.currentTool?.onPointerMove(e, this);
         };
         this.handlePointerUp = (e) => {
-            this.currentTool?.onPointerUp(e, this);
-            this.canvas.releasePointerCapture(e.pointerId);
+            try {
+                this.currentTool?.onPointerUp(e, this);
+            }
+            finally {
+                this.finishStroke();
+                this.canvas.releasePointerCapture(e.pointerId);
+            }
+        };
+        this.handlePointerCancel = (e) => {
+            try {
+                this.currentTool?.onPointerUp(e, this);
+            }
+            finally {
+                this.finishStroke();
+                this.canvas.releasePointerCapture(e.pointerId);
+            }
         };
         this.handleResize = () => {
             const data = this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height);
@@ -37,6 +64,7 @@ export class Editor {
         this.canvas.addEventListener("pointerdown", this.handlePointerDown);
         this.canvas.addEventListener("pointermove", this.handlePointerMove);
         this.canvas.addEventListener("pointerup", this.handlePointerUp);
+        this.canvas.addEventListener("pointercancel", this.handlePointerCancel);
     }
     setTool(tool) {
         this.currentTool?.destroy?.();
@@ -108,5 +136,12 @@ export class Editor {
         this.canvas.removeEventListener("pointerdown", this.handlePointerDown);
         this.canvas.removeEventListener("pointermove", this.handlePointerMove);
         this.canvas.removeEventListener("pointerup", this.handlePointerUp);
+        this.canvas.removeEventListener("pointercancel", this.handlePointerCancel);
+    }
+    finishStroke() {
+        if (!this.activeStrokeToken)
+            return;
+        profiler.end(this.activeStrokeToken);
+        this.activeStrokeToken = null;
     }
 }

--- a/dist/core/Profiler.js
+++ b/dist/core/Profiler.js
@@ -1,0 +1,152 @@
+const MAX_TIMINGS = 6;
+class Profiler {
+    constructor() {
+        this.enabled = false;
+        this.overlay = null;
+        this.timings = [];
+        this.counter = 0;
+        this.active = new Map();
+        this.rafHandle = null;
+        this.fps = 0;
+        this.lastFpsSample = 0;
+        this.frameCount = 0;
+    }
+    initialize() {
+        if (this.overlay)
+            return;
+        const overlay = document.createElement("div");
+        overlay.className = "profiling-hud";
+        overlay.setAttribute("aria-live", "polite");
+        overlay.style.display = "none";
+        document.body.appendChild(overlay);
+        this.overlay = overlay;
+    }
+    setEnabled(enabled) {
+        if (this.enabled === enabled)
+            return;
+        this.enabled = enabled;
+        if (this.overlay) {
+            this.overlay.style.display = enabled ? "block" : "none";
+            if (!enabled) {
+                this.overlay.innerHTML = "";
+            }
+        }
+        this.timings = [];
+        this.resetFps();
+        if (enabled) {
+            this.startFpsLoop();
+            this.render();
+        }
+        else {
+            this.stopFpsLoop();
+        }
+    }
+    isEnabled() {
+        return this.enabled;
+    }
+    begin(name) {
+        if (!this.enabled || typeof performance === "undefined") {
+            return null;
+        }
+        const id = `${name}-${++this.counter}`;
+        const startMark = `${id}-start`;
+        this.active.set(id, { name, startMark });
+        performance.mark(startMark);
+        return id;
+    }
+    end(token) {
+        if (!token || !this.enabled || typeof performance === "undefined") {
+            return;
+        }
+        const data = this.active.get(token);
+        if (!data)
+            return;
+        const endMark = `${token}-end`;
+        const measureName = `${token}-measure`;
+        performance.mark(endMark);
+        const measure = performance.measure(measureName, data.startMark, endMark);
+        this.recordTiming(data.name, measure.duration);
+        performance.clearMarks(data.startMark);
+        performance.clearMarks(endMark);
+        performance.clearMeasures(measureName);
+        this.active.delete(token);
+    }
+    run(name, fn) {
+        const token = this.begin(name);
+        try {
+            return fn();
+        }
+        finally {
+            this.end(token);
+        }
+    }
+    recordTiming(name, duration) {
+        if (!this.enabled)
+            return;
+        this.timings.unshift({ name, duration, timestamp: performance.now() });
+        if (this.timings.length > MAX_TIMINGS) {
+            this.timings.length = MAX_TIMINGS;
+        }
+        this.render();
+    }
+    render() {
+        if (!this.enabled || !this.overlay)
+            return;
+        const labels = {
+            stroke: "Stroke",
+            fill: "Fill",
+            export: "Export",
+        };
+        const lines = this.timings
+            .map((entry) => {
+            const age = Math.max(0, performance.now() - entry.timestamp);
+            const secondsAgo = (age / 1000).toFixed(1);
+            const duration = entry.duration.toFixed(1);
+            const label = labels[entry.name];
+            return `<li><span>${label}</span><span>${duration}ms</span><span>${secondsAgo}s ago</span></li>`;
+        })
+            .join("");
+        this.overlay.innerHTML = `
+      <div class="profiling-hud__header">
+        <span>FPS: ${this.fps.toFixed(1)}</span>
+        <span>Profiling On</span>
+      </div>
+      <ul class="profiling-hud__list">${lines || "<li>No timings yet</li>"}</ul>
+    `;
+    }
+    startFpsLoop() {
+        if (this.rafHandle !== null)
+            return;
+        const tick = (time) => {
+            if (!this.enabled) {
+                this.stopFpsLoop();
+                return;
+            }
+            this.frameCount += 1;
+            if (!this.lastFpsSample) {
+                this.lastFpsSample = time;
+            }
+            const elapsed = time - this.lastFpsSample;
+            if (elapsed >= 1000) {
+                this.fps = (this.frameCount * 1000) / elapsed;
+                this.frameCount = 0;
+                this.lastFpsSample = time;
+                this.render();
+            }
+            this.rafHandle = window.requestAnimationFrame(tick);
+        };
+        this.rafHandle = window.requestAnimationFrame(tick);
+    }
+    stopFpsLoop() {
+        if (this.rafHandle !== null) {
+            window.cancelAnimationFrame(this.rafHandle);
+            this.rafHandle = null;
+        }
+    }
+    resetFps() {
+        this.fps = 0;
+        this.lastFpsSample = 0;
+        this.frameCount = 0;
+    }
+}
+export const profiler = new Profiler();

--- a/dist/editor.js
+++ b/dist/editor.js
@@ -1,5 +1,6 @@
 import { Editor } from "./core/Editor.js";
 import { Shortcuts } from "./core/Shortcuts.js";
+import { profiler } from "./core/Profiler.js";
 import { PencilTool } from "./tools/PencilTool.js";
 import { EraserTool } from "./tools/EraserTool.js";
 import { RectangleTool } from "./tools/RectangleTool.js";
@@ -21,6 +22,7 @@ function listen(el, type, handler, list) {
  * {@link EditorHandle} that allows tests or callers to tear down the editor.
  */
 export function initEditor() {
+    profiler.initialize();
     const canvases = Array.from(document.querySelectorAll("canvas"));
     const toolConstructors = {
         pencil: PencilTool,
@@ -76,6 +78,7 @@ export function initEditor() {
     const saveBtn = document.getElementById("save");
     const formatSelect = document.getElementById("formatSelect");
     const colorHistory = document.getElementById("colorHistory");
+    const profilingToggle = document.getElementById("profilingToggle");
     if (!colorPicker) {
         throw new Error("Missing #colorPicker input");
     }
@@ -123,6 +126,15 @@ export function initEditor() {
     const undoBtn = document.getElementById("undo");
     const redoBtn = document.getElementById("redo");
     const listeners = [];
+    if (profilingToggle) {
+        profiler.setEnabled(profilingToggle.checked);
+        listen(profilingToggle, "input", () => {
+            profiler.setEnabled(profilingToggle.checked);
+        }, listeners);
+    }
+    else {
+        profiler.setEnabled(false);
+    }
     const recentColors = [];
     const maxRecentColors = 10;
     const renderColorHistory = () => {
@@ -206,33 +218,35 @@ export function initEditor() {
     }, listeners);
     // saving
     listen(saveBtn, "click", () => {
-        const format = formatSelect.value.toLowerCase() === "jpeg" ? "jpeg" : "png";
-        const mime = format === "jpeg" ? "image/jpeg" : "image/png";
-        const quality = format === "jpeg" ? 0.9 : undefined;
-        let exportCanvas;
-        if (canvases.length > 1) {
-            // composite all layers respecting their opacity
-            exportCanvas = document.createElement("canvas");
-            exportCanvas.width = canvases[0].width;
-            exportCanvas.height = canvases[0].height;
-            const tempCtx = exportCanvas.getContext("2d");
-            canvases.forEach((cv) => {
-                const opacity = parseFloat(cv.style.opacity) || 1;
-                tempCtx.globalAlpha = opacity;
-                tempCtx.drawImage(cv, 0, 0);
-            });
-            tempCtx.globalAlpha = 1;
-        }
-        else {
-            exportCanvas = editor.canvas;
-        }
-        const data = quality !== undefined
-            ? exportCanvas.toDataURL(mime, quality)
-            : exportCanvas.toDataURL(mime);
-        const a = document.createElement("a");
-        a.href = data;
-        a.download = `canvas.${format === "jpeg" ? "jpg" : "png"}`;
-        a.click();
+        profiler.run("export", () => {
+            const format = formatSelect.value.toLowerCase() === "jpeg" ? "jpeg" : "png";
+            const mime = format === "jpeg" ? "image/jpeg" : "image/png";
+            const quality = format === "jpeg" ? 0.9 : undefined;
+            let exportCanvas;
+            if (canvases.length > 1) {
+                // composite all layers respecting their opacity
+                exportCanvas = document.createElement("canvas");
+                exportCanvas.width = canvases[0].width;
+                exportCanvas.height = canvases[0].height;
+                const tempCtx = exportCanvas.getContext("2d");
+                canvases.forEach((cv) => {
+                    const opacity = parseFloat(cv.style.opacity) || 1;
+                    tempCtx.globalAlpha = opacity;
+                    tempCtx.drawImage(cv, 0, 0);
+                });
+                tempCtx.globalAlpha = 1;
+            }
+            else {
+                exportCanvas = editor.canvas;
+            }
+            const data = quality !== undefined
+                ? exportCanvas.toDataURL(mime, quality)
+                : exportCanvas.toDataURL(mime);
+            const a = document.createElement("a");
+            a.href = data;
+            a.download = `canvas.${format === "jpeg" ? "jpg" : "png"}`;
+            a.click();
+        });
     }, listeners);
     // image loading
     const imageLoader = document.getElementById("imageLoader");
@@ -293,6 +307,7 @@ export function initEditor() {
             listeners.forEach((fn) => fn());
             shortcuts.destroy();
             editors.forEach((e) => e.destroy());
+            profiler.setEnabled(false);
         },
     };
     recordColor(colorPicker.value);

--- a/dist/tools/BucketFillTool.js
+++ b/dist/tools/BucketFillTool.js
@@ -1,83 +1,86 @@
+import { profiler } from "../core/Profiler.js";
 /**
  * Tool that fills a contiguous region of pixels with the current fill color.
  * Uses an iterative flood fill with typed-array backed queue to reduce memory churn.
  */
 export class BucketFillTool {
     onPointerDown(e, editor) {
-        const ctx = editor.ctx;
-        const image = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
-        const { width, height, data } = image;
-        const pixelCount = width * height;
-        if (pixelCount > BucketFillTool.MAX_FILL_PIXELS) {
-            console.warn("Bucket fill aborted: area too large");
-            return;
-        }
-        const dpr = window.devicePixelRatio || 1;
-        const sx = Math.max(0, Math.min(width - 1, Math.floor(e.offsetX * dpr)));
-        const sy = Math.max(0, Math.min(height - 1, Math.floor(e.offsetY * dpr)));
-        const start = sy * width + sx;
-        const targetOffset = start * 4;
-        const tr = data[targetOffset];
-        const tg = data[targetOffset + 1];
-        const tb = data[targetOffset + 2];
-        const [fr, fg, fb] = this.hexToRgb(editor.fillStyle);
-        // if target already the fill color, nothing to do
-        if (tr === fr && tg === fg && tb === fb)
-            return;
-        const queue = new Uint32Array(pixelCount);
-        const visited = new Uint8Array(pixelCount);
-        let head = 0;
-        let tail = 0;
-        let processed = 0;
-        queue[tail++] = start;
-        visited[start] = 1;
-        while (head < tail) {
-            const idx = queue[head++];
-            const offset = idx * 4;
-            if (data[offset] !== tr || data[offset + 1] !== tg || data[offset + 2] !== tb) {
-                continue;
+        profiler.run("fill", () => {
+            const ctx = editor.ctx;
+            const image = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
+            const { width, height, data } = image;
+            const pixelCount = width * height;
+            if (pixelCount > BucketFillTool.MAX_FILL_PIXELS) {
+                console.warn("Bucket fill aborted: area too large");
+                return;
             }
-            data[offset] = fr;
-            data[offset + 1] = fg;
-            data[offset + 2] = fb;
-            data[offset + 3] = 255;
-            processed++;
-            if (processed > BucketFillTool.MAX_FILL_PIXELS) {
-                console.warn("Bucket fill aborted: exceeded pixel limit");
-                break;
-            }
-            const x = idx % width;
-            const y = (idx / width) | 0;
-            if (x > 0) {
-                const n = idx - 1;
-                if (!visited[n]) {
-                    queue[tail++] = n;
-                    visited[n] = 1;
+            const dpr = window.devicePixelRatio || 1;
+            const sx = Math.max(0, Math.min(width - 1, Math.floor(e.offsetX * dpr)));
+            const sy = Math.max(0, Math.min(height - 1, Math.floor(e.offsetY * dpr)));
+            const start = sy * width + sx;
+            const targetOffset = start * 4;
+            const tr = data[targetOffset];
+            const tg = data[targetOffset + 1];
+            const tb = data[targetOffset + 2];
+            const [fr, fg, fb] = this.hexToRgb(editor.fillStyle);
+            // if target already the fill color, nothing to do
+            if (tr === fr && tg === fg && tb === fb)
+                return;
+            const queue = new Uint32Array(pixelCount);
+            const visited = new Uint8Array(pixelCount);
+            let head = 0;
+            let tail = 0;
+            let processed = 0;
+            queue[tail++] = start;
+            visited[start] = 1;
+            while (head < tail) {
+                const idx = queue[head++];
+                const offset = idx * 4;
+                if (data[offset] !== tr || data[offset + 1] !== tg || data[offset + 2] !== tb) {
+                    continue;
+                }
+                data[offset] = fr;
+                data[offset + 1] = fg;
+                data[offset + 2] = fb;
+                data[offset + 3] = 255;
+                processed++;
+                if (processed > BucketFillTool.MAX_FILL_PIXELS) {
+                    console.warn("Bucket fill aborted: exceeded pixel limit");
+                    break;
+                }
+                const x = idx % width;
+                const y = (idx / width) | 0;
+                if (x > 0) {
+                    const n = idx - 1;
+                    if (!visited[n]) {
+                        queue[tail++] = n;
+                        visited[n] = 1;
+                    }
+                }
+                if (x < width - 1) {
+                    const n = idx + 1;
+                    if (!visited[n]) {
+                        queue[tail++] = n;
+                        visited[n] = 1;
+                    }
+                }
+                if (y > 0) {
+                    const n = idx - width;
+                    if (!visited[n]) {
+                        queue[tail++] = n;
+                        visited[n] = 1;
+                    }
+                }
+                if (y < height - 1) {
+                    const n = idx + width;
+                    if (!visited[n]) {
+                        queue[tail++] = n;
+                        visited[n] = 1;
+                    }
                 }
             }
-            if (x < width - 1) {
-                const n = idx + 1;
-                if (!visited[n]) {
-                    queue[tail++] = n;
-                    visited[n] = 1;
-                }
-            }
-            if (y > 0) {
-                const n = idx - width;
-                if (!visited[n]) {
-                    queue[tail++] = n;
-                    visited[n] = 1;
-                }
-            }
-            if (y < height - 1) {
-                const n = idx + width;
-                if (!visited[n]) {
-                    queue[tail++] = n;
-                    visited[n] = 1;
-                }
-            }
-        }
-        ctx.putImageData(image, 0, 0);
+            ctx.putImageData(image, 0, 0);
+        });
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     onPointerMove(_e, _editor) {

--- a/index.html
+++ b/index.html
@@ -21,6 +21,10 @@
         <input type="checkbox" id="fillMode" />
         Fill
       </label>
+      <label class="toggle">
+        <input type="checkbox" id="profilingToggle" />
+        Profiling
+      </label>
       <button id="pencil" class="tool-button" title="Pencil">
         <img src="icons/pencil.svg" alt="Pencil" />
       </button>

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -1,4 +1,5 @@
 import { Tool } from "../tools/Tool.js";
+import { profiler } from "./Profiler.js";
 
 export class Editor {
   canvas: HTMLCanvasElement;
@@ -12,6 +13,7 @@ export class Editor {
   fontFamily: HTMLSelectElement | null;
   fontSize: HTMLInputElement | null;
   private onChange?: () => void;
+  private activeStrokeToken: string | null = null;
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -38,6 +40,7 @@ export class Editor {
     this.canvas.addEventListener("pointerdown", this.handlePointerDown);
     this.canvas.addEventListener("pointermove", this.handlePointerMove);
     this.canvas.addEventListener("pointerup", this.handlePointerUp);
+    this.canvas.addEventListener("pointercancel", this.handlePointerCancel);
   }
 
   setTool(tool: Tool) {
@@ -50,7 +53,17 @@ export class Editor {
     // Capture the pointer once before recording canvas state
     this.canvas.setPointerCapture(e.pointerId);
     this.saveState();
-    this.currentTool?.onPointerDown(e, this);
+    if (this.activeStrokeToken) {
+      this.finishStroke();
+    }
+    this.activeStrokeToken = profiler.begin("stroke");
+    try {
+      this.currentTool?.onPointerDown(e, this);
+    } catch (error) {
+      this.finishStroke();
+      this.canvas.releasePointerCapture(e.pointerId);
+      throw error;
+    }
   };
 
   private handlePointerMove = (e: PointerEvent) => {
@@ -58,8 +71,21 @@ export class Editor {
   };
 
   private handlePointerUp = (e: PointerEvent) => {
-    this.currentTool?.onPointerUp(e, this);
-    this.canvas.releasePointerCapture(e.pointerId);
+    try {
+      this.currentTool?.onPointerUp(e, this);
+    } finally {
+      this.finishStroke();
+      this.canvas.releasePointerCapture(e.pointerId);
+    }
+  };
+
+  private handlePointerCancel = (e: PointerEvent) => {
+    try {
+      this.currentTool?.onPointerUp(e, this);
+    } finally {
+      this.finishStroke();
+      this.canvas.releasePointerCapture(e.pointerId);
+    }
   };
 
   private adjustForPixelRatio() {
@@ -153,5 +179,12 @@ export class Editor {
     this.canvas.removeEventListener("pointerdown", this.handlePointerDown);
     this.canvas.removeEventListener("pointermove", this.handlePointerMove);
     this.canvas.removeEventListener("pointerup", this.handlePointerUp);
+    this.canvas.removeEventListener("pointercancel", this.handlePointerCancel);
+  }
+
+  private finishStroke() {
+    if (!this.activeStrokeToken) return;
+    profiler.end(this.activeStrokeToken);
+    this.activeStrokeToken = null;
   }
 }

--- a/src/core/Profiler.ts
+++ b/src/core/Profiler.ts
@@ -1,0 +1,164 @@
+type ProfilingEvent = "stroke" | "fill" | "export";
+
+interface TimingEntry {
+  name: ProfilingEvent;
+  duration: number;
+  timestamp: number;
+}
+
+const MAX_TIMINGS = 6;
+
+class Profiler {
+  private enabled = false;
+  private overlay: HTMLDivElement | null = null;
+  private timings: TimingEntry[] = [];
+  private counter = 0;
+  private active = new Map<string, { name: ProfilingEvent; startMark: string }>();
+  private rafHandle: number | null = null;
+  private fps = 0;
+  private lastFpsSample = 0;
+  private frameCount = 0;
+
+  initialize(): void {
+    if (this.overlay) return;
+    const overlay = document.createElement("div");
+    overlay.className = "profiling-hud";
+    overlay.setAttribute("aria-live", "polite");
+    overlay.style.display = "none";
+    document.body.appendChild(overlay);
+    this.overlay = overlay;
+  }
+
+  setEnabled(enabled: boolean): void {
+    if (this.enabled === enabled) return;
+    this.enabled = enabled;
+    if (this.overlay) {
+      this.overlay.style.display = enabled ? "block" : "none";
+      if (!enabled) {
+        this.overlay.innerHTML = "";
+      }
+    }
+    this.timings = [];
+    this.resetFps();
+    if (enabled) {
+      this.startFpsLoop();
+      this.render();
+    } else {
+      this.stopFpsLoop();
+    }
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  begin(name: ProfilingEvent): string | null {
+    if (!this.enabled || typeof performance === "undefined") {
+      return null;
+    }
+    const id = `${name}-${++this.counter}`;
+    const startMark = `${id}-start`;
+    this.active.set(id, { name, startMark });
+    performance.mark(startMark);
+    return id;
+  }
+
+  end(token: string | null): void {
+    if (!token || !this.enabled || typeof performance === "undefined") {
+      return;
+    }
+    const data = this.active.get(token);
+    if (!data) return;
+    const endMark = `${token}-end`;
+    const measureName = `${token}-measure`;
+    performance.mark(endMark);
+    const measure = performance.measure(measureName, data.startMark, endMark);
+    this.recordTiming(data.name, measure.duration);
+    performance.clearMarks(data.startMark);
+    performance.clearMarks(endMark);
+    performance.clearMeasures(measureName);
+    this.active.delete(token);
+  }
+
+  run<T>(name: ProfilingEvent, fn: () => T): T {
+    const token = this.begin(name);
+    try {
+      return fn();
+    } finally {
+      this.end(token);
+    }
+  }
+
+  private recordTiming(name: ProfilingEvent, duration: number): void {
+    if (!this.enabled) return;
+    this.timings.unshift({ name, duration, timestamp: performance.now() });
+    if (this.timings.length > MAX_TIMINGS) {
+      this.timings.length = MAX_TIMINGS;
+    }
+    this.render();
+  }
+
+  private render(): void {
+    if (!this.enabled || !this.overlay) return;
+    const labels: Record<ProfilingEvent, string> = {
+      stroke: "Stroke",
+      fill: "Fill",
+      export: "Export",
+    };
+    const lines = this.timings
+      .map((entry) => {
+        const age = Math.max(0, performance.now() - entry.timestamp);
+        const secondsAgo = (age / 1000).toFixed(1);
+        const duration = entry.duration.toFixed(1);
+        const label = labels[entry.name];
+        return `<li><span>${label}</span><span>${duration}ms</span><span>${secondsAgo}s ago</span></li>`;
+      })
+      .join("");
+    this.overlay.innerHTML = `
+      <div class="profiling-hud__header">
+        <span>FPS: ${this.fps.toFixed(1)}</span>
+        <span>Profiling On</span>
+      </div>
+      <ul class="profiling-hud__list">${lines || "<li>No timings yet</li>"}</ul>
+    `;
+  }
+
+  private startFpsLoop(): void {
+    if (this.rafHandle !== null) return;
+    const tick = (time: number) => {
+      if (!this.enabled) {
+        this.stopFpsLoop();
+        return;
+      }
+      this.frameCount += 1;
+      if (!this.lastFpsSample) {
+        this.lastFpsSample = time;
+      }
+      const elapsed = time - this.lastFpsSample;
+      if (elapsed >= 1000) {
+        this.fps = (this.frameCount * 1000) / elapsed;
+        this.frameCount = 0;
+        this.lastFpsSample = time;
+        this.render();
+      }
+      this.rafHandle = window.requestAnimationFrame(tick);
+    };
+    this.rafHandle = window.requestAnimationFrame(tick);
+  }
+
+  private stopFpsLoop(): void {
+    if (this.rafHandle !== null) {
+      window.cancelAnimationFrame(this.rafHandle);
+      this.rafHandle = null;
+    }
+  }
+
+  private resetFps(): void {
+    this.fps = 0;
+    this.lastFpsSample = 0;
+    this.frameCount = 0;
+  }
+}
+
+export const profiler = new Profiler();
+export type { ProfilingEvent };

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,5 +1,6 @@
 import { Editor } from "./core/Editor.js";
 import { Shortcuts } from "./core/Shortcuts.js";
+import { profiler } from "./core/Profiler.js";
 import { PencilTool } from "./tools/PencilTool.js";
 import { EraserTool } from "./tools/EraserTool.js";
 import { RectangleTool } from "./tools/RectangleTool.js";
@@ -35,6 +36,7 @@ export interface EditorHandle {
  * {@link EditorHandle} that allows tests or callers to tear down the editor.
  */
 export function initEditor(): EditorHandle {
+  profiler.initialize();
   const canvases = Array.from(
     document.querySelectorAll<HTMLCanvasElement>("canvas"),
   );
@@ -99,6 +101,8 @@ export function initEditor(): EditorHandle {
   const colorHistory = document.getElementById(
     "colorHistory",
   ) as HTMLDivElement | null;
+  const profilingToggle =
+    document.getElementById("profilingToggle") as HTMLInputElement | null;
 
   if (!colorPicker) {
     throw new Error("Missing #colorPicker input");
@@ -155,6 +159,20 @@ export function initEditor(): EditorHandle {
   const undoBtn = document.getElementById("undo") as HTMLButtonElement | null;
   const redoBtn = document.getElementById("redo") as HTMLButtonElement | null;
   const listeners: Array<() => void> = [];
+
+  if (profilingToggle) {
+    profiler.setEnabled(profilingToggle.checked);
+    listen(
+      profilingToggle,
+      "input",
+      () => {
+        profiler.setEnabled(profilingToggle.checked);
+      },
+      listeners,
+    );
+  } else {
+    profiler.setEnabled(false);
+  }
 
   const recentColors: string[] = [];
   const maxRecentColors = 10;
@@ -277,36 +295,38 @@ export function initEditor(): EditorHandle {
     saveBtn,
     "click",
     () => {
-      const format =
-        formatSelect.value.toLowerCase() === "jpeg" ? "jpeg" : "png";
-      const mime = format === "jpeg" ? "image/jpeg" : "image/png";
-      const quality = format === "jpeg" ? 0.9 : undefined;
+      profiler.run("export", () => {
+        const format =
+          formatSelect.value.toLowerCase() === "jpeg" ? "jpeg" : "png";
+        const mime = format === "jpeg" ? "image/jpeg" : "image/png";
+        const quality = format === "jpeg" ? 0.9 : undefined;
 
-      let exportCanvas: HTMLCanvasElement;
-      if (canvases.length > 1) {
-        // composite all layers respecting their opacity
-        exportCanvas = document.createElement("canvas");
-        exportCanvas.width = canvases[0].width;
-        exportCanvas.height = canvases[0].height;
-        const tempCtx = exportCanvas.getContext("2d")!;
-        canvases.forEach((cv) => {
-          const opacity = parseFloat(cv.style.opacity) || 1;
-          tempCtx.globalAlpha = opacity;
-          tempCtx.drawImage(cv, 0, 0);
-        });
-        tempCtx.globalAlpha = 1;
-      } else {
-        exportCanvas = editor.canvas;
-      }
+        let exportCanvas: HTMLCanvasElement;
+        if (canvases.length > 1) {
+          // composite all layers respecting their opacity
+          exportCanvas = document.createElement("canvas");
+          exportCanvas.width = canvases[0].width;
+          exportCanvas.height = canvases[0].height;
+          const tempCtx = exportCanvas.getContext("2d")!;
+          canvases.forEach((cv) => {
+            const opacity = parseFloat(cv.style.opacity) || 1;
+            tempCtx.globalAlpha = opacity;
+            tempCtx.drawImage(cv, 0, 0);
+          });
+          tempCtx.globalAlpha = 1;
+        } else {
+          exportCanvas = editor.canvas;
+        }
 
-      const data =
-        quality !== undefined
-          ? exportCanvas.toDataURL(mime, quality)
-          : exportCanvas.toDataURL(mime);
-      const a = document.createElement("a");
-      a.href = data;
-      a.download = `canvas.${format === "jpeg" ? "jpg" : "png"}`;
-      a.click();
+        const data =
+          quality !== undefined
+            ? exportCanvas.toDataURL(mime, quality)
+            : exportCanvas.toDataURL(mime);
+        const a = document.createElement("a");
+        a.href = data;
+        a.download = `canvas.${format === "jpeg" ? "jpg" : "png"}`;
+        a.click();
+      });
     },
     listeners,
   );
@@ -390,6 +410,7 @@ export function initEditor(): EditorHandle {
       listeners.forEach((fn) => fn());
       shortcuts.destroy();
       editors.forEach((e) => e.destroy());
+      profiler.setEnabled(false);
     },
   };
   recordColor(colorPicker.value);

--- a/src/tools/BucketFillTool.ts
+++ b/src/tools/BucketFillTool.ts
@@ -1,4 +1,5 @@
 import { Editor } from "../core/Editor.js";
+import { profiler } from "../core/Profiler.js";
 import { Tool } from "./Tool.js";
 
 /**
@@ -9,89 +10,91 @@ export class BucketFillTool implements Tool {
   private static readonly MAX_FILL_PIXELS = 1_000_000;
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
-    const ctx = editor.ctx;
-    const image = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
-    const { width, height, data } = image;
+    profiler.run("fill", () => {
+      const ctx = editor.ctx;
+      const image = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
+      const { width, height, data } = image;
 
-    const pixelCount = width * height;
-    if (pixelCount > BucketFillTool.MAX_FILL_PIXELS) {
-      console.warn("Bucket fill aborted: area too large");
-      return;
-    }
-
-    const dpr = window.devicePixelRatio || 1;
-    const sx = Math.max(0, Math.min(width - 1, Math.floor(e.offsetX * dpr)));
-    const sy = Math.max(0, Math.min(height - 1, Math.floor(e.offsetY * dpr)));
-    const start = sy * width + sx;
-    const targetOffset = start * 4;
-    const tr = data[targetOffset];
-    const tg = data[targetOffset + 1];
-    const tb = data[targetOffset + 2];
-
-    const [fr, fg, fb] = this.hexToRgb(editor.fillStyle);
-
-    // if target already the fill color, nothing to do
-    if (tr === fr && tg === fg && tb === fb) return;
-
-    const queue = new Uint32Array(pixelCount);
-    const visited = new Uint8Array(pixelCount);
-    let head = 0;
-    let tail = 0;
-    let processed = 0;
-
-    queue[tail++] = start;
-    visited[start] = 1;
-
-    while (head < tail) {
-      const idx = queue[head++];
-      const offset = idx * 4;
-      if (data[offset] !== tr || data[offset + 1] !== tg || data[offset + 2] !== tb) {
-        continue;
+      const pixelCount = width * height;
+      if (pixelCount > BucketFillTool.MAX_FILL_PIXELS) {
+        console.warn("Bucket fill aborted: area too large");
+        return;
       }
 
-      data[offset] = fr;
-      data[offset + 1] = fg;
-      data[offset + 2] = fb;
-      data[offset + 3] = 255;
-      processed++;
-      if (processed > BucketFillTool.MAX_FILL_PIXELS) {
-        console.warn("Bucket fill aborted: exceeded pixel limit");
-        break;
-      }
+      const dpr = window.devicePixelRatio || 1;
+      const sx = Math.max(0, Math.min(width - 1, Math.floor(e.offsetX * dpr)));
+      const sy = Math.max(0, Math.min(height - 1, Math.floor(e.offsetY * dpr)));
+      const start = sy * width + sx;
+      const targetOffset = start * 4;
+      const tr = data[targetOffset];
+      const tg = data[targetOffset + 1];
+      const tb = data[targetOffset + 2];
 
-      const x = idx % width;
-      const y = (idx / width) | 0;
+      const [fr, fg, fb] = this.hexToRgb(editor.fillStyle);
 
-      if (x > 0) {
-        const n = idx - 1;
-        if (!visited[n]) {
-          queue[tail++] = n;
-          visited[n] = 1;
+      // if target already the fill color, nothing to do
+      if (tr === fr && tg === fg && tb === fb) return;
+
+      const queue = new Uint32Array(pixelCount);
+      const visited = new Uint8Array(pixelCount);
+      let head = 0;
+      let tail = 0;
+      let processed = 0;
+
+      queue[tail++] = start;
+      visited[start] = 1;
+
+      while (head < tail) {
+        const idx = queue[head++];
+        const offset = idx * 4;
+        if (data[offset] !== tr || data[offset + 1] !== tg || data[offset + 2] !== tb) {
+          continue;
+        }
+
+        data[offset] = fr;
+        data[offset + 1] = fg;
+        data[offset + 2] = fb;
+        data[offset + 3] = 255;
+        processed++;
+        if (processed > BucketFillTool.MAX_FILL_PIXELS) {
+          console.warn("Bucket fill aborted: exceeded pixel limit");
+          break;
+        }
+
+        const x = idx % width;
+        const y = (idx / width) | 0;
+
+        if (x > 0) {
+          const n = idx - 1;
+          if (!visited[n]) {
+            queue[tail++] = n;
+            visited[n] = 1;
+          }
+        }
+        if (x < width - 1) {
+          const n = idx + 1;
+          if (!visited[n]) {
+            queue[tail++] = n;
+            visited[n] = 1;
+          }
+        }
+        if (y > 0) {
+          const n = idx - width;
+          if (!visited[n]) {
+            queue[tail++] = n;
+            visited[n] = 1;
+          }
+        }
+        if (y < height - 1) {
+          const n = idx + width;
+          if (!visited[n]) {
+            queue[tail++] = n;
+            visited[n] = 1;
+          }
         }
       }
-      if (x < width - 1) {
-        const n = idx + 1;
-        if (!visited[n]) {
-          queue[tail++] = n;
-          visited[n] = 1;
-        }
-      }
-      if (y > 0) {
-        const n = idx - width;
-        if (!visited[n]) {
-          queue[tail++] = n;
-          visited[n] = 1;
-        }
-      }
-      if (y < height - 1) {
-        const n = idx + width;
-        if (!visited[n]) {
-          queue[tail++] = n;
-          visited[n] = 1;
-        }
-      }
-    }
-    ctx.putImageData(image, 0, 0);
+      ctx.putImageData(image, 0, 0);
+    });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/style.css
+++ b/style.css
@@ -99,4 +99,54 @@ body {
   box-sizing: border-box;
 }
 
+#toolbar label.toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+}
+
+.profiling-hud {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  background: rgba(18, 18, 18, 0.88);
+  color: #fff;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 12px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  pointer-events: none;
+  z-index: 1000;
+  min-width: 180px;
+}
+
+.profiling-hud__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.profiling-hud__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.profiling-hud__list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.profiling-hud__list li span:last-child {
+  opacity: 0.7;
+}
+
 


### PR DESCRIPTION
## Summary
- add a browser profiler utility that records Performance API measures and renders a HUD overlay with FPS and recent timings
- integrate profiling controls into the editor, including a toolbar toggle, stroke/export instrumentation, and bucket fill timing
- style the profiling HUD and expose the new profiling toggle in the toolbar markup

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d60d2490a88328a712d7494a947a7c