### PR TITLE
Use createImageBitmap for image loading

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -313,30 +313,50 @@ export function initEditor(): EditorHandle {
 
   // image loading
   const imageLoader = document.getElementById("imageLoader") as HTMLInputElement | null;
-  listen(
-    imageLoader,
-    "change",
-    (e: Event) => {
-      const file = (e.target as HTMLInputElement).files?.[0];
-      if (!file) return;
+  const loadImageFromFile = async (file: File): Promise<CanvasImageSource> => {
+    if (typeof window.createImageBitmap === "function") {
+      try {
+        return await window.createImageBitmap(file);
+      } catch (error) {
+        console.warn("createImageBitmap failed, falling back to Image", error);
+      }
+    }
+
+    return await new Promise<HTMLImageElement>((resolve, reject) => {
       const reader = new FileReader();
+      reader.onerror = () => reject(reader.error);
       reader.onload = () => {
         const img = new Image();
-        img.onload = () => {
-          editor.saveState();
-          editor.ctx.drawImage(
-            img,
-            0,
-            0,
-            editor.canvas.width,
-            editor.canvas.height,
-          );
-          updateHistoryButtons();
-          if (imageLoader) imageLoader.value = "";
-        };
+        img.onload = () => resolve(img);
+        img.onerror = reject;
         img.src = reader.result as string;
       };
       reader.readAsDataURL(file);
+    });
+  };
+
+  listen(
+    imageLoader,
+    "change",
+    async (e: Event) => {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (!file) return;
+      try {
+        const img = await loadImageFromFile(file);
+        editor.saveState();
+        editor.ctx.drawImage(
+          img,
+          0,
+          0,
+          editor.canvas.width,
+          editor.canvas.height,
+        );
+        updateHistoryButtons();
+      } catch (error) {
+        console.error("Failed to load image", error);
+      } finally {
+        if (imageLoader) imageLoader.value = "";
+      }
     },
     listeners,
   );

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -6,8 +6,13 @@ describe("image load and save", () => {
   let handle: EditorHandle;
   let anchor: { href: string; download: string; click: jest.Mock };
   let createElementSpy: jest.SpyInstance;
-  let fileReaderSpy: jest.SpyInstance;
-  let imageSpy: jest.SpyInstance;
+  let createImageBitmapMock: jest.Mock;
+  let originalCreateImageBitmap: typeof window.createImageBitmap | undefined;
+  let mockBitmap: ImageBitmap;
+  let fileReaderSpy: jest.SpyInstance | undefined;
+  let imageSpy: jest.SpyInstance | undefined;
+
+  const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -63,27 +68,14 @@ describe("image load and save", () => {
       .spyOn(document, "createElement")
       .mockReturnValue(anchor as any);
 
-    class MockFileReader {
-      result: string | ArrayBuffer | null = null;
-      onload: () => void = () => {};
-      readAsDataURL(_file: Blob) {
-        this.result = "data:image/png;base64,LOAD";
-        this.onload();
-      }
-    }
-    fileReaderSpy = jest
-      .spyOn(window as any, "FileReader")
-      .mockImplementation(() => new MockFileReader() as any);
-
-    class MockImage {
-      onload: () => void = () => {};
-      set src(_src: string) {
-        setTimeout(() => this.onload(), 0);
-      }
-    }
-    imageSpy = jest
-      .spyOn(window as any, "Image")
-      .mockImplementation(() => new MockImage() as any);
+    mockBitmap = { width: 200, height: 100 } as unknown as ImageBitmap;
+    createImageBitmapMock = jest.fn(async () => mockBitmap);
+    originalCreateImageBitmap = window.createImageBitmap;
+    Object.defineProperty(window, "createImageBitmap", {
+      configurable: true,
+      writable: true,
+      value: createImageBitmapMock,
+    });
 
     handle = initEditor();
   });
@@ -91,8 +83,13 @@ describe("image load and save", () => {
   afterEach(() => {
     handle.destroy();
     createElementSpy.mockRestore();
-    fileReaderSpy.mockRestore();
-    imageSpy.mockRestore();
+    fileReaderSpy?.mockRestore();
+    imageSpy?.mockRestore();
+    if (originalCreateImageBitmap) {
+      window.createImageBitmap = originalCreateImageBitmap;
+    } else {
+      delete (window as any).createImageBitmap;
+    }
   });
 
   it("loads an image from input", async () => {
@@ -103,8 +100,15 @@ describe("image load and save", () => {
       configurable: true,
     });
     loader.dispatchEvent(new Event("change"));
-    await new Promise((r) => setTimeout(r, 0));
-    expect(ctx.drawImage).toHaveBeenCalled();
+    await flushPromises();
+    expect(createImageBitmapMock).toHaveBeenCalledWith(file);
+    expect(ctx.drawImage).toHaveBeenCalledWith(
+      mockBitmap,
+      0,
+      0,
+      canvas.width,
+      canvas.height,
+    );
   });
 
   it("adds state to undo stack when loading image", async () => {
@@ -115,7 +119,7 @@ describe("image load and save", () => {
       configurable: true,
     });
     loader.dispatchEvent(new Event("change"));
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
     expect(handle.editor.canUndo).toBe(true);
     handle.editor.undo();
     expect(ctx.putImageData).toHaveBeenCalled();
@@ -140,7 +144,7 @@ describe("image load and save", () => {
       });
       if (loader.value !== prev) {
         loader.dispatchEvent(new Event("change"));
-        await new Promise((r) => setTimeout(r, 0));
+        await flushPromises();
       }
     };
 
@@ -152,6 +156,51 @@ describe("image load and save", () => {
 
     await selectFile();
     expect(ctx.drawImage).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to FileReader when createImageBitmap is unavailable", async () => {
+    delete (window as any).createImageBitmap;
+
+    class MockFileReader {
+      result: string | ArrayBuffer | null = null;
+      onload: () => void = () => {};
+      readAsDataURL(_file: Blob) {
+        this.result = "data:image/png;base64,LOAD";
+        this.onload();
+      }
+    }
+    fileReaderSpy = jest
+      .spyOn(window as any, "FileReader")
+      .mockImplementation(() => new MockFileReader() as any);
+
+    class MockImage {
+      onload: () => void = () => {};
+      set src(_src: string) {
+        setTimeout(() => this.onload(), 0);
+      }
+    }
+    imageSpy = jest
+      .spyOn(window as any, "Image")
+      .mockImplementation(() => new MockImage() as any);
+
+    const file = new File([""], "test.png", { type: "image/png" });
+    const loader = document.getElementById("imageLoader") as HTMLInputElement;
+    Object.defineProperty(loader, "files", {
+      value: [file],
+      configurable: true,
+    });
+    loader.dispatchEvent(new Event("change"));
+    await flushPromises();
+    await flushPromises();
+    expect(fileReaderSpy).toHaveBeenCalled();
+    expect(imageSpy).toHaveBeenCalled();
+    expect(ctx.drawImage).toHaveBeenCalledWith(
+      expect.any(Object),
+      0,
+      0,
+      canvas.width,
+      canvas.height,
+    );
   });
 
   it("saves the canvas as an image", () => {


### PR DESCRIPTION
## Summary
- load dropped images with createImageBitmap when available and keep the FileReader/Image fallback
- reset the file input after drawing and surface errors without breaking history updates
- refresh image tests to mock createImageBitmap, cover the fallback path, and verify draw dimensions

## Testing
- npm test -- image

------
https://chatgpt.com/codex/tasks/task_e_68d60d22aa0c832881e04a45c4b77901