### PR TITLE
Optimize shape preview dirty regions

### DIFF
--- a/src/core/DirtyRegionTracker.ts
+++ b/src/core/DirtyRegionTracker.ts
@@ -1,0 +1,103 @@
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface Bounds {
+  width: number;
+  height: number;
+}
+
+function rectanglesOverlap(a: Rect, b: Rect): boolean {
+  return (
+    a.x < b.x + b.width &&
+    a.x + a.width > b.x &&
+    a.y < b.y + b.height &&
+    a.y + a.height > b.y
+  );
+}
+
+function mergeRectangles(rectangles: Rect[]): Rect[] {
+  const merged: Rect[] = [];
+  for (const rect of rectangles) {
+    if (rect.width <= 0 || rect.height <= 0) continue;
+    let current = { ...rect };
+    for (let i = 0; i < merged.length; ) {
+      const candidate = merged[i];
+      if (rectanglesOverlap(candidate, current)) {
+        current = {
+          x: Math.min(candidate.x, current.x),
+          y: Math.min(candidate.y, current.y),
+          width:
+            Math.max(candidate.x + candidate.width, current.x + current.width) -
+            Math.min(candidate.x, current.x),
+          height:
+            Math.max(candidate.y + candidate.height, current.y + current.height) -
+            Math.min(candidate.y, current.y),
+        };
+        merged.splice(i, 1);
+      } else {
+        i += 1;
+      }
+    }
+    merged.push(current);
+  }
+  return merged;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function clipRect(rect: Rect, bounds: Bounds): Rect | null {
+  const maxX = rect.x + rect.width;
+  const maxY = rect.y + rect.height;
+  const clippedX = clamp(rect.x, 0, bounds.width);
+  const clippedY = clamp(rect.y, 0, bounds.height);
+  const clippedMaxX = clamp(maxX, 0, bounds.width);
+  const clippedMaxY = clamp(maxY, 0, bounds.height);
+  const width = clippedMaxX - clippedX;
+  const height = clippedMaxY - clippedY;
+  if (width <= 0 || height <= 0) {
+    return null;
+  }
+  return {
+    x: Math.floor(clippedX),
+    y: Math.floor(clippedY),
+    width: Math.ceil(width),
+    height: Math.ceil(height),
+  };
+}
+
+export function expandRectForStroke(
+  rect: Rect,
+  lineWidth: number,
+  bounds: Bounds,
+): Rect | null {
+  const padding = Math.ceil(lineWidth / 2);
+  const expanded: Rect = {
+    x: Math.floor(rect.x - padding),
+    y: Math.floor(rect.y - padding),
+    width: Math.ceil(rect.width + padding * 2),
+    height: Math.ceil(rect.height + padding * 2),
+  };
+  return clipRect(expanded, bounds);
+}
+
+export class DirtyRegionTracker {
+  private regions: Rect[] = [];
+
+  clear(): void {
+    this.regions = [];
+  }
+
+  setRegions(rectangles: Rect[]): void {
+    this.regions = mergeRectangles(rectangles);
+  }
+
+  getRegions(): readonly Rect[] {
+    return this.regions;
+  }
+}

--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -1,3 +1,8 @@
+import {
+  DirtyRegionTracker,
+  clipRect,
+  expandRectForStroke,
+} from "../core/DirtyRegionTracker.js";
 import { Editor } from "../core/Editor.js";
 import { DrawingTool } from "./DrawingTool.js";
 
@@ -5,6 +10,46 @@ export class CircleTool extends DrawingTool {
   private startX = 0;
   private startY = 0;
   private imageData: ImageData | null = null;
+  private dirtyRegions = new DirtyRegionTracker();
+
+  private restoreDirtyRegions(ctx: CanvasRenderingContext2D, editor: Editor) {
+    if (!this.imageData) return;
+    const bounds = {
+      width: editor.canvas.width,
+      height: editor.canvas.height,
+    };
+    for (const region of this.dirtyRegions.getRegions()) {
+      const clipped = clipRect(region, bounds);
+      if (!clipped) continue;
+      ctx.putImageData(
+        this.imageData,
+        0,
+        0,
+        clipped.x,
+        clipped.y,
+        clipped.width,
+        clipped.height,
+      );
+    }
+  }
+
+  private updateDirtyRegion(
+    radiusX: number,
+    radiusY: number,
+    editor: Editor,
+  ): void {
+    const rect = {
+      x: this.startX - radiusX,
+      y: this.startY - radiusY,
+      width: radiusX * 2,
+      height: radiusY * 2,
+    };
+    const dirty = expandRectForStroke(rect, editor.lineWidthValue, {
+      width: editor.canvas.width,
+      height: editor.canvas.height,
+    });
+    this.dirtyRegions.setRegions(dirty ? [dirty] : []);
+  }
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
     this.startX = e.offsetX;
@@ -16,12 +61,13 @@ export class CircleTool extends DrawingTool {
     } else {
       this.imageData = null;
     }
+    this.dirtyRegions.clear();
   }
 
   onPointerMove(e: PointerEvent, editor: Editor): void {
     if (e.buttons !== 1 || !this.imageData) return;
     const ctx = editor.ctx;
-    ctx.putImageData(this.imageData, 0, 0);
+    this.restoreDirtyRegions(ctx, editor);
     this.applyStroke(ctx, editor);
     const dx = e.offsetX - this.startX;
     const dy = e.offsetY - this.startY;
@@ -32,6 +78,7 @@ export class CircleTool extends DrawingTool {
       radiusX = radius;
       radiusY = radius;
     }
+    this.updateDirtyRegion(radiusX, radiusY, editor);
     ctx.beginPath();
     ctx.ellipse(this.startX, this.startY, radiusX, radiusY, 0, 0, Math.PI * 2);
     ctx.stroke();
@@ -44,7 +91,7 @@ export class CircleTool extends DrawingTool {
   onPointerUp(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
     if (this.imageData) {
-      ctx.putImageData(this.imageData, 0, 0);
+      this.restoreDirtyRegions(ctx, editor);
     }
     this.applyStroke(ctx, editor);
     const dx = e.offsetX - this.startX;
@@ -64,6 +111,7 @@ export class CircleTool extends DrawingTool {
     }
     ctx.closePath();
     this.imageData = null;
+    this.dirtyRegions.clear();
   }
 }
 

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -1,3 +1,8 @@
+import {
+  DirtyRegionTracker,
+  clipRect,
+  expandRectForStroke,
+} from "../core/DirtyRegionTracker.js";
 import { Editor } from "../core/Editor.js";
 import { DrawingTool } from "./DrawingTool.js";
 
@@ -5,6 +10,42 @@ export class LineTool extends DrawingTool {
   private startX = 0;
   private startY = 0;
   private imageData: ImageData | null = null;
+  private dirtyRegions = new DirtyRegionTracker();
+
+  private restoreDirtyRegions(ctx: CanvasRenderingContext2D, editor: Editor) {
+    if (!this.imageData) return;
+    const bounds = {
+      width: editor.canvas.width,
+      height: editor.canvas.height,
+    };
+    for (const region of this.dirtyRegions.getRegions()) {
+      const clipped = clipRect(region, bounds);
+      if (!clipped) continue;
+      ctx.putImageData(
+        this.imageData,
+        0,
+        0,
+        clipped.x,
+        clipped.y,
+        clipped.width,
+        clipped.height,
+      );
+    }
+  }
+
+  private updateDirtyRegion(endX: number, endY: number, editor: Editor) {
+    const rect = {
+      x: Math.min(this.startX, endX),
+      y: Math.min(this.startY, endY),
+      width: Math.max(Math.abs(endX - this.startX), 1),
+      height: Math.max(Math.abs(endY - this.startY), 1),
+    };
+    const dirty = expandRectForStroke(rect, editor.lineWidthValue, {
+      width: editor.canvas.width,
+      height: editor.canvas.height,
+    });
+    this.dirtyRegions.setRegions(dirty ? [dirty] : []);
+  }
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
@@ -17,12 +58,13 @@ export class LineTool extends DrawingTool {
       editor.canvas.width,
       editor.canvas.height,
     );
+    this.dirtyRegions.clear();
   }
 
   onPointerMove(e: PointerEvent, editor: Editor): void {
     if (e.buttons !== 1 || !this.imageData) return;
     const ctx = editor.ctx;
-    ctx.putImageData(this.imageData, 0, 0);
+    this.restoreDirtyRegions(ctx, editor);
     this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
@@ -37,6 +79,7 @@ export class LineTool extends DrawingTool {
       x = this.startX + length * Math.cos(snapped);
       y = this.startY + length * Math.sin(snapped);
     }
+    this.updateDirtyRegion(x, y, editor);
     ctx.lineTo(x, y);
     ctx.stroke();
     ctx.closePath();
@@ -45,7 +88,7 @@ export class LineTool extends DrawingTool {
   onPointerUp(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
     if (this.imageData) {
-      ctx.putImageData(this.imageData, 0, 0);
+      this.restoreDirtyRegions(ctx, editor);
     }
     this.applyStroke(ctx, editor);
     ctx.beginPath();
@@ -61,9 +104,11 @@ export class LineTool extends DrawingTool {
       x = this.startX + length * Math.cos(snapped);
       y = this.startY + length * Math.sin(snapped);
     }
+    this.updateDirtyRegion(x, y, editor);
     ctx.lineTo(x, y);
     ctx.stroke();
     ctx.closePath();
     this.imageData = null;
+    this.dirtyRegions.clear();
   }
 }

--- a/src/tools/RectangleTool.ts
+++ b/src/tools/RectangleTool.ts
@@ -1,3 +1,8 @@
+import {
+  DirtyRegionTracker,
+  clipRect,
+  expandRectForStroke,
+} from "../core/DirtyRegionTracker.js";
 import { Editor } from "../core/Editor.js";
 import { DrawingTool } from "./DrawingTool.js";
 
@@ -5,6 +10,47 @@ export class RectangleTool extends DrawingTool {
   private startX = 0;
   private startY = 0;
   private imageData: ImageData | null = null;
+  private dirtyRegions = new DirtyRegionTracker();
+
+  private restoreDirtyRegions(ctx: CanvasRenderingContext2D, editor: Editor) {
+    if (!this.imageData) return;
+    const bounds = {
+      width: editor.canvas.width,
+      height: editor.canvas.height,
+    };
+    for (const region of this.dirtyRegions.getRegions()) {
+      const clipped = clipRect(region, bounds);
+      if (!clipped) continue;
+      ctx.putImageData(
+        this.imageData,
+        0,
+        0,
+        clipped.x,
+        clipped.y,
+        clipped.width,
+        clipped.height,
+      );
+    }
+  }
+
+  private updateDirtyRegion(
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number,
+    editor: Editor,
+  ) {
+    const x = Math.min(startX, endX);
+    const y = Math.min(startY, endY);
+    const width = Math.abs(endX - startX);
+    const height = Math.abs(endY - startY);
+    const dirty = expandRectForStroke(
+      { x, y, width: Math.max(width, 1), height: Math.max(height, 1) },
+      editor.lineWidthValue,
+      { width: editor.canvas.width, height: editor.canvas.height },
+    );
+    this.dirtyRegions.setRegions(dirty ? [dirty] : []);
+  }
 
   onPointerDown(e: PointerEvent, editor: Editor) {
     this.startX = e.offsetX;
@@ -12,12 +58,13 @@ export class RectangleTool extends DrawingTool {
     this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
     this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
+    this.dirtyRegions.clear();
   }
 
   onPointerMove(e: PointerEvent, editor: Editor) {
     if (e.buttons !== 1 || !this.imageData) return;
     const ctx = editor.ctx;
-    ctx.putImageData(this.imageData, 0, 0);
+    this.restoreDirtyRegions(ctx, editor);
     this.applyStroke(editor.ctx, editor);
 
     const x = e.offsetX;
@@ -29,6 +76,7 @@ export class RectangleTool extends DrawingTool {
       width = size * Math.sign(width);
       height = size * Math.sign(height);
     }
+    this.updateDirtyRegion(this.startX, this.startY, x, y, editor);
     ctx.strokeRect(this.startX, this.startY, width, height);
     if (editor.fill) {
       ctx.fillRect(this.startX, this.startY, width, height);
@@ -38,7 +86,7 @@ export class RectangleTool extends DrawingTool {
   onPointerUp(e: PointerEvent, editor: Editor) {
     const ctx = editor.ctx;
     if (this.imageData) {
-      ctx.putImageData(this.imageData, 0, 0);
+      this.restoreDirtyRegions(ctx, editor);
     }
 
     this.applyStroke(editor.ctx, editor);
@@ -56,5 +104,6 @@ export class RectangleTool extends DrawingTool {
       ctx.fillRect(this.startX, this.startY, width, height);
     }
     this.imageData = null;
+    this.dirtyRegions.clear();
   }
 }

--- a/tests/circleTool.test.ts
+++ b/tests/circleTool.test.ts
@@ -30,6 +30,17 @@ describe("CircleTool", () => {
     canvas.getContext = jest
       .fn()
       .mockReturnValue(ctx as CanvasRenderingContext2D);
+    canvas.getBoundingClientRect = () => ({
+      width: 100,
+      height: 100,
+      top: 0,
+      left: 0,
+      bottom: 100,
+      right: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
     editor = new Editor(
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
@@ -46,10 +57,15 @@ describe("CircleTool", () => {
       offsetY: 7,
       buttons: 1,
     } as PointerEvent, editor);
+    tool.onPointerMove({
+      offsetX: 6,
+      offsetY: 8,
+      buttons: 1,
+    } as PointerEvent, editor);
 
     expect(ctx.getImageData).toHaveBeenCalled();
     const image = (ctx.getImageData as jest.Mock).mock.results[0].value;
-    expect(ctx.putImageData).toHaveBeenCalledWith(image, 0, 0);
+    expect(ctx.putImageData).toHaveBeenCalledWith(image, 0, 0, 0, 0, 6, 8);
     const dx = 5 - 2;
     const dy = 7 - 3;
     const radiusX = Math.abs(dx);

--- a/tests/dirtyRegionTracker.test.ts
+++ b/tests/dirtyRegionTracker.test.ts
@@ -1,0 +1,29 @@
+import {
+  DirtyRegionTracker,
+  type Rect,
+} from "../src/core/DirtyRegionTracker.js";
+
+describe("DirtyRegionTracker", () => {
+  it("merges overlapping regions into a single rect", () => {
+    const tracker = new DirtyRegionTracker();
+    const regions: Rect[] = [
+      { x: 0, y: 0, width: 10, height: 10 },
+      { x: 5, y: 5, width: 8, height: 8 },
+      { x: 30, y: 30, width: 5, height: 5 },
+    ];
+
+    tracker.setRegions(regions);
+
+    expect(tracker.getRegions()).toEqual([
+      { x: 0, y: 0, width: 13, height: 13 },
+      { x: 30, y: 30, width: 5, height: 5 },
+    ]);
+  });
+
+  it("clears all regions when requested", () => {
+    const tracker = new DirtyRegionTracker();
+    tracker.setRegions([{ x: 1, y: 1, width: 2, height: 2 }]);
+    tracker.clear();
+    expect(tracker.getRegions()).toEqual([]);
+  });
+});

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -130,8 +130,10 @@ describe("editor toolbar controls", () => {
     (document.getElementById("rectangle") as HTMLButtonElement).click();
     dispatch("pointerdown", 1, 1, 1);
     dispatch("pointermove", 3, 4, 1);
+    dispatch("pointermove", 4, 5, 1);
     expect(ctx.getImageData).toHaveBeenCalled();
-    expect(ctx.putImageData).toHaveBeenCalled();
+    const image = (ctx.getImageData as jest.Mock).mock.results[0].value;
+    expect(ctx.putImageData).toHaveBeenCalledWith(image, 0, 0, 0, 0, 4, 5);
     expect(ctx.strokeRect).toHaveBeenCalledWith(1, 1, 2, 3);
   });
 

--- a/tests/lineTool.test.ts
+++ b/tests/lineTool.test.ts
@@ -38,6 +38,17 @@ describe("LineTool", () => {
     canvas.getContext = jest
       .fn()
       .mockReturnValue(ctx as CanvasRenderingContext2D);
+    canvas.getBoundingClientRect = () => ({
+      width: 100,
+      height: 100,
+      top: 0,
+      left: 0,
+      bottom: 100,
+      right: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
     editor = new Editor(
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
@@ -54,18 +65,24 @@ describe("LineTool", () => {
       offsetY: 4,
       buttons: 1,
     } as PointerEvent, editor);
+    tool.onPointerMove({
+      offsetX: 4,
+      offsetY: 5,
+      buttons: 1,
+    } as PointerEvent, editor);
     tool.onPointerUp({ offsetX: 3, offsetY: 4 } as PointerEvent, editor);
 
     expect(ctx.getImageData).toHaveBeenCalled();
     const image = (ctx.getImageData as jest.Mock).mock.results[0].value;
-    expect(ctx.putImageData).toHaveBeenCalledTimes(2);
-    expect(ctx.putImageData).toHaveBeenNthCalledWith(1, image, 0, 0);
-    expect(ctx.putImageData).toHaveBeenNthCalledWith(2, image, 0, 0);
-    expect(ctx.beginPath).toHaveBeenCalledTimes(2);
+    const calls = (ctx.putImageData as jest.Mock).mock.calls;
+    expect(calls.length).toBe(2);
+    expect(calls[0]).toEqual([image, 0, 0, 0, 1, 4, 4]);
+    expect(calls[1]).toEqual([image, 0, 0, 0, 1, 5, 5]);
+    expect(ctx.beginPath).toHaveBeenCalledTimes(3);
     expect(ctx.moveTo).toHaveBeenCalledWith(1, 2);
     expect(ctx.lineTo).toHaveBeenCalledWith(3, 4);
-    expect(ctx.stroke).toHaveBeenCalledTimes(2);
-    expect(ctx.closePath).toHaveBeenCalledTimes(2);
+    expect(ctx.stroke).toHaveBeenCalledTimes(3);
+    expect(ctx.closePath).toHaveBeenCalledTimes(3);
     expect(ctx.strokeStyle).toBe(editor.strokeStyle);
     expect(ctx.fillStyle).toBe(editor.fillStyle);
     expect(ctx.lineWidth).toBe(editor.lineWidthValue);
@@ -75,7 +92,7 @@ describe("LineTool", () => {
     const tool = new LineTool();
     tool.onPointerDown({ offsetX: 1, offsetY: 2 } as PointerEvent, editor);
     tool.onPointerUp({ offsetX: 5, offsetY: 6 } as PointerEvent, editor);
-    expect(ctx.putImageData).toHaveBeenCalled();
+    expect((ctx.putImageData as jest.Mock).mock.calls).toHaveLength(0);
     expect(ctx.beginPath).toHaveBeenCalled();
     expect(ctx.moveTo).toHaveBeenCalledWith(1, 2);
     expect(ctx.lineTo).toHaveBeenCalledWith(5, 6);
@@ -90,7 +107,7 @@ describe("LineTool", () => {
     tool.onPointerUp({ offsetX: 1, offsetY: 1 } as PointerEvent, editor);
     editor.undo();
     expect(ctx.clearRect).toHaveBeenCalledTimes(1);
-    expect(ctx.putImageData).toHaveBeenCalledTimes(2);
+    expect(ctx.putImageData).toHaveBeenCalled();
   });
 
   it("snaps angles to 45° increments when shift is held", () => {

--- a/tests/rectangleTool.test.ts
+++ b/tests/rectangleTool.test.ts
@@ -73,6 +73,26 @@ describe("RectangleTool", () => {
     expect(ctx.strokeRect).toHaveBeenCalledWith(10, 15, 10, 10);
   });
 
+  it("restores only the dirty region while previewing", () => {
+    const tool = new RectangleTool();
+    tool.onPointerDown({ offsetX: 10, offsetY: 15 } as PointerEvent, editor);
+    tool.onPointerMove({
+      offsetX: 20,
+      offsetY: 25,
+      buttons: 1,
+    } as PointerEvent, editor);
+    tool.onPointerMove({
+      offsetX: 25,
+      offsetY: 30,
+      buttons: 1,
+    } as PointerEvent, editor);
+
+    expect(ctx.putImageData).toHaveBeenCalledTimes(1);
+    const call = (ctx.putImageData as jest.Mock).mock.calls[0];
+    expect(call[0]).toBe(ctx.getImageData.mock.results[0].value);
+    expect(call.slice(1)).toEqual([0, 0, 9, 14, 12, 12]);
+  });
+
   it("fills a rectangle when fill mode is enabled", () => {
     const tool = new RectangleTool();
     (document.getElementById("fillMode") as HTMLInputElement).checked = true;


### PR DESCRIPTION
## Summary
- add a shared DirtyRegionTracker helper for clipping and merging dirty rectangles
- update the rectangle, circle, and line tools to restore only the tracked dirty regions during previews
- extend editor and tool tests, including new dirty-region unit tests, to cover overlapping previews and targeted restores

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d60d222f2c83288ac79750b1043fee