### PR TITLE
Offload bucket fill to worker

### DIFF
--- a/dist/core/Editor.js
+++ b/dist/core/Editor.js
@@ -1,8 +1,11 @@
+import { floodFill } from "./floodFill.js";
 export class Editor {
     constructor(canvas, colorPicker, lineWidth, fillMode, onChange, fontFamily, fontSize) {
         this.undoStack = [];
         this.redoStack = [];
         this.currentTool = null;
+        this.bucketFillWorkerId = 0;
+        this.bucketFillResolvers = new Map();
         this.handlePointerDown = (e) => {
             // Capture the pointer once before recording canvas state
             this.canvas.setPointerCapture(e.pointerId);
@@ -21,6 +24,26 @@ export class Editor {
             this.adjustForPixelRatio();
             this.ctx.putImageData(data, 0, 0);
         };
+        this.handleBucketFillWorkerMessage = (event) => {
+            const message = event.data;
+            if (!message)
+                return;
+            const pending = this.bucketFillResolvers.get(message.id);
+            if (!pending)
+                return;
+            this.bucketFillResolvers.delete(message.id);
+            if (message.type === "result") {
+                pending.resolve(message);
+            }
+            else {
+                pending.reject(new Error(message.message));
+            }
+        };
+        this.handleBucketFillWorkerError = (event) => {
+            this.bucketFillResolvers.forEach(({ reject }) => reject(event.error));
+            this.bucketFillResolvers.clear();
+            this.tearDownBucketFillWorker();
+        };
         this.canvas = canvas;
         const ctx = canvas.getContext("2d");
         if (!ctx)
@@ -32,6 +55,7 @@ export class Editor {
         this.onChange = onChange;
         this.fontFamily = fontFamily ?? null;
         this.fontSize = fontSize ?? null;
+        this.supportsWorker = typeof Worker !== "undefined";
         this.adjustForPixelRatio();
         window.addEventListener("resize", this.handleResize);
         this.canvas.addEventListener("pointerdown", this.handlePointerDown);
@@ -98,6 +122,33 @@ export class Editor {
     get fontSizeValue() {
         return parseInt(this.fontSize?.value ?? "", 10) || 16;
     }
+    supportsBucketFillWorkers() {
+        return this.supportsWorker;
+    }
+    async requestBucketFill(request, transferables) {
+        const worker = this.ensureBucketFillWorker();
+        if (!worker) {
+            return this.runBucketFillFallback(request);
+        }
+        const id = ++this.bucketFillWorkerId;
+        const message = { ...request, id };
+        return new Promise((resolve, reject) => {
+            this.bucketFillResolvers.set(id, { resolve, reject });
+            try {
+                worker.postMessage(message, transferables);
+            }
+            catch (error) {
+                this.bucketFillResolvers.delete(id);
+                this.tearDownBucketFillWorker();
+                try {
+                    resolve(this.runBucketFillFallback(request));
+                }
+                catch (fallbackError) {
+                    reject(fallbackError);
+                }
+            }
+        });
+    }
     /**
      * Remove all event listeners registered by the editor.
      * Should be called before discarding the instance to prevent leaks.
@@ -108,5 +159,55 @@ export class Editor {
         this.canvas.removeEventListener("pointerdown", this.handlePointerDown);
         this.canvas.removeEventListener("pointermove", this.handlePointerMove);
         this.canvas.removeEventListener("pointerup", this.handlePointerUp);
+        this.bucketFillResolvers.forEach(({ reject }) => reject(new Error("Editor destroyed")));
+        this.bucketFillResolvers.clear();
+        this.tearDownBucketFillWorker();
+    }
+    ensureBucketFillWorker() {
+        if (!this.supportsWorker)
+            return null;
+        if (this.bucketFillWorker)
+            return this.bucketFillWorker;
+        try {
+            this.bucketFillWorker = new Worker("dist/workers/floodFillWorker.js", {
+                type: "module",
+            });
+            this.bucketFillWorker.addEventListener("message", this.handleBucketFillWorkerMessage);
+            this.bucketFillWorker.addEventListener("error", this.handleBucketFillWorkerError);
+            return this.bucketFillWorker;
+        }
+        catch (error) {
+            console.warn("Failed to initialize bucket fill worker", error);
+            this.bucketFillWorker = undefined;
+            return null;
+        }
+    }
+    runBucketFillFallback(request) {
+        if (!request.imageBuffer) {
+            throw new Error("Bucket fill fallback requires image buffer");
+        }
+        const pixels = new Uint8ClampedArray(request.imageBuffer);
+        const result = floodFill(pixels, {
+            width: request.width,
+            height: request.height,
+            startX: request.startX,
+            startY: request.startY,
+            fill: request.fill,
+            maxPixels: request.maxPixels,
+        });
+        return {
+            id: 0,
+            type: "result",
+            dirtyRects: result.dirtyRects,
+            aborted: result.aborted,
+        };
+    }
+    tearDownBucketFillWorker() {
+        if (!this.bucketFillWorker)
+            return;
+        this.bucketFillWorker.removeEventListener("message", this.handleBucketFillWorkerMessage);
+        this.bucketFillWorker.removeEventListener("error", this.handleBucketFillWorkerError);
+        this.bucketFillWorker.terminate();
+        this.bucketFillWorker = undefined;
     }
 }

--- a/dist/core/floodFill.js
+++ b/dist/core/floodFill.js
@@ -1,0 +1,113 @@
+export function floodFill(data, options) {
+    const { width, height, startX, startY, fill, maxPixels } = options;
+    if (startX < 0 || startY < 0 || startX >= width || startY >= height) {
+        return { dirtyRects: [], processed: 0, aborted: false };
+    }
+    const startIndex = startY * width + startX;
+    const targetOffset = startIndex * 4;
+    const targetR = data[targetOffset];
+    const targetG = data[targetOffset + 1];
+    const targetB = data[targetOffset + 2];
+    const targetA = data[targetOffset + 3];
+    const [fillR, fillG, fillB, fillA] = fill;
+    if (targetR === fillR &&
+        targetG === fillG &&
+        targetB === fillB &&
+        targetA === fillA) {
+        return { dirtyRects: [], processed: 0, aborted: false };
+    }
+    const pixelCount = width * height;
+    const queue = new Uint32Array(pixelCount);
+    const visited = new Uint8Array(pixelCount);
+    let head = 0;
+    let tail = 0;
+    let processed = 0;
+    let aborted = false;
+    let minX = startX;
+    let maxX = startX;
+    let minY = startY;
+    let maxY = startY;
+    queue[tail++] = startIndex;
+    visited[startIndex] = 1;
+    while (head < tail) {
+        const idx = queue[head++];
+        const offset = idx * 4;
+        if (data[offset] !== targetR ||
+            data[offset + 1] !== targetG ||
+            data[offset + 2] !== targetB ||
+            data[offset + 3] !== targetA) {
+            continue;
+        }
+        data[offset] = fillR;
+        data[offset + 1] = fillG;
+        data[offset + 2] = fillB;
+        data[offset + 3] = fillA;
+        processed++;
+        if (processed > maxPixels) {
+            aborted = true;
+            break;
+        }
+        const x = idx % width;
+        const y = (idx / width) | 0;
+        if (x < minX)
+            minX = x;
+        if (x > maxX)
+            maxX = x;
+        if (y < minY)
+            minY = y;
+        if (y > maxY)
+            maxY = y;
+        if (x > 0) {
+            const left = idx - 1;
+            if (!visited[left]) {
+                queue[tail++] = left;
+                visited[left] = 1;
+            }
+        }
+        if (x < width - 1) {
+            const right = idx + 1;
+            if (!visited[right]) {
+                queue[tail++] = right;
+                visited[right] = 1;
+            }
+        }
+        if (y > 0) {
+            const up = idx - width;
+            if (!visited[up]) {
+                queue[tail++] = up;
+                visited[up] = 1;
+            }
+        }
+        if (y < height - 1) {
+            const down = idx + width;
+            if (!visited[down]) {
+                queue[tail++] = down;
+                visited[down] = 1;
+            }
+        }
+    }
+    if (processed === 0) {
+        return { dirtyRects: [], processed: 0, aborted };
+    }
+    const rectWidth = maxX - minX + 1;
+    const rectHeight = maxY - minY + 1;
+    const rectBuffer = new Uint8ClampedArray(rectWidth * rectHeight * 4);
+    for (let row = 0; row < rectHeight; row++) {
+        const sourceStart = ((minY + row) * width + minX) * 4;
+        const destStart = row * rectWidth * 4;
+        rectBuffer.set(data.subarray(sourceStart, sourceStart + rectWidth * 4), destStart);
+    }
+    return {
+        dirtyRects: [
+            {
+                x: minX,
+                y: minY,
+                width: rectWidth,
+                height: rectHeight,
+                buffer: rectBuffer.buffer,
+            },
+        ],
+        processed,
+        aborted,
+    };
+}

--- a/dist/tools/BucketFillTool.js
+++ b/dist/tools/BucketFillTool.js
@@ -6,7 +6,7 @@ export class BucketFillTool {
     onPointerDown(e, editor) {
         const ctx = editor.ctx;
         const image = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
-        const { width, height, data } = image;
+        const { width, height } = image;
         const pixelCount = width * height;
         if (pixelCount > BucketFillTool.MAX_FILL_PIXELS) {
             console.warn("Bucket fill aborted: area too large");
@@ -15,69 +15,28 @@ export class BucketFillTool {
         const dpr = window.devicePixelRatio || 1;
         const sx = Math.max(0, Math.min(width - 1, Math.floor(e.offsetX * dpr)));
         const sy = Math.max(0, Math.min(height - 1, Math.floor(e.offsetY * dpr)));
-        const start = sy * width + sx;
-        const targetOffset = start * 4;
-        const tr = data[targetOffset];
-        const tg = data[targetOffset + 1];
-        const tb = data[targetOffset + 2];
-        const [fr, fg, fb] = this.hexToRgb(editor.fillStyle);
-        // if target already the fill color, nothing to do
-        if (tr === fr && tg === fg && tb === fb)
-            return;
-        const queue = new Uint32Array(pixelCount);
-        const visited = new Uint8Array(pixelCount);
-        let head = 0;
-        let tail = 0;
-        let processed = 0;
-        queue[tail++] = start;
-        visited[start] = 1;
-        while (head < tail) {
-            const idx = queue[head++];
-            const offset = idx * 4;
-            if (data[offset] !== tr || data[offset + 1] !== tg || data[offset + 2] !== tb) {
-                continue;
-            }
-            data[offset] = fr;
-            data[offset + 1] = fg;
-            data[offset + 2] = fb;
-            data[offset + 3] = 255;
-            processed++;
-            if (processed > BucketFillTool.MAX_FILL_PIXELS) {
-                console.warn("Bucket fill aborted: exceeded pixel limit");
-                break;
-            }
-            const x = idx % width;
-            const y = (idx / width) | 0;
-            if (x > 0) {
-                const n = idx - 1;
-                if (!visited[n]) {
-                    queue[tail++] = n;
-                    visited[n] = 1;
-                }
-            }
-            if (x < width - 1) {
-                const n = idx + 1;
-                if (!visited[n]) {
-                    queue[tail++] = n;
-                    visited[n] = 1;
-                }
-            }
-            if (y > 0) {
-                const n = idx - width;
-                if (!visited[n]) {
-                    queue[tail++] = n;
-                    visited[n] = 1;
-                }
-            }
-            if (y < height - 1) {
-                const n = idx + width;
-                if (!visited[n]) {
-                    queue[tail++] = n;
-                    visited[n] = 1;
-                }
-            }
-        }
-        ctx.putImageData(image, 0, 0);
+        const fillColor = this.hexToRgba(editor.fillStyle);
+        const offscreen = this.createOffscreenCanvasCopy(image);
+        const request = {
+            type: "fill",
+            width,
+            height,
+            startX: sx,
+            startY: sy,
+            fill: fillColor,
+            maxPixels: BucketFillTool.MAX_FILL_PIXELS,
+            imageBuffer: image.data.buffer,
+            canvas: offscreen,
+        };
+        const transfers = [image.data.buffer];
+        if (offscreen)
+            transfers.push(offscreen);
+        void editor
+            .requestBucketFill(request, transfers)
+            .then((result) => this.applyFillResult(result, editor))
+            .catch((err) => {
+            console.error("Bucket fill failed", err);
+        });
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     onPointerMove(_e, _editor) {
@@ -87,13 +46,51 @@ export class BucketFillTool {
     onPointerUp(_e, _editor) {
         // intentionally unused
     }
-    hexToRgb(hex) {
+    hexToRgba(hex) {
         let h = hex.replace(/^#/, "");
         if (h.length === 3) {
             h = h.split("").map((c) => c + c).join("");
         }
         const num = parseInt(h, 16);
-        return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
+        return [
+            (num >> 16) & 255,
+            (num >> 8) & 255,
+            num & 255,
+            255,
+        ];
+    }
+    createOffscreenCanvasCopy(image) {
+        const scratch = document.createElement("canvas");
+        if (typeof scratch.transferControlToOffscreen !== "function") {
+            return undefined;
+        }
+        scratch.width = image.width;
+        scratch.height = image.height;
+        const scratchCtx = scratch.getContext("2d");
+        if (!scratchCtx) {
+            return undefined;
+        }
+        scratchCtx.putImageData(image, 0, 0);
+        return scratch.transferControlToOffscreen();
+    }
+    applyFillResult(result, editor) {
+        if (result.aborted) {
+            console.warn("Bucket fill aborted: exceeded pixel limit");
+        }
+        if (!result.dirtyRects.length)
+            return;
+        const ctx = editor.ctx;
+        for (const rect of result.dirtyRects) {
+            const imageData = this.createImageData(rect);
+            ctx.putImageData(imageData, rect.x, rect.y);
+        }
+    }
+    createImageData(rect) {
+        const pixels = new Uint8ClampedArray(rect.buffer);
+        if (typeof ImageData !== "undefined") {
+            return new ImageData(pixels, rect.width, rect.height);
+        }
+        return { data: pixels, width: rect.width, height: rect.height };
     }
 }
 BucketFillTool.MAX_FILL_PIXELS = 1000000;

--- a/dist/workers/floodFillWorker.js
+++ b/dist/workers/floodFillWorker.js
@@ -1,0 +1,48 @@
+import { floodFill } from "../core/floodFill.js";
+self.addEventListener("message", (event) => {
+    const msg = event.data;
+    if (!msg || msg.type !== "fill") {
+        return;
+    }
+    try {
+        const { width, height, startX, startY, fill, maxPixels } = msg;
+        let buffer = msg.imageBuffer;
+        if (!buffer && msg.canvas) {
+            const ctx = msg.canvas.getContext("2d");
+            if (!ctx) {
+                throw new Error("Offscreen canvas missing 2D context");
+            }
+            const imageData = ctx.getImageData(0, 0, width, height);
+            buffer = imageData.data.buffer.slice(0);
+        }
+        if (!buffer) {
+            throw new Error("Flood fill request missing pixel buffer");
+        }
+        const pixels = new Uint8ClampedArray(buffer);
+        const result = floodFill(pixels, {
+            width,
+            height,
+            startX,
+            startY,
+            fill,
+            maxPixels,
+        });
+        const transfers = result.dirtyRects.map((rect) => rect.buffer);
+        const response = {
+            id: msg.id,
+            type: "result",
+            dirtyRects: result.dirtyRects,
+            aborted: result.aborted,
+        };
+        self.postMessage(response, transfers);
+    }
+    catch (error) {
+        const message = error instanceof Error ? error.message : "Unknown flood fill error";
+        const response = {
+            id: msg.id,
+            type: "error",
+            message,
+        };
+        self.postMessage(response);
+    }
+});

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -1,4 +1,34 @@
 import { Tool } from "../tools/Tool.js";
+import type { FloodFillDirtyRect } from "./floodFill.js";
+import { floodFill } from "./floodFill.js";
+
+interface FloodFillWorkerRequest {
+  id: number;
+  type: "fill";
+  width: number;
+  height: number;
+  startX: number;
+  startY: number;
+  fill: [number, number, number, number];
+  maxPixels: number;
+  imageBuffer?: ArrayBuffer;
+  canvas?: OffscreenCanvas;
+}
+
+export interface FloodFillWorkerSuccess {
+  id: number;
+  type: "result";
+  dirtyRects: FloodFillDirtyRect[];
+  aborted: boolean;
+}
+
+interface FloodFillWorkerError {
+  id: number;
+  type: "error";
+  message: string;
+}
+
+type FloodFillWorkerResponse = FloodFillWorkerSuccess | FloodFillWorkerError;
 
 export class Editor {
   canvas: HTMLCanvasElement;
@@ -12,6 +42,16 @@ export class Editor {
   fontFamily: HTMLSelectElement | null;
   fontSize: HTMLInputElement | null;
   private onChange?: () => void;
+  private bucketFillWorker?: Worker;
+  private bucketFillWorkerId = 0;
+  private bucketFillResolvers = new Map<
+    number,
+    {
+      resolve: (value: FloodFillWorkerSuccess) => void;
+      reject: (reason: unknown) => void;
+    }
+  >();
+  private readonly supportsWorker: boolean;
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -32,6 +72,7 @@ export class Editor {
     this.onChange = onChange;
     this.fontFamily = fontFamily ?? null;
     this.fontSize = fontSize ?? null;
+    this.supportsWorker = typeof Worker !== "undefined";
     this.adjustForPixelRatio();
     window.addEventListener("resize", this.handleResize);
 
@@ -143,6 +184,38 @@ export class Editor {
     return parseInt(this.fontSize?.value ?? "", 10) || 16;
   }
 
+  supportsBucketFillWorkers() {
+    return this.supportsWorker;
+  }
+
+  async requestBucketFill(
+    request: Omit<FloodFillWorkerRequest, "id">,
+    transferables: Transferable[],
+  ): Promise<FloodFillWorkerSuccess> {
+    const worker = this.ensureBucketFillWorker();
+    if (!worker) {
+      return this.runBucketFillFallback(request);
+    }
+
+    const id = ++this.bucketFillWorkerId;
+    const message: FloodFillWorkerRequest = { ...request, id };
+
+    return new Promise<FloodFillWorkerSuccess>((resolve, reject) => {
+      this.bucketFillResolvers.set(id, { resolve, reject });
+      try {
+        worker.postMessage(message, transferables);
+      } catch (error) {
+        this.bucketFillResolvers.delete(id);
+        this.tearDownBucketFillWorker();
+        try {
+          resolve(this.runBucketFillFallback(request));
+        } catch (fallbackError) {
+          reject(fallbackError);
+        }
+      }
+    });
+  }
+
   /**
    * Remove all event listeners registered by the editor.
    * Should be called before discarding the instance to prevent leaks.
@@ -153,5 +226,94 @@ export class Editor {
     this.canvas.removeEventListener("pointerdown", this.handlePointerDown);
     this.canvas.removeEventListener("pointermove", this.handlePointerMove);
     this.canvas.removeEventListener("pointerup", this.handlePointerUp);
+    this.bucketFillResolvers.forEach(({ reject }) => reject(new Error("Editor destroyed")));
+    this.bucketFillResolvers.clear();
+    this.tearDownBucketFillWorker();
+  }
+
+  private ensureBucketFillWorker(): Worker | null {
+    if (!this.supportsWorker) return null;
+    if (this.bucketFillWorker) return this.bucketFillWorker;
+    try {
+      this.bucketFillWorker = new Worker("dist/workers/floodFillWorker.js", {
+        type: "module",
+      });
+      this.bucketFillWorker.addEventListener(
+        "message",
+        this.handleBucketFillWorkerMessage,
+      );
+      this.bucketFillWorker.addEventListener(
+        "error",
+        this.handleBucketFillWorkerError,
+      );
+      return this.bucketFillWorker;
+    } catch (error) {
+      console.warn("Failed to initialize bucket fill worker", error);
+      this.bucketFillWorker = undefined;
+      return null;
+    }
+  }
+
+  private runBucketFillFallback(
+    request: Omit<FloodFillWorkerRequest, "id">,
+  ): FloodFillWorkerSuccess {
+    if (!request.imageBuffer) {
+      throw new Error("Bucket fill fallback requires image buffer");
+    }
+
+    const pixels = new Uint8ClampedArray(request.imageBuffer);
+    const result = floodFill(pixels, {
+      width: request.width,
+      height: request.height,
+      startX: request.startX,
+      startY: request.startY,
+      fill: request.fill,
+      maxPixels: request.maxPixels,
+    });
+
+    return {
+      id: 0,
+      type: "result",
+      dirtyRects: result.dirtyRects,
+      aborted: result.aborted,
+    };
+  }
+
+  private handleBucketFillWorkerMessage = (
+    event: MessageEvent<FloodFillWorkerResponse>,
+  ) => {
+    const message = event.data;
+    if (!message) return;
+
+    const pending = this.bucketFillResolvers.get(message.id);
+    if (!pending) return;
+
+    this.bucketFillResolvers.delete(message.id);
+
+    if (message.type === "result") {
+      pending.resolve(message);
+    } else {
+      pending.reject(new Error(message.message));
+    }
+  };
+
+  private handleBucketFillWorkerError = (event: ErrorEvent) => {
+    this.bucketFillResolvers.forEach(({ reject }) => reject(event.error));
+    this.bucketFillResolvers.clear();
+    this.tearDownBucketFillWorker();
+  };
+
+  private tearDownBucketFillWorker() {
+    if (!this.bucketFillWorker) return;
+    this.bucketFillWorker.removeEventListener(
+      "message",
+      this.handleBucketFillWorkerMessage,
+    );
+    this.bucketFillWorker.removeEventListener(
+      "error",
+      this.handleBucketFillWorkerError,
+    );
+    this.bucketFillWorker.terminate();
+    this.bucketFillWorker = undefined;
   }
 }

--- a/src/core/floodFill.ts
+++ b/src/core/floodFill.ts
@@ -1,0 +1,163 @@
+export interface FloodFillDirtyRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  buffer: ArrayBuffer;
+}
+
+export interface FloodFillRunOptions {
+  width: number;
+  height: number;
+  startX: number;
+  startY: number;
+  fill: [number, number, number, number];
+  maxPixels: number;
+}
+
+export interface FloodFillResult {
+  dirtyRects: FloodFillDirtyRect[];
+  processed: number;
+  aborted: boolean;
+}
+
+export function floodFill(
+  data: Uint8ClampedArray,
+  options: FloodFillRunOptions,
+): FloodFillResult {
+  const { width, height, startX, startY, fill, maxPixels } = options;
+
+  if (startX < 0 || startY < 0 || startX >= width || startY >= height) {
+    return { dirtyRects: [], processed: 0, aborted: false };
+  }
+
+  const startIndex = startY * width + startX;
+  const targetOffset = startIndex * 4;
+  const targetR = data[targetOffset];
+  const targetG = data[targetOffset + 1];
+  const targetB = data[targetOffset + 2];
+  const targetA = data[targetOffset + 3];
+
+  const [fillR, fillG, fillB, fillA] = fill;
+
+  if (
+    targetR === fillR &&
+    targetG === fillG &&
+    targetB === fillB &&
+    targetA === fillA
+  ) {
+    return { dirtyRects: [], processed: 0, aborted: false };
+  }
+
+  const pixelCount = width * height;
+  const queue = new Uint32Array(pixelCount);
+  const visited = new Uint8Array(pixelCount);
+  let head = 0;
+  let tail = 0;
+
+  let processed = 0;
+  let aborted = false;
+
+  let minX = startX;
+  let maxX = startX;
+  let minY = startY;
+  let maxY = startY;
+
+  queue[tail++] = startIndex;
+  visited[startIndex] = 1;
+
+  while (head < tail) {
+    const idx = queue[head++];
+    const offset = idx * 4;
+
+    if (
+      data[offset] !== targetR ||
+      data[offset + 1] !== targetG ||
+      data[offset + 2] !== targetB ||
+      data[offset + 3] !== targetA
+    ) {
+      continue;
+    }
+
+    data[offset] = fillR;
+    data[offset + 1] = fillG;
+    data[offset + 2] = fillB;
+    data[offset + 3] = fillA;
+
+    processed++;
+    if (processed > maxPixels) {
+      aborted = true;
+      break;
+    }
+
+    const x = idx % width;
+    const y = (idx / width) | 0;
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+
+    if (x > 0) {
+      const left = idx - 1;
+      if (!visited[left]) {
+        queue[tail++] = left;
+        visited[left] = 1;
+      }
+    }
+
+    if (x < width - 1) {
+      const right = idx + 1;
+      if (!visited[right]) {
+        queue[tail++] = right;
+        visited[right] = 1;
+      }
+    }
+
+    if (y > 0) {
+      const up = idx - width;
+      if (!visited[up]) {
+        queue[tail++] = up;
+        visited[up] = 1;
+      }
+    }
+
+    if (y < height - 1) {
+      const down = idx + width;
+      if (!visited[down]) {
+        queue[tail++] = down;
+        visited[down] = 1;
+      }
+    }
+  }
+
+  if (processed === 0) {
+    return { dirtyRects: [], processed: 0, aborted };
+  }
+
+  const rectWidth = maxX - minX + 1;
+  const rectHeight = maxY - minY + 1;
+  const rectBuffer = new Uint8ClampedArray(rectWidth * rectHeight * 4);
+
+  for (let row = 0; row < rectHeight; row++) {
+    const sourceStart = ((minY + row) * width + minX) * 4;
+    const destStart = row * rectWidth * 4;
+    rectBuffer.set(
+      data.subarray(sourceStart, sourceStart + rectWidth * 4),
+      destStart,
+    );
+  }
+
+  return {
+    dirtyRects: [
+      {
+        x: minX,
+        y: minY,
+        width: rectWidth,
+        height: rectHeight,
+        buffer: rectBuffer.buffer,
+      },
+    ],
+    processed,
+    aborted,
+  };
+}

--- a/src/tools/BucketFillTool.ts
+++ b/src/tools/BucketFillTool.ts
@@ -1,5 +1,6 @@
 import { Editor } from "../core/Editor.js";
 import { Tool } from "./Tool.js";
+import type { FloodFillWorkerSuccess } from "../core/Editor.js";
 
 /**
  * Tool that fills a contiguous region of pixels with the current fill color.
@@ -11,7 +12,7 @@ export class BucketFillTool implements Tool {
   onPointerDown(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
     const image = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
-    const { width, height, data } = image;
+    const { width, height } = image;
 
     const pixelCount = width * height;
     if (pixelCount > BucketFillTool.MAX_FILL_PIXELS) {
@@ -22,76 +23,32 @@ export class BucketFillTool implements Tool {
     const dpr = window.devicePixelRatio || 1;
     const sx = Math.max(0, Math.min(width - 1, Math.floor(e.offsetX * dpr)));
     const sy = Math.max(0, Math.min(height - 1, Math.floor(e.offsetY * dpr)));
-    const start = sy * width + sx;
-    const targetOffset = start * 4;
-    const tr = data[targetOffset];
-    const tg = data[targetOffset + 1];
-    const tb = data[targetOffset + 2];
 
-    const [fr, fg, fb] = this.hexToRgb(editor.fillStyle);
+    const fillColor = this.hexToRgba(editor.fillStyle);
 
-    // if target already the fill color, nothing to do
-    if (tr === fr && tg === fg && tb === fb) return;
+    const offscreen = this.createOffscreenCanvasCopy(image);
 
-    const queue = new Uint32Array(pixelCount);
-    const visited = new Uint8Array(pixelCount);
-    let head = 0;
-    let tail = 0;
-    let processed = 0;
+    const request = {
+      type: "fill" as const,
+      width,
+      height,
+      startX: sx,
+      startY: sy,
+      fill: fillColor,
+      maxPixels: BucketFillTool.MAX_FILL_PIXELS,
+      imageBuffer: image.data.buffer,
+      canvas: offscreen,
+    };
 
-    queue[tail++] = start;
-    visited[start] = 1;
+    const transfers: Transferable[] = [image.data.buffer];
+    if (offscreen) transfers.push(offscreen);
 
-    while (head < tail) {
-      const idx = queue[head++];
-      const offset = idx * 4;
-      if (data[offset] !== tr || data[offset + 1] !== tg || data[offset + 2] !== tb) {
-        continue;
-      }
-
-      data[offset] = fr;
-      data[offset + 1] = fg;
-      data[offset + 2] = fb;
-      data[offset + 3] = 255;
-      processed++;
-      if (processed > BucketFillTool.MAX_FILL_PIXELS) {
-        console.warn("Bucket fill aborted: exceeded pixel limit");
-        break;
-      }
-
-      const x = idx % width;
-      const y = (idx / width) | 0;
-
-      if (x > 0) {
-        const n = idx - 1;
-        if (!visited[n]) {
-          queue[tail++] = n;
-          visited[n] = 1;
-        }
-      }
-      if (x < width - 1) {
-        const n = idx + 1;
-        if (!visited[n]) {
-          queue[tail++] = n;
-          visited[n] = 1;
-        }
-      }
-      if (y > 0) {
-        const n = idx - width;
-        if (!visited[n]) {
-          queue[tail++] = n;
-          visited[n] = 1;
-        }
-      }
-      if (y < height - 1) {
-        const n = idx + width;
-        if (!visited[n]) {
-          queue[tail++] = n;
-          visited[n] = 1;
-        }
-      }
-    }
-    ctx.putImageData(image, 0, 0);
+    void editor
+      .requestBucketFill(request, transfers)
+      .then((result) => this.applyFillResult(result, editor))
+      .catch((err) => {
+        console.error("Bucket fill failed", err);
+      });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -104,12 +61,53 @@ export class BucketFillTool implements Tool {
     // intentionally unused
   }
 
-  private hexToRgb(hex: string): [number, number, number] {
+  private hexToRgba(hex: string): [number, number, number, number] {
     let h = hex.replace(/^#/, "");
     if (h.length === 3) {
       h = h.split("").map((c) => c + c).join("");
     }
     const num = parseInt(h, 16);
-    return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
+    return [
+      (num >> 16) & 255,
+      (num >> 8) & 255,
+      num & 255,
+      255,
+    ];
+  }
+
+  private createOffscreenCanvasCopy(image: ImageData): OffscreenCanvas | undefined {
+    const scratch = document.createElement("canvas");
+    if (typeof scratch.transferControlToOffscreen !== "function") {
+      return undefined;
+    }
+    scratch.width = image.width;
+    scratch.height = image.height;
+    const scratchCtx = scratch.getContext("2d");
+    if (!scratchCtx) {
+      return undefined;
+    }
+    scratchCtx.putImageData(image, 0, 0);
+    return scratch.transferControlToOffscreen();
+  }
+
+  private applyFillResult(result: FloodFillWorkerSuccess, editor: Editor) {
+    if (result.aborted) {
+      console.warn("Bucket fill aborted: exceeded pixel limit");
+    }
+    if (!result.dirtyRects.length) return;
+
+    const ctx = editor.ctx;
+    for (const rect of result.dirtyRects) {
+      const imageData = this.createImageData(rect);
+      ctx.putImageData(imageData, rect.x, rect.y);
+    }
+  }
+
+  private createImageData(rect: FloodFillWorkerSuccess["dirtyRects"][number]): ImageData {
+    const pixels = new Uint8ClampedArray(rect.buffer);
+    if (typeof ImageData !== "undefined") {
+      return new ImageData(pixels, rect.width, rect.height);
+    }
+    return { data: pixels, width: rect.width, height: rect.height } as ImageData;
   }
 }

--- a/src/workers/floodFillWorker.ts
+++ b/src/workers/floodFillWorker.ts
@@ -1,0 +1,87 @@
+import { floodFill, type FloodFillResult } from "../core/floodFill.js";
+
+type FloodFillRequestMessage = {
+  id: number;
+  type: "fill";
+  width: number;
+  height: number;
+  startX: number;
+  startY: number;
+  fill: [number, number, number, number];
+  maxPixels: number;
+  imageBuffer?: ArrayBuffer;
+  canvas?: OffscreenCanvas;
+};
+
+type FloodFillResponseMessage = {
+  id: number;
+  type: "result";
+  dirtyRects: FloodFillResult["dirtyRects"];
+  aborted: boolean;
+};
+
+type FloodFillErrorMessage = {
+  id: number;
+  type: "error";
+  message: string;
+};
+
+type WorkerIncomingMessage = FloodFillRequestMessage;
+type WorkerOutgoingMessage =
+  | FloodFillResponseMessage
+  | FloodFillErrorMessage;
+
+declare const self: DedicatedWorkerGlobalScope;
+
+self.addEventListener("message", (event: MessageEvent<WorkerIncomingMessage>) => {
+  const msg = event.data;
+  if (!msg || msg.type !== "fill") {
+    return;
+  }
+
+  try {
+    const { width, height, startX, startY, fill, maxPixels } = msg;
+
+    let buffer = msg.imageBuffer;
+    if (!buffer && msg.canvas) {
+      const ctx = msg.canvas.getContext("2d");
+      if (!ctx) {
+        throw new Error("Offscreen canvas missing 2D context");
+      }
+      const imageData = ctx.getImageData(0, 0, width, height);
+      buffer = imageData.data.buffer.slice(0);
+    }
+
+    if (!buffer) {
+      throw new Error("Flood fill request missing pixel buffer");
+    }
+
+    const pixels = new Uint8ClampedArray(buffer);
+    const result = floodFill(pixels, {
+      width,
+      height,
+      startX,
+      startY,
+      fill,
+      maxPixels,
+    });
+
+    const transfers = result.dirtyRects.map((rect) => rect.buffer);
+    const response: WorkerOutgoingMessage = {
+      id: msg.id,
+      type: "result",
+      dirtyRects: result.dirtyRects,
+      aborted: result.aborted,
+    };
+    self.postMessage(response, transfers);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unknown flood fill error";
+    const response: WorkerOutgoingMessage = {
+      id: msg.id,
+      type: "error",
+      message,
+    };
+    self.postMessage(response);
+  }
+});

--- a/tests/bucketFillTool.test.ts
+++ b/tests/bucketFillTool.test.ts
@@ -48,25 +48,30 @@ describe("BucketFillTool", () => {
     );
   });
 
-  it("fills enclosed areas with the selected color", () => {
+  it("fills enclosed areas with the selected color", async () => {
     const tool = new BucketFillTool();
     tool.onPointerDown({ offsetX: 2, offsetY: 2 } as PointerEvent, editor);
 
-    const image = (ctx.getImageData as jest.Mock).mock.results[0].value as ImageData;
-    const center = (2 * 5 + 2) * 4;
-    // blue from colorPicker (#0000ff)
-    expect(image.data[center]).toBe(0);
-    expect(image.data[center + 1]).toBe(0);
-    expect(image.data[center + 2]).toBe(255);
-    // ensure border untouched
-    const corner = 0;
-    expect(image.data[corner]).toBe(0);
-    expect(image.data[corner + 1]).toBe(0);
-    expect(image.data[corner + 2]).toBe(0);
-    expect(ctx.putImageData).toHaveBeenCalledWith(image, 0, 0);
+    await Promise.resolve();
+
+    const call = (ctx.putImageData as jest.Mock).mock.calls[0];
+    expect(call[1]).toBe(1);
+    expect(call[2]).toBe(1);
+
+    const result = call[0] as ImageData;
+    expect(result.width).toBe(3);
+    expect(result.height).toBe(3);
+    const data = result.data;
+
+    // ensure center pixel of rect is blue (#0000ff)
+    const center = ((1 * result.width + 1) * 4) | 0;
+    expect(data[center]).toBe(0);
+    expect(data[center + 1]).toBe(0);
+    expect(data[center + 2]).toBe(255);
+    expect(ctx.putImageData).toHaveBeenCalledTimes(1);
   });
 
-  it("fills large areas efficiently", () => {
+  it("fills large areas efficiently", async () => {
     const width = 100;
     const height = 100;
     const data = new Uint8ClampedArray(width * height * 4);
@@ -83,10 +88,16 @@ describe("BucketFillTool", () => {
     const tool = new BucketFillTool();
     tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
 
-    const last = (width * height - 1) * 4;
-    expect(image.data[last]).toBe(0);
-    expect(image.data[last + 1]).toBe(0);
-    expect(image.data[last + 2]).toBe(255);
-    expect(ctx.putImageData).toHaveBeenCalledWith(image, 0, 0);
+    await Promise.resolve();
+
+    const call = (ctx.putImageData as jest.Mock).mock.calls[0];
+    const result = call[0] as ImageData;
+    expect(call[1]).toBe(0);
+    expect(call[2]).toBe(0);
+    expect(result.width * result.height).toBe(width * height);
+    const last = (result.data.length / 4 - 1) * 4;
+    expect(result.data[last]).toBe(0);
+    expect(result.data[last + 1]).toBe(0);
+    expect(result.data[last + 2]).toBe(255);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "lib": ["ES2020", "DOM"]
+    "lib": ["ES2020", "DOM", "WebWorker"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- add a shared flood-fill helper and worker script to process fills off the main thread
- update the editor and bucket fill tool to delegate work to the worker and apply dirty rect updates
- adjust configuration and tests for the worker-based flow

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60d219a708328bc56281243dd4d8c