### PR TITLE
Add layer visibility toggles and history support

### DIFF
--- a/dist/core/Editor.js
+++ b/dist/core/Editor.js
@@ -3,6 +3,7 @@ export class Editor {
         this.undoStack = [];
         this.redoStack = [];
         this.currentTool = null;
+        this._visible = true;
         this.handlePointerDown = (e) => {
             // Capture the pointer once before recording canvas state
             this.canvas.setPointerCapture(e.pointerId);
@@ -32,16 +33,40 @@ export class Editor {
         this.onChange = onChange;
         this.fontFamily = fontFamily ?? null;
         this.fontSize = fontSize ?? null;
+        this._visible = this.canvas.style.visibility !== "hidden";
+        this.applyVisibility();
         this.adjustForPixelRatio();
         window.addEventListener("resize", this.handleResize);
         this.canvas.addEventListener("pointerdown", this.handlePointerDown);
         this.canvas.addEventListener("pointermove", this.handlePointerMove);
         this.canvas.addEventListener("pointerup", this.handlePointerUp);
     }
+    snapshot() {
+        return {
+            imageData: this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height),
+            visible: this._visible,
+        };
+    }
     setTool(tool) {
         this.currentTool?.destroy?.();
         this.currentTool = tool;
         this.canvas.style.cursor = tool.cursor || "crosshair";
+    }
+    applyVisibility() {
+        this.canvas.style.visibility = this._visible ? "visible" : "hidden";
+    }
+    setVisible(visible, recordHistory = false) {
+        if (this._visible === visible)
+            return;
+        if (recordHistory) {
+            this.saveState();
+        }
+        this._visible = visible;
+        this.applyVisibility();
+        this.onChange?.();
+    }
+    get visible() {
+        return this._visible;
     }
     adjustForPixelRatio() {
         const dpr = window.devicePixelRatio || 1;
@@ -53,7 +78,7 @@ export class Editor {
         this.ctx.scale(1, 1);
     }
     saveState() {
-        this.undoStack.push(this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height));
+        this.undoStack.push(this.snapshot());
         if (this.undoStack.length > 50)
             this.undoStack.shift();
         this.redoStack.length = 0;
@@ -62,10 +87,12 @@ export class Editor {
     restoreState(stack, opposite) {
         if (!stack.length)
             return;
-        opposite.push(this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height));
-        const imageData = stack.pop();
+        opposite.push(this.snapshot());
+        const state = stack.pop();
         this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-        this.ctx.putImageData(imageData, 0, 0);
+        this.ctx.putImageData(state.imageData, 0, 0);
+        this._visible = state.visible;
+        this.applyVisibility();
         this.onChange?.();
     }
     undo() {

--- a/dist/editor.js
+++ b/dist/editor.js
@@ -37,6 +37,9 @@ export function initEditor() {
     const editorToolConstructors = new Map();
     let activeToolCtor = PencilTool;
     let activeLayerIndex = 0;
+    const editors = [];
+    const layerNames = [];
+    const visibilityButtons = [];
     Object.entries(toolConstructors).forEach(([id, Ctor]) => {
         const btn = document.getElementById(id);
         if (!btn) {
@@ -63,8 +66,34 @@ export function initEditor() {
     };
     const updateLayerInteractivity = () => {
         canvases.forEach((canvas, index) => {
-            canvas.style.pointerEvents = index === activeLayerIndex ? "auto" : "none";
+            const editorForLayer = editors[index];
+            const visible = editorForLayer?.visible ?? true;
+            const isActive = index === activeLayerIndex && visible;
+            canvas.style.pointerEvents = isActive ? "auto" : "none";
         });
+    };
+    const updateVisibilityButton = (index) => {
+        const button = visibilityButtons[index];
+        const editorForLayer = editors[index];
+        if (!button)
+            return;
+        if (!editorForLayer) {
+            button.disabled = true;
+            button.textContent = "-";
+            button.title = "Layer unavailable";
+            button.removeAttribute("aria-label");
+            button.removeAttribute("aria-pressed");
+            button.classList.add("is-hidden");
+            return;
+        }
+        button.disabled = false;
+        const visible = editorForLayer.visible;
+        const layerName = layerNames[index] ?? `Layer ${index + 1}`;
+        button.textContent = visible ? "👁" : "🚫";
+        button.title = `${visible ? "Hide" : "Show"} ${layerName}`;
+        button.setAttribute("aria-label", `${visible ? "Hide" : "Show"} ${layerName}`);
+        button.setAttribute("aria-pressed", String(visible));
+        button.classList.toggle("is-hidden", !visible);
     };
     const colorPicker = document.getElementById("colorPicker");
     const lineWidth = document.getElementById("lineWidth");
@@ -97,26 +126,49 @@ export function initEditor() {
     canvases.forEach((c, i) => {
         const canvasId = c.id || `layer${i + 1}`;
         const name = c.id || `Layer ${i + 1}`;
+        layerNames[i] = name;
         if (layerSelect) {
             const opt = document.createElement("option");
             opt.value = String(i);
             opt.textContent = name;
             layerSelect.appendChild(opt);
         }
-        if (!document.getElementById(`${canvasId}Opacity`) && i > 0) {
+        if (!document.getElementById(`${canvasId}Controls`)) {
             const group = document.createElement("div");
-            group.className = "group";
+            if (!(group instanceof HTMLElement)) {
+                return;
+            }
+            group.className = "group layer-controls";
+            group.id = `${canvasId}Controls`;
             const label = document.createElement("label");
-            label.htmlFor = `${canvasId}Opacity`;
-            label.textContent = `${name} Opacity`;
-            const input = document.createElement("input");
-            input.id = `${canvasId}Opacity`;
-            input.type = "number";
-            input.min = "0";
-            input.max = "100";
-            input.value = "100";
+            if (!(label instanceof HTMLElement)) {
+                return;
+            }
+            label.textContent = name;
             group.appendChild(label);
-            group.appendChild(input);
+            const toggle = document.createElement("button");
+            if (!(toggle instanceof HTMLElement)) {
+                return;
+            }
+            toggle.type = "button";
+            toggle.className = "layer-visibility-toggle";
+            toggle.id = `${canvasId}Visibility`;
+            toggle.textContent = "👁";
+            group.appendChild(toggle);
+            visibilityButtons[i] = toggle;
+            if (i > 0) {
+                label.htmlFor = `${canvasId}Opacity`;
+                const input = document.createElement("input");
+                if (!(input instanceof HTMLElement)) {
+                    return;
+                }
+                input.id = `${canvasId}Opacity`;
+                input.type = "number";
+                input.min = "0";
+                input.max = "100";
+                input.value = "100";
+                group.appendChild(input);
+            }
             toolbar.appendChild(group);
         }
     });
@@ -161,19 +213,21 @@ export function initEditor() {
         if (redoBtn)
             redoBtn.disabled = !editor?.canRedo;
     };
-    const editors = [];
-    canvases.forEach((c) => {
+    canvases.forEach((c, canvasIndex) => {
         try {
             const e = new Editor(c, colorPicker, lineWidth, fillMode, () => {
                 updateHistoryButtons();
+                updateVisibilityButton(canvasIndex);
+                updateLayerInteractivity();
             }, fontFamily ?? undefined, fontSize ?? undefined);
-            editors.push(e);
+            editors[canvasIndex] = e;
         }
         catch {
             /* skip canvases without 2D context */
         }
     });
-    if (editors.length === 0) {
+    const firstEditorIndex = editors.findIndex((ed) => !!ed);
+    if (firstEditorIndex === -1) {
         throw new Error("initEditor() requires at least one <canvas> element with a 2D context");
     }
     editors.forEach((e) => {
@@ -187,11 +241,14 @@ export function initEditor() {
         };
     });
     // active editor defaults to the first successfully created editor
-    editor = editors[0];
+    editor = editors[firstEditorIndex];
+    activeLayerIndex = firstEditorIndex;
     // default tool
     editor.setTool(new PencilTool());
     editorToolConstructors.set(editor, PencilTool);
     updateLayerInteractivity();
+    if (layerSelect)
+        layerSelect.value = String(activeLayerIndex);
     // keyboard shortcuts
     const shortcuts = new Shortcuts(editor);
     // map button id to tool constructor
@@ -216,7 +273,10 @@ export function initEditor() {
             exportCanvas.width = canvases[0].width;
             exportCanvas.height = canvases[0].height;
             const tempCtx = exportCanvas.getContext("2d");
-            canvases.forEach((cv) => {
+            canvases.forEach((cv, idx) => {
+                const editorForLayer = editors[idx];
+                if (editorForLayer && !editorForLayer.visible)
+                    return;
                 const opacity = parseFloat(cv.style.opacity) || 1;
                 tempCtx.globalAlpha = opacity;
                 tempCtx.drawImage(cv, 0, 0);
@@ -274,17 +334,34 @@ export function initEditor() {
     function activateLayer(index) {
         if (index < 0 || index >= editors.length)
             return;
+        const targetEditor = editors[index];
+        if (!targetEditor)
+            return;
         activeLayerIndex = index;
-        editor = editors[index];
+        editor = targetEditor;
         handle.editor = editor;
         shortcuts.switchEditor(editor);
         updateLayerInteractivity();
         const ToolCtor = editorToolConstructors.get(editor) ?? activeToolCtor;
         editor.setTool(new ToolCtor());
         updateHistoryButtons();
+        updateVisibilityButton(index);
         if (layerSelect)
             layerSelect.value = String(index);
     }
+    visibilityButtons.forEach((button, index) => {
+        listen(button, "click", () => {
+            const editorForLayer = editors[index];
+            if (!editorForLayer)
+                return;
+            const nextVisible = !editorForLayer.visible;
+            editorForLayer.setVisible(nextVisible, true);
+            updateVisibilityButton(index);
+            updateLayerInteractivity();
+            updateHistoryButtons();
+        }, listeners);
+        updateVisibilityButton(index);
+    });
     const handle = {
         editor,
         editors,

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -1,10 +1,15 @@
 import { Tool } from "../tools/Tool.js";
 
+type CanvasState = {
+  imageData: ImageData;
+  visible: boolean;
+};
+
 export class Editor {
   canvas: HTMLCanvasElement;
   ctx: CanvasRenderingContext2D;
-  private undoStack: ImageData[] = [];
-  private redoStack: ImageData[] = [];
+  private undoStack: CanvasState[] = [];
+  private redoStack: CanvasState[] = [];
   private currentTool: Tool | null = null;
   colorPicker: HTMLInputElement;
   lineWidth: HTMLInputElement;
@@ -12,6 +17,7 @@ export class Editor {
   fontFamily: HTMLSelectElement | null;
   fontSize: HTMLInputElement | null;
   private onChange?: () => void;
+  private _visible = true;
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -32,6 +38,8 @@ export class Editor {
     this.onChange = onChange;
     this.fontFamily = fontFamily ?? null;
     this.fontSize = fontSize ?? null;
+    this._visible = this.canvas.style.visibility !== "hidden";
+    this.applyVisibility();
     this.adjustForPixelRatio();
     window.addEventListener("resize", this.handleResize);
 
@@ -40,10 +48,35 @@ export class Editor {
     this.canvas.addEventListener("pointerup", this.handlePointerUp);
   }
 
+  private snapshot(): CanvasState {
+    return {
+      imageData: this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height),
+      visible: this._visible,
+    };
+  }
+
   setTool(tool: Tool) {
     this.currentTool?.destroy?.();
     this.currentTool = tool;
     this.canvas.style.cursor = tool.cursor || "crosshair";
+  }
+
+  private applyVisibility() {
+    this.canvas.style.visibility = this._visible ? "visible" : "hidden";
+  }
+
+  setVisible(visible: boolean, recordHistory = false) {
+    if (this._visible === visible) return;
+    if (recordHistory) {
+      this.saveState();
+    }
+    this._visible = visible;
+    this.applyVisibility();
+    this.onChange?.();
+  }
+
+  get visible() {
+    return this._visible;
   }
 
   private handlePointerDown = (e: PointerEvent) => {
@@ -84,22 +117,20 @@ export class Editor {
   };
 
   saveState() {
-    this.undoStack.push(
-      this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height),
-    );
+    this.undoStack.push(this.snapshot());
     if (this.undoStack.length > 50) this.undoStack.shift();
     this.redoStack.length = 0;
     this.onChange?.();
   }
 
-  private restoreState(stack: ImageData[], opposite: ImageData[]) {
+  private restoreState(stack: CanvasState[], opposite: CanvasState[]) {
     if (!stack.length) return;
-    opposite.push(
-      this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height),
-    );
-    const imageData = stack.pop()!;
+    opposite.push(this.snapshot());
+    const state = stack.pop()!;
     this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-    this.ctx.putImageData(imageData, 0, 0);
+    this.ctx.putImageData(state.imageData, 0, 0);
+    this._visible = state.visible;
+    this.applyVisibility();
     this.onChange?.();
   }
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -55,6 +55,9 @@ export function initEditor(): EditorHandle {
   const editorToolConstructors = new Map<Editor, new () => Tool>();
   let activeToolCtor: new () => Tool = PencilTool;
   let activeLayerIndex = 0;
+  const editors: Editor[] = [];
+  const layerNames: string[] = [];
+  const visibilityButtons: Array<HTMLButtonElement | null> = [];
   Object.entries(toolConstructors).forEach(([id, Ctor]) => {
     const btn = document.getElementById(id) as HTMLButtonElement | null;
     if (!btn) {
@@ -81,8 +84,34 @@ export function initEditor(): EditorHandle {
 
   const updateLayerInteractivity = () => {
     canvases.forEach((canvas, index) => {
-      canvas.style.pointerEvents = index === activeLayerIndex ? "auto" : "none";
+      const editorForLayer = editors[index];
+      const visible = editorForLayer?.visible ?? true;
+      const isActive = index === activeLayerIndex && visible;
+      canvas.style.pointerEvents = isActive ? "auto" : "none";
     });
+  };
+
+  const updateVisibilityButton = (index: number) => {
+    const button = visibilityButtons[index];
+    const editorForLayer = editors[index];
+    if (!button) return;
+    if (!editorForLayer) {
+      button.disabled = true;
+      button.textContent = "-";
+      button.title = "Layer unavailable";
+      button.removeAttribute("aria-label");
+      button.removeAttribute("aria-pressed");
+      button.classList.add("is-hidden");
+      return;
+    }
+    button.disabled = false;
+    const visible = editorForLayer.visible;
+    const layerName = layerNames[index] ?? `Layer ${index + 1}`;
+    button.textContent = visible ? "👁" : "🚫";
+    button.title = `${visible ? "Hide" : "Show"} ${layerName}`;
+    button.setAttribute("aria-label", `${visible ? "Hide" : "Show"} ${layerName}`);
+    button.setAttribute("aria-pressed", String(visible));
+    button.classList.toggle("is-hidden", !visible);
   };
 
   const colorPicker =
@@ -123,6 +152,7 @@ export function initEditor(): EditorHandle {
   canvases.forEach((c, i) => {
     const canvasId = c.id || `layer${i + 1}`;
     const name = c.id || `Layer ${i + 1}`;
+    layerNames[i] = name;
 
     if (layerSelect) {
       const opt = document.createElement("option");
@@ -131,23 +161,46 @@ export function initEditor(): EditorHandle {
       layerSelect.appendChild(opt);
     }
 
-    if (!document.getElementById(`${canvasId}Opacity`) && i > 0) {
+    if (!document.getElementById(`${canvasId}Controls`)) {
       const group = document.createElement("div");
-      group.className = "group";
+      if (!(group instanceof HTMLElement)) {
+        return;
+      }
+      group.className = "group layer-controls";
+      group.id = `${canvasId}Controls`;
 
       const label = document.createElement("label");
-      label.htmlFor = `${canvasId}Opacity`;
-      label.textContent = `${name} Opacity`;
-
-      const input = document.createElement("input");
-      input.id = `${canvasId}Opacity`;
-      input.type = "number";
-      input.min = "0";
-      input.max = "100";
-      input.value = "100";
-
+      if (!(label instanceof HTMLElement)) {
+        return;
+      }
+      label.textContent = name;
       group.appendChild(label);
-      group.appendChild(input);
+
+      const toggle = document.createElement("button");
+      if (!(toggle instanceof HTMLElement)) {
+        return;
+      }
+      toggle.type = "button";
+      toggle.className = "layer-visibility-toggle";
+      toggle.id = `${canvasId}Visibility`;
+      toggle.textContent = "👁";
+      group.appendChild(toggle);
+      visibilityButtons[i] = toggle;
+
+      if (i > 0) {
+        label.htmlFor = `${canvasId}Opacity`;
+        const input = document.createElement("input");
+        if (!(input instanceof HTMLElement)) {
+          return;
+        }
+        input.id = `${canvasId}Opacity`;
+        input.type = "number";
+        input.min = "0";
+        input.max = "100";
+        input.value = "100";
+        group.appendChild(input);
+      }
+
       toolbar.appendChild(group);
     }
   });
@@ -199,8 +252,7 @@ export function initEditor(): EditorHandle {
     if (redoBtn) redoBtn.disabled = !editor?.canRedo;
   };
 
-  const editors: Editor[] = [];
-  canvases.forEach((c) => {
+  canvases.forEach((c, canvasIndex) => {
     try {
       const e = new Editor(
         c,
@@ -209,17 +261,21 @@ export function initEditor(): EditorHandle {
         fillMode,
         () => {
           updateHistoryButtons();
+          updateVisibilityButton(canvasIndex);
+          updateLayerInteractivity();
         },
         fontFamily ?? undefined,
         fontSize ?? undefined,
       );
-      editors.push(e);
+      editors[canvasIndex] = e;
     } catch {
       /* skip canvases without 2D context */
     }
   });
 
-  if (editors.length === 0) {
+  const firstEditorIndex = editors.findIndex((ed) => !!ed);
+
+  if (firstEditorIndex === -1) {
     throw new Error(
       "initEditor() requires at least one <canvas> element with a 2D context",
     );
@@ -237,12 +293,14 @@ export function initEditor(): EditorHandle {
   });
 
   // active editor defaults to the first successfully created editor
-  editor = editors[0];
+  editor = editors[firstEditorIndex]!;
+  activeLayerIndex = firstEditorIndex;
 
   // default tool
   editor.setTool(new PencilTool());
   editorToolConstructors.set(editor, PencilTool);
   updateLayerInteractivity();
+  if (layerSelect) layerSelect.value = String(activeLayerIndex);
 
   // keyboard shortcuts
   const shortcuts = new Shortcuts(editor);
@@ -289,7 +347,9 @@ export function initEditor(): EditorHandle {
         exportCanvas.width = canvases[0].width;
         exportCanvas.height = canvases[0].height;
         const tempCtx = exportCanvas.getContext("2d")!;
-        canvases.forEach((cv) => {
+        canvases.forEach((cv, idx) => {
+          const editorForLayer = editors[idx];
+          if (editorForLayer && !editorForLayer.visible) return;
           const opacity = parseFloat(cv.style.opacity) || 1;
           tempCtx.globalAlpha = opacity;
           tempCtx.drawImage(cv, 0, 0);
@@ -371,16 +431,37 @@ export function initEditor(): EditorHandle {
 
   function activateLayer(index: number) {
     if (index < 0 || index >= editors.length) return;
+    const targetEditor = editors[index];
+    if (!targetEditor) return;
     activeLayerIndex = index;
-    editor = editors[index];
+    editor = targetEditor;
     handle.editor = editor;
     shortcuts.switchEditor(editor);
     updateLayerInteractivity();
     const ToolCtor = editorToolConstructors.get(editor) ?? activeToolCtor;
     editor.setTool(new ToolCtor());
     updateHistoryButtons();
+    updateVisibilityButton(index);
     if (layerSelect) layerSelect.value = String(index);
   }
+
+  visibilityButtons.forEach((button, index) => {
+    listen(
+      button,
+      "click",
+      () => {
+        const editorForLayer = editors[index];
+        if (!editorForLayer) return;
+        const nextVisible = !editorForLayer.visible;
+        editorForLayer.setVisible(nextVisible, true);
+        updateVisibilityButton(index);
+        updateLayerInteractivity();
+        updateHistoryButtons();
+      },
+      listeners,
+    );
+    updateVisibilityButton(index);
+  });
 
   const handle: EditorHandle = {
     editor,

--- a/style.css
+++ b/style.css
@@ -47,6 +47,32 @@ body {
   gap: 8px;
 }
 
+.layer-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.layer-visibility-toggle {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid #ccc;
+  background: #fff;
+  cursor: pointer;
+}
+
+.layer-visibility-toggle:hover {
+  background: #f0f0f0;
+}
+
+.layer-visibility-toggle.is-hidden {
+  opacity: 0.6;
+}
+
 .tool-button {
   width: 32px;
   height: 32px;


### PR DESCRIPTION
## Summary
- add per-layer visibility toggles in the toolbar and sync them with editor state
- track layer visibility inside the editor so undo/redo and exports respect hidden layers
- style the new visibility controls to match existing toolbar buttons

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60d1fb57083288690fde94d9b4fb5