### PR TITLE
Add dynamic layer management controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,20 @@
         <label for="layerSelect">Layer</label>
         <select id="layerSelect"></select>
       </div>
+      <div class="group layer-actions">
+        <button id="addLayer" class="tool-button" title="Add layer">+</button>
+        <button
+          id="removeLayer"
+          class="tool-button"
+          title="Remove layer"
+          disabled
+        >
+          –
+        </button>
+        <button id="renameLayer" class="tool-button" title="Rename layer">
+          Rename
+        </button>
+      </div>
       <select id="formatSelect">
         <option value="png">PNG</option>
         <option value="jpeg">JPEG</option>

--- a/src/core/LayerManager.ts
+++ b/src/core/LayerManager.ts
@@ -1,0 +1,262 @@
+import { Editor } from "./Editor.js";
+
+interface LayerEntry {
+  canvas: HTMLCanvasElement;
+  editor: Editor;
+  name: string;
+  option: HTMLOptionElement | null;
+  opacityGroup: HTMLDivElement | null;
+  opacityInput: HTMLInputElement | null;
+  opacityLabel: HTMLLabelElement | null;
+  cleanup?: () => void;
+}
+
+export interface LayerManagerOptions {
+  canvases: HTMLCanvasElement[];
+  canvasContainer: HTMLElement;
+  toolbar: HTMLElement;
+  layerSelect: HTMLSelectElement | null;
+  colorPicker: HTMLInputElement;
+  lineWidth: HTMLInputElement;
+  fillMode: HTMLInputElement;
+  onHistoryChange: () => void;
+  fontFamily?: HTMLSelectElement | null;
+  fontSize?: HTMLInputElement | null;
+}
+
+/**
+ * Handles dynamic creation, destruction and metadata for editor layers.
+ */
+export class LayerManager {
+  readonly editors: Editor[] = [];
+  private layers: LayerEntry[] = [];
+  private activeIndex = 0;
+  private readonly options: LayerManagerOptions;
+
+  constructor(options: LayerManagerOptions) {
+    this.options = options;
+    this.options.layerSelect?.replaceChildren();
+    options.canvases.forEach((canvas) => {
+      this.addCanvas(canvas, canvas.dataset.layerName || canvas.id);
+    });
+    if (this.layers.length === 0) {
+      throw new Error(
+        "LayerManager requires at least one canvas element with a 2D context",
+      );
+    }
+    this.activateLayer(0);
+  }
+
+  get length(): number {
+    return this.layers.length;
+  }
+
+  get activeLayerIndex(): number {
+    return this.activeIndex;
+  }
+
+  get activeEditor(): Editor {
+    return this.layers[this.activeIndex].editor;
+  }
+
+  get layerNames(): string[] {
+    return this.layers.map((layer) => layer.name);
+  }
+
+  createLayer(name?: string): number {
+    const base = this.layers[0].canvas;
+    const canvas = document.createElement("canvas");
+    canvas.width = base.width;
+    canvas.height = base.height;
+    canvas.style.width = base.style.width;
+    canvas.style.height = base.style.height;
+    canvas.dataset.layerName = name ?? "";
+    this.options.canvasContainer.appendChild(canvas);
+    const idx = this.addCanvas(canvas, name);
+    if (idx === null) {
+      return this.activeIndex;
+    }
+    this.activateLayer(idx);
+    return idx;
+  }
+
+  removeLayer(index: number): boolean {
+    if (this.layers.length <= 1) {
+      return false;
+    }
+    if (index < 0 || index >= this.layers.length) {
+      return false;
+    }
+    const [removed] = this.layers.splice(index, 1);
+    const editorIndex = this.editors.indexOf(removed.editor);
+    if (editorIndex !== -1) {
+      this.editors.splice(editorIndex, 1);
+    }
+    removed.editor.destroy();
+    removed.canvas.remove();
+    removed.option?.remove();
+    removed.opacityGroup?.remove();
+    removed.cleanup?.();
+    this.refreshLayerMetadata();
+    if (this.activeIndex >= this.layers.length) {
+      this.activeIndex = this.layers.length - 1;
+    }
+    this.activateLayer(this.activeIndex);
+    return true;
+  }
+
+  renameLayer(index: number, newName: string) {
+    const layer = this.layers[index];
+    if (!layer) return;
+    layer.name = newName;
+    layer.canvas.dataset.layerName = newName;
+    if (layer.option) {
+      layer.option.textContent = newName;
+    }
+    if (layer.opacityLabel) {
+      layer.opacityLabel.textContent = `${newName} Opacity`;
+    }
+  }
+
+  activateLayer(index: number): boolean {
+    if (index < 0 || index >= this.layers.length) return false;
+    this.activeIndex = index;
+    this.layers.forEach((layer, i) => {
+      layer.canvas.style.pointerEvents = i === index ? "auto" : "none";
+    });
+    if (this.options.layerSelect) {
+      this.options.layerSelect.value = String(index);
+    }
+    return true;
+  }
+
+  destroy() {
+    this.layers.forEach((layer) => {
+      layer.editor.destroy();
+      layer.cleanup?.();
+    });
+    this.layers = [];
+    this.editors.length = 0;
+  }
+
+  private addCanvas(canvas: HTMLCanvasElement, name?: string): number | null {
+    const layerName =
+      name && name.trim().length > 0
+        ? name
+        : `Layer ${this.layers.length + 1}`;
+    const editor = this.instantiateEditor(canvas);
+    if (!editor) return null;
+    const option = this.options.layerSelect
+      ? document.createElement("option")
+      : null;
+    if (option) {
+      option.value = String(this.layers.length);
+      option.textContent = layerName;
+      this.options.layerSelect!.appendChild(option);
+    }
+    const opacity = this.layers.length === 0 ? null : this.createOpacityControls(canvas, layerName);
+
+    const entry: LayerEntry = {
+      canvas,
+      editor,
+      name: layerName,
+      option,
+      opacityGroup: opacity?.group ?? null,
+      opacityInput: opacity?.input ?? null,
+      opacityLabel: opacity?.label ?? null,
+      cleanup: opacity?.cleanup,
+    };
+    canvas.dataset.layerName = layerName;
+    this.layers.push(entry);
+    this.editors.push(editor);
+    this.refreshLayerMetadata();
+    return this.layers.length - 1;
+  }
+
+  private instantiateEditor(canvas: HTMLCanvasElement): Editor | null {
+    try {
+      return new Editor(
+        canvas,
+        this.options.colorPicker,
+        this.options.lineWidth,
+        this.options.fillMode,
+        this.options.onHistoryChange,
+        this.options.fontFamily ?? undefined,
+        this.options.fontSize ?? undefined,
+      );
+    } catch {
+      canvas.remove();
+      return null;
+    }
+  }
+
+  private createOpacityControls(canvas: HTMLCanvasElement, name: string) {
+    const id = `${canvas.id || `layer${Date.now()}`}Opacity`;
+    const existing = document.getElementById(id) as HTMLInputElement | null;
+    let group: HTMLDivElement | null = null;
+    let label: HTMLLabelElement | null = null;
+    let input: HTMLInputElement;
+
+    if (existing) {
+      input = existing;
+      input.type = "number";
+      input.min = input.min || "0";
+      input.max = input.max || "100";
+      input.value = input.value || "100";
+      label = existing.previousElementSibling instanceof HTMLLabelElement
+        ? existing.previousElementSibling
+        : null;
+      if (label) {
+        label.htmlFor = id;
+        label.textContent = `${name} Opacity`;
+      }
+      group = existing.closest(".group") as HTMLDivElement | null;
+    } else {
+      group = document.createElement("div");
+      group.className = "group";
+
+      label = document.createElement("label");
+      label.htmlFor = id;
+      label.textContent = `${name} Opacity`;
+
+      input = document.createElement("input");
+      input.id = id;
+      input.type = "number";
+      input.min = "0";
+      input.max = "100";
+      input.value = "100";
+      group.appendChild(label);
+      group.appendChild(input);
+      this.options.toolbar.appendChild(group);
+    }
+
+    const handler = () => {
+      const value = parseFloat(input.value);
+      canvas.style.opacity = isNaN(value) ? "1" : String(value / 100);
+    };
+    input.addEventListener("input", handler);
+
+    return {
+      group,
+      input,
+      label,
+      cleanup: () => input.removeEventListener("input", handler),
+    };
+  }
+
+  private refreshLayerMetadata() {
+    this.layers.forEach((layer, index) => {
+      if (layer.option) {
+        layer.option.value = String(index);
+      }
+      if (layer.opacityLabel) {
+        layer.opacityLabel.textContent = `${layer.name} Opacity`;
+      }
+      layer.canvas.style.zIndex = String(index);
+    });
+    if (this.options.layerSelect) {
+      this.options.layerSelect.value = String(this.activeIndex);
+    }
+  }
+}
+

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,5 +1,6 @@
 import { Editor } from "./core/Editor.js";
 import { Shortcuts } from "./core/Shortcuts.js";
+import { LayerManager } from "./core/LayerManager.js";
 import { PencilTool } from "./tools/PencilTool.js";
 import { EraserTool } from "./tools/EraserTool.js";
 import { RectangleTool } from "./tools/RectangleTool.js";
@@ -27,6 +28,10 @@ export interface EditorHandle {
   editor: Editor;
   editors: Editor[];
   activateLayer(index: number): void;
+  addLayer(name?: string): number;
+  removeLayer(index?: number): boolean;
+  renameLayer(index: number, name: string): void;
+  getLayerNames(): string[];
   destroy(): void;
 }
 
@@ -54,7 +59,6 @@ export function initEditor(): EditorHandle {
   const constructorToId = new Map<new () => Tool, string>();
   const editorToolConstructors = new Map<Editor, new () => Tool>();
   let activeToolCtor: new () => Tool = PencilTool;
-  let activeLayerIndex = 0;
   Object.entries(toolConstructors).forEach(([id, Ctor]) => {
     const btn = document.getElementById(id) as HTMLButtonElement | null;
     if (!btn) {
@@ -79,12 +83,6 @@ export function initEditor(): EditorHandle {
     return null;
   };
 
-  const updateLayerInteractivity = () => {
-    canvases.forEach((canvas, index) => {
-      canvas.style.pointerEvents = index === activeLayerIndex ? "auto" : "none";
-    });
-  };
-
   const colorPicker =
     document.getElementById("colorPicker") as HTMLInputElement | null;
   const lineWidth = document.getElementById("lineWidth") as HTMLInputElement | null;
@@ -92,6 +90,9 @@ export function initEditor(): EditorHandle {
   const fontFamily = document.getElementById("fontFamily") as HTMLSelectElement | null;
   const fontSize = document.getElementById("fontSize") as HTMLInputElement | null;
   const layerSelect = document.getElementById("layerSelect") as HTMLSelectElement | null;
+  const addLayerBtn = document.getElementById("addLayer") as HTMLButtonElement | null;
+  const removeLayerBtn = document.getElementById("removeLayer") as HTMLButtonElement | null;
+  const renameLayerBtn = document.getElementById("renameLayer") as HTMLButtonElement | null;
   const toolbar = document.getElementById("toolbar") || document.body;
   const saveBtn = document.getElementById("save") as HTMLButtonElement | null;
   const formatSelect =
@@ -115,42 +116,6 @@ export function initEditor(): EditorHandle {
   if (!formatSelect) {
     throw new Error("Missing #formatSelect select");
   }
-
-  if (layerSelect) {
-    layerSelect.innerHTML = "";
-  }
-
-  canvases.forEach((c, i) => {
-    const canvasId = c.id || `layer${i + 1}`;
-    const name = c.id || `Layer ${i + 1}`;
-
-    if (layerSelect) {
-      const opt = document.createElement("option");
-      opt.value = String(i);
-      opt.textContent = name;
-      layerSelect.appendChild(opt);
-    }
-
-    if (!document.getElementById(`${canvasId}Opacity`) && i > 0) {
-      const group = document.createElement("div");
-      group.className = "group";
-
-      const label = document.createElement("label");
-      label.htmlFor = `${canvasId}Opacity`;
-      label.textContent = `${name} Opacity`;
-
-      const input = document.createElement("input");
-      input.id = `${canvasId}Opacity`;
-      input.type = "number";
-      input.min = "0";
-      input.max = "100";
-      input.value = "100";
-
-      group.appendChild(label);
-      group.appendChild(input);
-      toolbar.appendChild(group);
-    }
-  });
 
   const undoBtn = document.getElementById("undo") as HTMLButtonElement | null;
   const redoBtn = document.getElementById("redo") as HTMLButtonElement | null;
@@ -192,38 +157,38 @@ export function initEditor(): EditorHandle {
     listeners,
   );
 
-  let editor: Editor; // set after editors created
-
   const updateHistoryButtons = () => {
     if (undoBtn) undoBtn.disabled = !editor?.canUndo;
     if (redoBtn) redoBtn.disabled = !editor?.canRedo;
   };
 
-  const editors: Editor[] = [];
-  canvases.forEach((c) => {
-    try {
-      const e = new Editor(
-        c,
-        colorPicker,
-        lineWidth,
-        fillMode,
-        () => {
-          updateHistoryButtons();
-        },
-        fontFamily ?? undefined,
-        fontSize ?? undefined,
-      );
-      editors.push(e);
-    } catch {
-      /* skip canvases without 2D context */
-    }
+  const canvasContainer =
+    document.getElementById("canvasContainer") || canvases[0]?.parentElement;
+  if (!canvasContainer) {
+    throw new Error("Missing canvas container element");
+  }
+
+  const layerManager = new LayerManager({
+    canvases,
+    canvasContainer,
+    toolbar,
+    layerSelect,
+    colorPicker,
+    lineWidth,
+    fillMode,
+    onHistoryChange: () => updateHistoryButtons(),
+    fontFamily: fontFamily ?? undefined,
+    fontSize: fontSize ?? undefined,
   });
 
-  if (editors.length === 0) {
+  if (layerManager.length === 0) {
     throw new Error(
       "initEditor() requires at least one <canvas> element with a 2D context",
     );
   }
+
+  const editors = layerManager.editors;
+  let editor: Editor = layerManager.activeEditor;
 
   editors.forEach((e) => {
     const original = e.setTool.bind(e);
@@ -237,12 +202,10 @@ export function initEditor(): EditorHandle {
   });
 
   // active editor defaults to the first successfully created editor
-  editor = editors[0];
-
   // default tool
   editor.setTool(new PencilTool());
   editorToolConstructors.set(editor, PencilTool);
-  updateLayerInteractivity();
+  layerManager.activateLayer(0);
 
   // keyboard shortcuts
   const shortcuts = new Shortcuts(editor);
@@ -341,23 +304,6 @@ export function initEditor(): EditorHandle {
     listeners,
   );
 
-  document
-    .querySelectorAll<HTMLInputElement>('input[id$="Opacity"]')
-    .forEach((input) => {
-      const targetId = input.id.replace(/Opacity$/, "");
-      const layer = document.getElementById(targetId) as HTMLCanvasElement | null;
-      if (!layer) return;
-      listen(
-        input,
-        "input",
-        () => {
-          const value = parseFloat(input.value);
-          layer.style.opacity = isNaN(value) ? "1" : String(value / 100);
-        },
-        listeners,
-      );
-    });
-
   // layer selection
   listen(
     layerSelect,
@@ -369,27 +315,107 @@ export function initEditor(): EditorHandle {
     listeners,
   );
 
-  function activateLayer(index: number) {
-    if (index < 0 || index >= editors.length) return;
-    activeLayerIndex = index;
-    editor = editors[index];
+  const updateLayerControls = () => {
+    if (removeLayerBtn) {
+      removeLayerBtn.disabled = layerManager.length <= 1;
+    }
+    if (renameLayerBtn) {
+      renameLayerBtn.disabled = layerManager.length === 0;
+    }
+  };
+
+  const activateLayer = (index: number) => {
+    if (!layerManager.activateLayer(index)) return;
+    editor = layerManager.activeEditor;
     handle.editor = editor;
     shortcuts.switchEditor(editor);
-    updateLayerInteractivity();
     const ToolCtor = editorToolConstructors.get(editor) ?? activeToolCtor;
     editor.setTool(new ToolCtor());
     updateHistoryButtons();
     if (layerSelect) layerSelect.value = String(index);
-  }
+    updateLayerControls();
+  };
+
+  const addLayer = (name?: string) => {
+    const index = layerManager.createLayer(name);
+    const newEditor = layerManager.activeEditor;
+    editorToolConstructors.set(newEditor, activeToolCtor);
+    handle.editors = layerManager.editors;
+    activateLayer(index);
+    return index;
+  };
+
+  const removeLayer = (index = layerManager.activeLayerIndex) => {
+    const removed = layerManager.removeLayer(index);
+    if (!removed) return false;
+    handle.editors = layerManager.editors;
+    activateLayer(layerManager.activeLayerIndex);
+    return true;
+  };
+
+  const renameLayer = (index: number, newName: string) => {
+    layerManager.renameLayer(index, newName);
+    updateLayerControls();
+  };
+
+  const promptRename = () => {
+    const idx = layerManager.activeLayerIndex;
+    const currentName = layerManager.layerNames[idx];
+    const next = window.prompt("Layer name", currentName);
+    if (!next || next.trim() === "") return;
+    renameLayer(idx, next.trim());
+  };
+
+  listen(addLayerBtn, "click", () => addLayer(), listeners);
+  listen(removeLayerBtn, "click", () => removeLayer(), listeners);
+  listen(renameLayerBtn, "click", () => promptRename(), listeners);
+
+  const isTextInput = (target: EventTarget | null) => {
+    if (!(target instanceof HTMLElement)) return false;
+    const tag = target.tagName.toLowerCase();
+    return (
+      target.isContentEditable ||
+      tag === "input" ||
+      tag === "textarea" ||
+      tag === "select"
+    );
+  };
+
+  const shortcutHandler = (event: KeyboardEvent) => {
+    if (isTextInput(event.target)) return;
+    const key = event.key.toLowerCase();
+    const ctrl = event.ctrlKey || event.metaKey;
+    if (!ctrl || !event.shiftKey) return;
+
+    if (key === "n") {
+      event.preventDefault();
+      addLayer();
+    } else if (key === "d") {
+      event.preventDefault();
+      removeLayer();
+    } else if (key === "r") {
+      event.preventDefault();
+      promptRename();
+    }
+  };
+
+  document.addEventListener("keydown", shortcutHandler);
+  listeners.push(() => document.removeEventListener("keydown", shortcutHandler));
+
+  updateLayerControls();
 
   const handle: EditorHandle = {
     editor,
     editors,
     activateLayer,
+    addLayer,
+    removeLayer,
+    renameLayer,
+    getLayerNames: () => layerManager.layerNames.slice(),
     destroy() {
       listeners.forEach((fn) => fn());
       shortcuts.destroy();
-      editors.forEach((e) => e.destroy());
+      layerManager.destroy();
     },
   };
   recordColor(colorPicker.value);

--- a/tests/layers.test.ts
+++ b/tests/layers.test.ts
@@ -8,6 +8,9 @@ describe("layer-specific undo/redo", () => {
   let ctx2: Partial<CanvasRenderingContext2D>;
   let undoBtn: HTMLButtonElement;
   let redoBtn: HTMLButtonElement;
+  const originalGetContext = HTMLCanvasElement.prototype.getContext;
+  const originalGetBoundingClientRect =
+    HTMLCanvasElement.prototype.getBoundingClientRect;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -28,7 +31,10 @@ describe("layer-specific undo/redo", () => {
       <button id="save"></button>
       <button id="undo"></button>
       <button id="redo"></button>
-    `;
+      <button id="addLayer"></button>
+      <button id="removeLayer"></button>
+      <button id="renameLayer"></button>
+      `;
 
     canvas1 = document.getElementById("c1") as HTMLCanvasElement;
     canvas2 = document.getElementById("c2") as HTMLCanvasElement;
@@ -75,13 +81,32 @@ describe("layer-specific undo/redo", () => {
     canvas1.getContext = jest.fn().mockReturnValue(ctx1 as any);
     canvas2.getContext = jest.fn().mockReturnValue(ctx2 as any);
     canvas1.getBoundingClientRect = canvas2.getBoundingClientRect = () => rect;
+    HTMLCanvasElement.prototype.getContext = jest
+      .fn()
+      .mockReturnValue({
+        clearRect: jest.fn(),
+        putImageData: jest.fn(),
+        getImageData: jest.fn().mockReturnValue({
+          data: new Uint8ClampedArray(),
+          width: 1,
+          height: 1,
+        } as ImageData),
+        setTransform: jest.fn(),
+        scale: jest.fn(),
+      } as Partial<CanvasRenderingContext2D> as CanvasRenderingContext2D);
+    HTMLCanvasElement.prototype.getBoundingClientRect = () => rect;
 
     handle = initEditor();
     undoBtn = document.getElementById("undo") as HTMLButtonElement;
     redoBtn = document.getElementById("redo") as HTMLButtonElement;
   });
 
-  afterEach(() => handle.destroy());
+  afterEach(() => {
+    handle.destroy();
+    HTMLCanvasElement.prototype.getContext = originalGetContext;
+    HTMLCanvasElement.prototype.getBoundingClientRect =
+      originalGetBoundingClientRect;
+  });
 
   it("targets the active layer and toggles button states", () => {
     // initially disabled
@@ -123,6 +148,23 @@ describe("layer-specific undo/redo", () => {
 
     expect(canvases[0].style.pointerEvents).toBe("none");
     expect(canvases[1].style.pointerEvents).toBe("auto");
+  });
+
+  it("supports adding, renaming and removing layers", () => {
+    const addSpy = jest.spyOn(handle, "addLayer");
+    const removeSpy = jest.spyOn(handle, "removeLayer");
+
+    const newIndex = handle.addLayer("Sketch");
+    expect(addSpy).toHaveReturnedWith(newIndex);
+    expect(handle.getLayerNames()).toContain("Sketch");
+
+    handle.renameLayer(newIndex, "Inked");
+    expect(handle.getLayerNames()).toContain("Inked");
+
+    const removed = handle.removeLayer(newIndex);
+    expect(removeSpy).toHaveReturnedWith(true);
+    expect(removed).toBe(true);
+    expect(handle.getLayerNames()).not.toContain("Inked");
   });
 });
 


### PR DESCRIPTION
## Summary
- add a LayerManager to create, destroy, and rename canvases while keeping editor state and opacity controls in sync
- wire add/remove/rename controls and keyboard shortcuts into the editor handle, exposing helpers for tests and consumers
- update the toolbar markup and layer tests to cover the new controls and behaviour

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d60d1d1f508328b0cfe167f987a6ec