### PR TITLE
Add clone stamp tool with brush preview and tests

### DIFF
--- a/dist/core/Editor.js
+++ b/dist/core/Editor.js
@@ -6,7 +6,9 @@ export class Editor {
         this.handlePointerDown = (e) => {
             // Capture the pointer once before recording canvas state
             this.canvas.setPointerCapture(e.pointerId);
-            this.saveState();
+            if (!e.altKey) {
+                this.saveState();
+            }
             this.currentTool?.onPointerDown(e, this);
         };
         this.handlePointerMove = (e) => {

--- a/dist/core/Shortcuts.js
+++ b/dist/core/Shortcuts.js
@@ -6,6 +6,7 @@ import { TextTool } from "../tools/TextTool.js";
 import { EraserTool } from "../tools/EraserTool.js";
 import { BucketFillTool } from "../tools/BucketFillTool.js";
 import { EyedropperTool } from "../tools/EyedropperTool.js";
+import { CloneStampTool } from "../tools/CloneStampTool.js";
 /**
  * Keyboard shortcuts handler for the editor.
  * Maps specific key presses to tool changes or editor actions.
@@ -66,6 +67,10 @@ export class Shortcuts {
             case "b":
                 e.preventDefault();
                 this.editor.setTool(new BucketFillTool());
+                break;
+            case "s":
+                e.preventDefault();
+                this.editor.setTool(new CloneStampTool());
                 break;
             case "i":
                 e.preventDefault();

--- a/dist/editor.js
+++ b/dist/editor.js
@@ -8,6 +8,7 @@ import { CircleTool } from "./tools/CircleTool.js";
 import { TextTool } from "./tools/TextTool.js";
 import { BucketFillTool } from "./tools/BucketFillTool.js";
 import { EyedropperTool } from "./tools/EyedropperTool.js";
+import { CloneStampTool } from "./tools/CloneStampTool.js";
 /** Utility to listen to events and auto-remove on destroy. */
 function listen(el, type, handler, list) {
     if (!el)
@@ -31,6 +32,7 @@ export function initEditor() {
         text: TextTool,
         bucket: BucketFillTool,
         eyedropper: EyedropperTool,
+        cloneStamp: CloneStampTool,
     };
     const toolButtons = {};
     const constructorToId = new Map();

--- a/dist/tools/CloneStampTool.js
+++ b/dist/tools/CloneStampTool.js
@@ -1,0 +1,200 @@
+class BrushPreview {
+    constructor(canvas) {
+        const container = canvas.parentElement ?? canvas;
+        this.overlay = document.createElement("div");
+        this.overlay.className = "clone-stamp-preview";
+        this.overlay.style.position = "absolute";
+        this.overlay.style.top = "0";
+        this.overlay.style.left = "0";
+        this.overlay.style.right = "0";
+        this.overlay.style.bottom = "0";
+        this.overlay.style.pointerEvents = "none";
+        container.appendChild(this.overlay);
+        this.brush = document.createElement("div");
+        this.brush.className = "clone-stamp-brush";
+        this.overlay.appendChild(this.brush);
+        this.source = document.createElement("div");
+        this.source.className = "clone-stamp-source";
+        this.overlay.appendChild(this.source);
+        this.hideBrush();
+        this.hideSource();
+    }
+    updateBrush(x, y, size) {
+        const diameter = Math.max(1, Math.round(size));
+        this.brush.style.display = "block";
+        this.brush.style.width = `${diameter}px`;
+        this.brush.style.height = `${diameter}px`;
+        this.brush.style.left = `${x}px`;
+        this.brush.style.top = `${y}px`;
+        this.brush.style.marginLeft = `${-diameter / 2}px`;
+        this.brush.style.marginTop = `${-diameter / 2}px`;
+    }
+    hideBrush() {
+        this.brush.style.display = "none";
+    }
+    updateSource(x, y) {
+        this.source.style.display = "block";
+        this.source.style.left = `${x}px`;
+        this.source.style.top = `${y}px`;
+    }
+    hideSource() {
+        this.source.style.display = "none";
+    }
+    destroy() {
+        this.overlay.remove();
+    }
+}
+export class CloneStampTool {
+    constructor() {
+        this.source = null;
+        this.offset = null;
+        this.snapshot = null;
+        this.painting = false;
+        this.preview = null;
+    }
+    getPreview(editor) {
+        if (!this.preview) {
+            this.preview = new BrushPreview(editor.canvas);
+        }
+        return this.preview;
+    }
+    onPointerDown(e, editor) {
+        const preview = this.getPreview(editor);
+        preview.updateBrush(e.offsetX, e.offsetY, editor.lineWidthValue);
+        if (e.altKey) {
+            this.source = { x: e.offsetX, y: e.offsetY };
+            this.offset = null;
+            this.snapshot = null;
+            preview.updateSource(e.offsetX, e.offsetY);
+            this.painting = false;
+            return;
+        }
+        if (!this.source) {
+            preview.hideSource();
+            return;
+        }
+        this.painting = true;
+        this.snapshot = editor.ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
+        this.offset = {
+            x: e.offsetX - this.source.x,
+            y: e.offsetY - this.source.y,
+        };
+        this.stampAt(e.offsetX, e.offsetY, editor);
+    }
+    onPointerMove(e, editor) {
+        const preview = this.getPreview(editor);
+        preview.updateBrush(e.offsetX, e.offsetY, editor.lineWidthValue);
+        if (e.altKey) {
+            preview.updateSource(e.offsetX, e.offsetY);
+            return;
+        }
+        if (this.painting && e.buttons === 1) {
+            this.stampAt(e.offsetX, e.offsetY, editor);
+            return;
+        }
+        if (this.source) {
+            preview.updateSource(this.source.x, this.source.y);
+        }
+        else {
+            preview.hideSource();
+        }
+    }
+    onPointerUp(e, editor) {
+        if (this.painting) {
+            this.painting = false;
+            this.stampAt(e.offsetX, e.offsetY, editor);
+        }
+        this.snapshot = null;
+        this.offset = null;
+        if (this.source) {
+            this.preview?.updateSource(this.source.x, this.source.y);
+        }
+        else {
+            this.preview?.hideSource();
+        }
+    }
+    destroy() {
+        this.preview?.destroy();
+        this.preview = null;
+    }
+    stampAt(x, y, editor) {
+        if (!this.snapshot || !this.source || !this.offset) {
+            return;
+        }
+        const sampleX = Math.round(x - this.offset.x);
+        const sampleY = Math.round(y - this.offset.y);
+        const size = Math.max(1, Math.round(editor.lineWidthValue));
+        const half = size / 2;
+        const destLeft = Math.round(x - half);
+        const destTop = Math.round(y - half);
+        const srcLeft = Math.round(sampleX - half);
+        const srcTop = Math.round(sampleY - half);
+        const srcData = this.snapshot.data;
+        const srcWidth = this.snapshot.width;
+        const srcHeight = this.snapshot.height;
+        const canvasWidth = editor.canvas.width;
+        const canvasHeight = editor.canvas.height;
+        const temp = new Uint8ClampedArray(size * size * 4);
+        let minDX = size;
+        let minDY = size;
+        let maxDX = -1;
+        let maxDY = -1;
+        for (let dy = 0; dy < size; dy++) {
+            const destY = destTop + dy;
+            const srcY = srcTop + dy;
+            if (destY < 0 || destY >= canvasHeight)
+                continue;
+            if (srcY < 0 || srcY >= srcHeight)
+                continue;
+            for (let dx = 0; dx < size; dx++) {
+                const destX = destLeft + dx;
+                const srcX = srcLeft + dx;
+                if (destX < 0 || destX >= canvasWidth)
+                    continue;
+                if (srcX < 0 || srcX >= srcWidth)
+                    continue;
+                const srcIndex = (srcY * srcWidth + srcX) * 4;
+                const destIndex = (dy * size + dx) * 4;
+                temp[destIndex] = srcData[srcIndex];
+                temp[destIndex + 1] = srcData[srcIndex + 1];
+                temp[destIndex + 2] = srcData[srcIndex + 2];
+                temp[destIndex + 3] = srcData[srcIndex + 3];
+                if (dx < minDX)
+                    minDX = dx;
+                if (dx > maxDX)
+                    maxDX = dx;
+                if (dy < minDY)
+                    minDY = dy;
+                if (dy > maxDY)
+                    maxDY = dy;
+            }
+        }
+        if (maxDX < minDX || maxDY < minDY) {
+            return;
+        }
+        const width = maxDX - minDX + 1;
+        const height = maxDY - minDY + 1;
+        const data = new Uint8ClampedArray(width * height * 4);
+        for (let dy = minDY; dy <= maxDY; dy++) {
+            for (let dx = minDX; dx <= maxDX; dx++) {
+                const srcIndex = (dy * size + dx) * 4;
+                const destIndex = ((dy - minDY) * width + (dx - minDX)) * 4;
+                data[destIndex] = temp[srcIndex];
+                data[destIndex + 1] = temp[srcIndex + 1];
+                data[destIndex + 2] = temp[srcIndex + 2];
+                data[destIndex + 3] = temp[srcIndex + 3];
+            }
+        }
+        const imageData = this.createImageData(data, width, height);
+        editor.ctx.putImageData(imageData, destLeft + minDX, destTop + minDY);
+        this.preview?.updateSource(sampleX, sampleY);
+    }
+    createImageData(data, width, height) {
+        if (typeof ImageData !== "undefined") {
+            const image = new ImageData(width, height);
+            image.data.set(data);
+            return image;
+        }
+        return { data, width, height };
+    }
+}

--- a/icons/stamp.svg
+++ b/icons/stamp.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M12 3v6" />
+    <path d="M9 9h6l2 4-2 4H9l-2-4z" />
+    <path d="M5 19h14" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -45,6 +45,9 @@
       <button id="bucket" class="tool-button" title="Bucket">
         <img src="icons/paint-bucket.svg" alt="Bucket" />
       </button>
+      <button id="cloneStamp" class="tool-button" title="Clone Stamp">
+        <img src="icons/stamp.svg" alt="Clone Stamp" />
+      </button>
       <input type="file" id="imageLoader" accept="image/*" />
       <button id="undo" class="tool-button" title="Undo" disabled>
         <img src="icons/undo.svg" alt="Undo" />

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -49,7 +49,9 @@ export class Editor {
   private handlePointerDown = (e: PointerEvent) => {
     // Capture the pointer once before recording canvas state
     this.canvas.setPointerCapture(e.pointerId);
-    this.saveState();
+    if (!e.altKey) {
+      this.saveState();
+    }
     this.currentTool?.onPointerDown(e, this);
   };
 

--- a/src/core/Shortcuts.ts
+++ b/src/core/Shortcuts.ts
@@ -7,6 +7,7 @@ import { TextTool } from "../tools/TextTool.js";
 import { EraserTool } from "../tools/EraserTool.js";
 import { BucketFillTool } from "../tools/BucketFillTool.js";
 import { EyedropperTool } from "../tools/EyedropperTool.js";
+import { CloneStampTool } from "../tools/CloneStampTool.js";
 
 
 /**
@@ -74,6 +75,10 @@ export class Shortcuts {
       case "b":
         e.preventDefault();
         this.editor.setTool(new BucketFillTool());
+        break;
+      case "s":
+        e.preventDefault();
+        this.editor.setTool(new CloneStampTool());
         break;
       case "i":
         e.preventDefault();

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -8,6 +8,7 @@ import { CircleTool } from "./tools/CircleTool.js";
 import { TextTool } from "./tools/TextTool.js";
 import { BucketFillTool } from "./tools/BucketFillTool.js";
 import { EyedropperTool } from "./tools/EyedropperTool.js";
+import { CloneStampTool } from "./tools/CloneStampTool.js";
 import type { Tool } from "./tools/Tool.js";
 
 /** Utility to listen to events and auto-remove on destroy. */
@@ -48,6 +49,7 @@ export function initEditor(): EditorHandle {
     text: TextTool,
     bucket: BucketFillTool,
     eyedropper: EyedropperTool,
+    cloneStamp: CloneStampTool,
   };
 
   const toolButtons: Record<string, HTMLButtonElement> = {};

--- a/src/tools/CloneStampTool.ts
+++ b/src/tools/CloneStampTool.ts
@@ -1,0 +1,238 @@
+import { Editor } from "../core/Editor.js";
+import { Tool } from "./Tool.js";
+
+type Point = { x: number; y: number };
+
+class BrushPreview {
+  private overlay: HTMLDivElement;
+  private brush: HTMLDivElement;
+  private source: HTMLDivElement;
+
+  constructor(canvas: HTMLCanvasElement) {
+    const container = canvas.parentElement ?? canvas;
+    this.overlay = document.createElement("div");
+    this.overlay.className = "clone-stamp-preview";
+    this.overlay.style.position = "absolute";
+    this.overlay.style.top = "0";
+    this.overlay.style.left = "0";
+    this.overlay.style.right = "0";
+    this.overlay.style.bottom = "0";
+    this.overlay.style.pointerEvents = "none";
+    container.appendChild(this.overlay);
+
+    this.brush = document.createElement("div");
+    this.brush.className = "clone-stamp-brush";
+    this.overlay.appendChild(this.brush);
+
+    this.source = document.createElement("div");
+    this.source.className = "clone-stamp-source";
+    this.overlay.appendChild(this.source);
+
+    this.hideBrush();
+    this.hideSource();
+  }
+
+  updateBrush(x: number, y: number, size: number) {
+    const diameter = Math.max(1, Math.round(size));
+    this.brush.style.display = "block";
+    this.brush.style.width = `${diameter}px`;
+    this.brush.style.height = `${diameter}px`;
+    this.brush.style.left = `${x}px`;
+    this.brush.style.top = `${y}px`;
+    this.brush.style.marginLeft = `${-diameter / 2}px`;
+    this.brush.style.marginTop = `${-diameter / 2}px`;
+  }
+
+  hideBrush() {
+    this.brush.style.display = "none";
+  }
+
+  updateSource(x: number, y: number) {
+    this.source.style.display = "block";
+    this.source.style.left = `${x}px`;
+    this.source.style.top = `${y}px`;
+  }
+
+  hideSource() {
+    this.source.style.display = "none";
+  }
+
+  destroy() {
+    this.overlay.remove();
+  }
+}
+
+export class CloneStampTool implements Tool {
+  private source: Point | null = null;
+  private offset: Point | null = null;
+  private snapshot: ImageData | null = null;
+  private painting = false;
+  private preview: BrushPreview | null = null;
+
+  private getPreview(editor: Editor): BrushPreview {
+    if (!this.preview) {
+      this.preview = new BrushPreview(editor.canvas);
+    }
+    return this.preview;
+  }
+
+  onPointerDown(e: PointerEvent, editor: Editor) {
+    const preview = this.getPreview(editor);
+    preview.updateBrush(e.offsetX, e.offsetY, editor.lineWidthValue);
+
+    if (e.altKey) {
+      this.source = { x: e.offsetX, y: e.offsetY };
+      this.offset = null;
+      this.snapshot = null;
+      preview.updateSource(e.offsetX, e.offsetY);
+      this.painting = false;
+      return;
+    }
+
+    if (!this.source) {
+      preview.hideSource();
+      return;
+    }
+
+    this.painting = true;
+    this.snapshot = editor.ctx.getImageData(
+      0,
+      0,
+      editor.canvas.width,
+      editor.canvas.height,
+    );
+    this.offset = {
+      x: e.offsetX - this.source.x,
+      y: e.offsetY - this.source.y,
+    };
+    this.stampAt(e.offsetX, e.offsetY, editor);
+  }
+
+  onPointerMove(e: PointerEvent, editor: Editor) {
+    const preview = this.getPreview(editor);
+    preview.updateBrush(e.offsetX, e.offsetY, editor.lineWidthValue);
+
+    if (e.altKey) {
+      preview.updateSource(e.offsetX, e.offsetY);
+      return;
+    }
+
+    if (this.painting && e.buttons === 1) {
+      this.stampAt(e.offsetX, e.offsetY, editor);
+      return;
+    }
+
+    if (this.source) {
+      preview.updateSource(this.source.x, this.source.y);
+    } else {
+      preview.hideSource();
+    }
+  }
+
+  onPointerUp(e: PointerEvent, editor: Editor) {
+    if (this.painting) {
+      this.painting = false;
+      this.stampAt(e.offsetX, e.offsetY, editor);
+    }
+    this.snapshot = null;
+    this.offset = null;
+    if (this.source) {
+      this.preview?.updateSource(this.source.x, this.source.y);
+    } else {
+      this.preview?.hideSource();
+    }
+  }
+
+  destroy() {
+    this.preview?.destroy();
+    this.preview = null;
+  }
+
+  private stampAt(x: number, y: number, editor: Editor) {
+    if (!this.snapshot || !this.source || !this.offset) {
+      return;
+    }
+
+    const sampleX = Math.round(x - this.offset.x);
+    const sampleY = Math.round(y - this.offset.y);
+
+    const size = Math.max(1, Math.round(editor.lineWidthValue));
+    const half = size / 2;
+    const destLeft = Math.round(x - half);
+    const destTop = Math.round(y - half);
+    const srcLeft = Math.round(sampleX - half);
+    const srcTop = Math.round(sampleY - half);
+
+    const srcData = this.snapshot.data;
+    const srcWidth = this.snapshot.width;
+    const srcHeight = this.snapshot.height;
+    const canvasWidth = editor.canvas.width;
+    const canvasHeight = editor.canvas.height;
+
+    const temp = new Uint8ClampedArray(size * size * 4);
+    let minDX = size;
+    let minDY = size;
+    let maxDX = -1;
+    let maxDY = -1;
+
+    for (let dy = 0; dy < size; dy++) {
+      const destY = destTop + dy;
+      const srcY = srcTop + dy;
+      if (destY < 0 || destY >= canvasHeight) continue;
+      if (srcY < 0 || srcY >= srcHeight) continue;
+      for (let dx = 0; dx < size; dx++) {
+        const destX = destLeft + dx;
+        const srcX = srcLeft + dx;
+        if (destX < 0 || destX >= canvasWidth) continue;
+        if (srcX < 0 || srcX >= srcWidth) continue;
+        const srcIndex = (srcY * srcWidth + srcX) * 4;
+        const destIndex = (dy * size + dx) * 4;
+        temp[destIndex] = srcData[srcIndex];
+        temp[destIndex + 1] = srcData[srcIndex + 1];
+        temp[destIndex + 2] = srcData[srcIndex + 2];
+        temp[destIndex + 3] = srcData[srcIndex + 3];
+        if (dx < minDX) minDX = dx;
+        if (dx > maxDX) maxDX = dx;
+        if (dy < minDY) minDY = dy;
+        if (dy > maxDY) maxDY = dy;
+      }
+    }
+
+    if (maxDX < minDX || maxDY < minDY) {
+      return;
+    }
+
+    const width = maxDX - minDX + 1;
+    const height = maxDY - minDY + 1;
+    const data = new Uint8ClampedArray(width * height * 4);
+
+    for (let dy = minDY; dy <= maxDY; dy++) {
+      for (let dx = minDX; dx <= maxDX; dx++) {
+        const srcIndex = (dy * size + dx) * 4;
+        const destIndex =
+          ((dy - minDY) * width + (dx - minDX)) * 4;
+        data[destIndex] = temp[srcIndex];
+        data[destIndex + 1] = temp[srcIndex + 1];
+        data[destIndex + 2] = temp[srcIndex + 2];
+        data[destIndex + 3] = temp[srcIndex + 3];
+      }
+    }
+
+    const imageData = this.createImageData(data, width, height);
+    editor.ctx.putImageData(imageData, destLeft + minDX, destTop + minDY);
+    this.preview?.updateSource(sampleX, sampleY);
+  }
+
+  private createImageData(
+    data: Uint8ClampedArray,
+    width: number,
+    height: number,
+  ): ImageData {
+    if (typeof ImageData !== "undefined") {
+      const image = new ImageData(width, height);
+      image.data.set(data);
+      return image;
+    }
+    return { data, width, height } as ImageData;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -99,4 +99,51 @@ body {
   box-sizing: border-box;
 }
 
+.clone-stamp-preview {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 10;
+}
+
+.clone-stamp-brush {
+  position: absolute;
+  border: 1px solid rgba(0, 0, 0, 0.6);
+  border-radius: 50%;
+  box-sizing: border-box;
+  pointer-events: none;
+}
+
+.clone-stamp-source {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  margin-left: -7px;
+  margin-top: -7px;
+  pointer-events: none;
+}
+
+.clone-stamp-source::before,
+.clone-stamp-source::after {
+  content: "";
+  position: absolute;
+  background: rgba(0, 0, 0, 0.75);
+}
+
+.clone-stamp-source::before {
+  width: 1px;
+  height: 100%;
+  left: 50%;
+  top: 0;
+  transform: translateX(-50%);
+}
+
+.clone-stamp-source::after {
+  height: 1px;
+  width: 100%;
+  top: 50%;
+  left: 0;
+  transform: translateY(-50%);
+}
+
 

--- a/tests/bucketIntegration.test.ts
+++ b/tests/bucketIntegration.test.ts
@@ -19,6 +19,7 @@ describe("bucket tool integration", () => {
       <button id="circle"></button>
       <button id="text"></button>
       <button id="bucket">Bucket</button>
+      <button id="cloneStamp"></button>
       <button id="eyedropper"></button>
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>

--- a/tests/cloneStampTool.test.ts
+++ b/tests/cloneStampTool.test.ts
@@ -1,0 +1,129 @@
+import { Editor } from "../src/core/Editor.js";
+import { CloneStampTool } from "../src/tools/CloneStampTool.js";
+
+describe("CloneStampTool", () => {
+  let canvas: HTMLCanvasElement;
+  let ctx: (Partial<CanvasRenderingContext2D> & {
+    putImageData: jest.Mock;
+    getImageData: jest.Mock;
+    clearRect: jest.Mock;
+  }) & {
+    setTransform: jest.Mock;
+    scale: jest.Mock;
+  };
+  let editor: Editor;
+  let tool: CloneStampTool;
+  let snapshot: ImageData;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <canvas id="canvas"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="1" />
+      <input id="fillMode" type="checkbox" />
+    `;
+
+    canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    (canvas as any).setPointerCapture = jest.fn();
+    (canvas as any).releasePointerCapture = jest.fn();
+    canvas.getBoundingClientRect = () => ({
+      width: 10,
+      height: 10,
+      top: 0,
+      left: 0,
+      bottom: 10,
+      right: 10,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+
+    const width = 10;
+    const height = 10;
+    const data = new Uint8ClampedArray(width * height * 4);
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const index = (y * width + x) * 4;
+        data[index] = x;
+        data[index + 1] = y;
+        data[index + 2] = 0;
+        data[index + 3] = 255;
+      }
+    }
+    snapshot = { data, width, height } as ImageData;
+
+    ctx = {
+      putImageData: jest.fn(),
+      getImageData: jest.fn(() => snapshot),
+      clearRect: jest.fn(),
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+    };
+
+    canvas.getContext = jest
+      .fn()
+      .mockReturnValue(ctx as unknown as CanvasRenderingContext2D);
+
+    editor = new Editor(
+      canvas,
+      document.getElementById("colorPicker") as HTMLInputElement,
+      document.getElementById("lineWidth") as HTMLInputElement,
+      document.getElementById("fillMode") as HTMLInputElement,
+    );
+
+    tool = new CloneStampTool();
+  });
+
+  it("samples from the aligned source location", () => {
+    tool.onPointerDown(
+      { altKey: true, offsetX: 2, offsetY: 2 } as PointerEvent,
+      editor,
+    );
+
+    editor.saveState();
+    tool.onPointerDown(
+      { altKey: false, offsetX: 6, offsetY: 4 } as PointerEvent,
+      editor,
+    );
+    tool.onPointerMove(
+      { buttons: 1, offsetX: 7, offsetY: 4 } as PointerEvent,
+      editor,
+    );
+
+    const lastCall = ctx.putImageData.mock.calls.at(-1);
+    expect(lastCall).toBeTruthy();
+    const [imageData, dx, dy] = lastCall!;
+    expect(dx).toBe(7);
+    expect(dy).toBe(4);
+    expect(imageData.width).toBe(1);
+    expect(imageData.height).toBe(1);
+    expect(Array.from(imageData.data)).toEqual([3, 2, 0, 255]);
+  });
+
+  it("participates in undo/redo history", () => {
+    tool.onPointerDown(
+      { altKey: true, offsetX: 2, offsetY: 2 } as PointerEvent,
+      editor,
+    );
+
+    editor.saveState();
+    tool.onPointerDown(
+      { altKey: false, offsetX: 6, offsetY: 4 } as PointerEvent,
+      editor,
+    );
+    tool.onPointerMove(
+      { buttons: 1, offsetX: 7, offsetY: 4 } as PointerEvent,
+      editor,
+    );
+    tool.onPointerUp(
+      { offsetX: 7, offsetY: 4 } as PointerEvent,
+      editor,
+    );
+
+    const beforeUndo = ctx.putImageData.mock.calls.length;
+    editor.undo();
+    expect(ctx.putImageData.mock.calls.length).toBe(beforeUndo + 1);
+    editor.redo();
+    expect(ctx.putImageData.mock.calls.length).toBe(beforeUndo + 2);
+  });
+});

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -20,6 +20,7 @@ describe("editor toolbar controls", () => {
       <button id="circle"></button>
       <button id="text"></button>
       <button id="bucket"></button>
+      <button id="cloneStamp"></button>
       <button id="eyedropper"></button>
       <select id="formatSelect"><option value="png">PNG</option></select>
       <input id="imageLoader" type="file" />

--- a/tests/eyedropperTool.test.ts
+++ b/tests/eyedropperTool.test.ts
@@ -104,6 +104,7 @@ describe("EyedropperTool color history", () => {
       <button id="circle"></button>
       <button id="text"></button>
       <button id="bucket"></button>
+      <button id="cloneStamp"></button>
       <button id="eyedropper"></button>
 
       <select id="formatSelect"><option value="png">PNG</option></select>

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -22,6 +22,7 @@ describe("image load and save", () => {
       <button id="circle"></button>
       <button id="text"></button>
       <button id="bucket"></button>
+      <button id="cloneStamp"></button>
       <button id="eyedropper"></button>
       <input id="imageLoader" type="file" />
       <select id="formatSelect"><option value="png">PNG</option></select>

--- a/tests/layers.test.ts
+++ b/tests/layers.test.ts
@@ -23,6 +23,7 @@ describe("layer-specific undo/redo", () => {
       <button id="circle"></button>
       <button id="text"></button>
       <button id="bucket"></button>
+      <button id="cloneStamp"></button>
       <button id="eyedropper"></button>
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>

--- a/tests/opacity.test.ts
+++ b/tests/opacity.test.ts
@@ -20,6 +20,7 @@ describe("layer opacity", () => {
       <button id="circle"></button>
       <button id="text"></button>
       <button id="bucket"></button>
+      <button id="cloneStamp"></button>
       <button id="eyedropper"></button>
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -14,6 +14,7 @@ describe("save button", () => {
       <button id="circle"></button>
       <button id="text"></button>
       <button id="bucket"></button>
+      <button id="cloneStamp"></button>
       <button id="eyedropper"></button>
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>
@@ -62,6 +63,7 @@ describe("save button", () => {
       <button id="circle"></button>
       <button id="text"></button>
       <button id="bucket"></button>
+      <button id="cloneStamp"></button>
       <button id="eyedropper"></button>
       <select id="formatSelect"><option value="png">PNG</option><option value="jpeg" selected>JPEG</option></select>
       <button id="save"></button>

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -9,6 +9,7 @@ import { TextTool } from "../src/tools/TextTool.js";
 import { BucketFillTool } from "../src/tools/BucketFillTool.js";
 import { Shortcuts } from "../src/core/Shortcuts.js";
 import { Editor } from "../src/core/Editor.js";
+import { CloneStampTool } from "../src/tools/CloneStampTool.js";
 
 describe("keyboard shortcuts", () => {
   let handle: EditorHandle;
@@ -28,6 +29,7 @@ describe("keyboard shortcuts", () => {
       <button id="circle"></button>
       <button id="text"></button>
       <button id="bucket"></button>
+      <button id="cloneStamp"></button>
       <button id="eyedropper"></button>
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>
@@ -72,6 +74,7 @@ describe("keyboard shortcuts", () => {
       ["c", CircleTool],
       ["t", TextTool],
       ["b", BucketFillTool],
+      ["s", CloneStampTool],
     ];
 
     cases.forEach(([key, ToolClass], index) => {

--- a/tests/toolbar.test.ts
+++ b/tests/toolbar.test.ts
@@ -6,6 +6,8 @@ import { LineTool } from "../src/tools/LineTool.js";
 import { CircleTool } from "../src/tools/CircleTool.js";
 import { TextTool } from "../src/tools/TextTool.js";
 import { EyedropperTool } from "../src/tools/EyedropperTool.js";
+import { BucketFillTool } from "../src/tools/BucketFillTool.js";
+import { CloneStampTool } from "../src/tools/CloneStampTool.js";
 
 describe("toolbar controls", () => {
   let handle: EditorHandle;
@@ -26,8 +28,9 @@ describe("toolbar controls", () => {
       <button id="line"></button>
       <button id="circle"></button>
       <button id="text"></button>
-      <button id="eyedropper"></button>
       <button id="bucket"></button>
+      <button id="cloneStamp"></button>
+      <button id="eyedropper"></button>
 
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>
@@ -97,8 +100,14 @@ describe("toolbar controls", () => {
       (document.getElementById("text") as HTMLButtonElement).click();
       expect(spy.mock.calls[5][0]).toBeInstanceOf(TextTool);
 
+      (document.getElementById("bucket") as HTMLButtonElement).click();
+      expect(spy.mock.calls[6][0]).toBeInstanceOf(BucketFillTool);
+
+      (document.getElementById("cloneStamp") as HTMLButtonElement).click();
+      expect(spy.mock.calls[7][0]).toBeInstanceOf(CloneStampTool);
+
       (document.getElementById("eyedropper") as HTMLButtonElement).click();
-      expect(spy.mock.calls[6][0]).toBeInstanceOf(EyedropperTool);
+      expect(spy.mock.calls[8][0]).toBeInstanceOf(EyedropperTool);
     });
 
     it("routes tool changes to the selected layer", () => {


### PR DESCRIPTION
## Summary
- add a Clone Stamp tool that tracks an aligned source sample, paints with the brush engine, and shows brush/source overlays
- extend the editor UI with a Clone Stamp toolbar button, icon, and CSS for the brush preview while skipping history snapshots during Alt sampling
- cover the new tool with focused unit tests and wire it into shortcuts, tool registration, and existing test fixtures

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d60d1be9cc8328910e9b6350514c84