### PR TITLE
Add polygon drawing tool with adjustable vertices

### DIFF
--- a/dist/core/Editor.js
+++ b/dist/core/Editor.js
@@ -1,5 +1,5 @@
 export class Editor {
-    constructor(canvas, colorPicker, lineWidth, fillMode, onChange, fontFamily, fontSize) {
+    constructor(canvas, colorPicker, lineWidth, fillMode, onChange, fontFamily, fontSize, polygonVertices, polygonStarMode) {
         this.undoStack = [];
         this.redoStack = [];
         this.currentTool = null;
@@ -32,6 +32,19 @@ export class Editor {
         this.onChange = onChange;
         this.fontFamily = fontFamily ?? null;
         this.fontSize = fontSize ?? null;
+        const verticesInput = polygonVertices ?? document.createElement("input");
+        if (!verticesInput.type) {
+            verticesInput.type = "number";
+        }
+        if (!verticesInput.value) {
+            verticesInput.value = "5";
+        }
+        const starInput = polygonStarMode ?? document.createElement("input");
+        if (!starInput.type) {
+            starInput.type = "checkbox";
+        }
+        this.polygonVerticesInput = verticesInput;
+        this.polygonStarModeInput = starInput;
         this.adjustForPixelRatio();
         window.addEventListener("resize", this.handleResize);
         this.canvas.addEventListener("pointerdown", this.handlePointerDown);
@@ -97,6 +110,28 @@ export class Editor {
     }
     get fontSizeValue() {
         return parseInt(this.fontSize?.value ?? "", 10) || 16;
+    }
+    get polygonVertexCount() {
+        const value = parseInt(this.polygonVerticesInput.value, 10);
+        if (!Number.isFinite(value)) {
+            return 5;
+        }
+        const clamped = Math.min(Math.max(value, 3), 48);
+        if (clamped !== value) {
+            this.polygonVerticesInput.value = String(clamped);
+        }
+        return clamped;
+    }
+    get polygonStarMode() {
+        return this.polygonStarModeInput.checked;
+    }
+    get polygonStarInset() {
+        const attr = this.polygonStarModeInput.dataset.inset;
+        const parsed = attr ? Number.parseFloat(attr) : NaN;
+        if (Number.isFinite(parsed)) {
+            return Math.min(Math.max(parsed, 0.05), 0.95);
+        }
+        return 0.5;
     }
     /**
      * Remove all event listeners registered by the editor.

--- a/dist/core/Shortcuts.js
+++ b/dist/core/Shortcuts.js
@@ -6,6 +6,7 @@ import { TextTool } from "../tools/TextTool.js";
 import { EraserTool } from "../tools/EraserTool.js";
 import { BucketFillTool } from "../tools/BucketFillTool.js";
 import { EyedropperTool } from "../tools/EyedropperTool.js";
+import { PolygonTool } from "../tools/PolygonTool.js";
 /**
  * Keyboard shortcuts handler for the editor.
  * Maps specific key presses to tool changes or editor actions.
@@ -54,6 +55,10 @@ export class Shortcuts {
             case "c":
                 e.preventDefault();
                 this.editor.setTool(new CircleTool());
+                break;
+            case "o":
+                e.preventDefault();
+                this.editor.setTool(new PolygonTool());
                 break;
             case "e":
                 e.preventDefault();

--- a/dist/editor.js
+++ b/dist/editor.js
@@ -8,6 +8,7 @@ import { CircleTool } from "./tools/CircleTool.js";
 import { TextTool } from "./tools/TextTool.js";
 import { BucketFillTool } from "./tools/BucketFillTool.js";
 import { EyedropperTool } from "./tools/EyedropperTool.js";
+import { PolygonTool } from "./tools/PolygonTool.js";
 /** Utility to listen to events and auto-remove on destroy. */
 function listen(el, type, handler, list) {
     if (!el)
@@ -28,6 +29,7 @@ export function initEditor() {
         rectangle: RectangleTool,
         line: LineTool,
         circle: CircleTool,
+        polygon: PolygonTool,
         text: TextTool,
         bucket: BucketFillTool,
         eyedropper: EyedropperTool,
@@ -71,6 +73,8 @@ export function initEditor() {
     const fillMode = document.getElementById("fillMode");
     const fontFamily = document.getElementById("fontFamily");
     const fontSize = document.getElementById("fontSize");
+    const polygonVertices = document.getElementById("polygonVertices");
+    const polygonStarMode = document.getElementById("polygonStarMode");
     const layerSelect = document.getElementById("layerSelect");
     const toolbar = document.getElementById("toolbar") || document.body;
     const saveBtn = document.getElementById("save");
@@ -84,6 +88,12 @@ export function initEditor() {
     }
     if (!fillMode) {
         throw new Error("Missing #fillMode input");
+    }
+    if (!polygonVertices) {
+        throw new Error("Missing #polygonVertices input");
+    }
+    if (!polygonStarMode) {
+        throw new Error("Missing #polygonStarMode input");
     }
     if (!saveBtn) {
         throw new Error("Missing #save button");
@@ -166,7 +176,7 @@ export function initEditor() {
         try {
             const e = new Editor(c, colorPicker, lineWidth, fillMode, () => {
                 updateHistoryButtons();
-            }, fontFamily ?? undefined, fontSize ?? undefined);
+            }, fontFamily ?? undefined, fontSize ?? undefined, polygonVertices, polygonStarMode);
             editors.push(e);
         }
         catch {

--- a/dist/tools/PolygonTool.js
+++ b/dist/tools/PolygonTool.js
@@ -1,0 +1,104 @@
+import { DrawingTool } from "./DrawingTool.js";
+const SNAP_ANGLE = Math.PI / 12; // 15 degrees
+export class PolygonTool extends DrawingTool {
+    constructor() {
+        super(...arguments);
+        this.startX = 0;
+        this.startY = 0;
+        this.imageData = null;
+        this.lockedRadius = null;
+    }
+    onPointerDown(e, editor) {
+        this.startX = e.offsetX;
+        this.startY = e.offsetY;
+        this.lockedRadius = null;
+        const ctx = editor.ctx;
+        this.applyStroke(ctx, editor);
+        if (typeof ctx.getImageData === "function") {
+            this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
+        }
+        else {
+            this.imageData = null;
+        }
+    }
+    onPointerMove(e, editor) {
+        if (e.buttons !== 1 || !this.imageData)
+            return;
+        const ctx = editor.ctx;
+        ctx.putImageData(this.imageData, 0, 0);
+        this.applyStroke(ctx, editor);
+        this.drawPolygon(ctx, editor, e);
+    }
+    onPointerUp(e, editor) {
+        const ctx = editor.ctx;
+        if (this.imageData) {
+            ctx.putImageData(this.imageData, 0, 0);
+        }
+        this.applyStroke(ctx, editor);
+        this.drawPolygon(ctx, editor, e);
+        this.imageData = null;
+        this.lockedRadius = null;
+    }
+    drawPolygon(ctx, editor, e) {
+        const dx = e.offsetX - this.startX;
+        const dy = e.offsetY - this.startY;
+        let radius = Math.hypot(dx, dy);
+        if (radius < 0.5) {
+            return;
+        }
+        let angle = Math.atan2(dy, dx);
+        if (e.shiftKey) {
+            angle = Math.round(angle / SNAP_ANGLE) * SNAP_ANGLE;
+        }
+        if (e.altKey) {
+            if (this.lockedRadius === null) {
+                this.lockedRadius = radius;
+            }
+            radius = this.lockedRadius;
+        }
+        else {
+            this.lockedRadius = null;
+        }
+        const sides = Math.max(3, editor.polygonVertexCount);
+        const isStar = editor.polygonStarMode;
+        const inset = Math.max(0.05, Math.min(0.95, editor.polygonStarInset));
+        const step = (Math.PI * 2) / sides;
+        ctx.beginPath();
+        if (isStar) {
+            const innerRadius = radius * inset;
+            for (let i = 0; i < sides; i += 1) {
+                const outerAngle = angle + step * i;
+                const innerAngle = outerAngle + step / 2;
+                const outerX = this.startX + Math.cos(outerAngle) * radius;
+                const outerY = this.startY + Math.sin(outerAngle) * radius;
+                const innerX = this.startX + Math.cos(innerAngle) * innerRadius;
+                const innerY = this.startY + Math.sin(innerAngle) * innerRadius;
+                if (i === 0) {
+                    ctx.moveTo(outerX, outerY);
+                }
+                else {
+                    ctx.lineTo(outerX, outerY);
+                }
+                ctx.lineTo(innerX, innerY);
+            }
+        }
+        else {
+            for (let i = 0; i < sides; i += 1) {
+                const theta = angle + step * i;
+                const x = this.startX + Math.cos(theta) * radius;
+                const y = this.startY + Math.sin(theta) * radius;
+                if (i === 0) {
+                    ctx.moveTo(x, y);
+                }
+                else {
+                    ctx.lineTo(x, y);
+                }
+            }
+        }
+        ctx.closePath();
+        ctx.stroke();
+        if (editor.fill) {
+            ctx.fill();
+        }
+    }
+}

--- a/icons/polygon.svg
+++ b/icons/polygon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" stroke-linecap="round">
+  <polygon points="12 3 20.5 8.5 17.5 20 6.5 20 3.5 8.5" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -36,6 +36,23 @@
       <button id="circle" class="tool-button" title="Circle">
         <img src="icons/circle.svg" alt="Circle" />
       </button>
+      <button id="polygon" class="tool-button" title="Polygon">
+        <img src="icons/polygon.svg" alt="Polygon" />
+      </button>
+      <div class="group">
+        <label for="polygonVertices">Vertices</label>
+        <input
+          type="number"
+          id="polygonVertices"
+          min="3"
+          max="24"
+          value="5"
+        />
+      </div>
+      <label>
+        <input type="checkbox" id="polygonStarMode" />
+        Star
+      </label>
       <button id="text" class="tool-button" title="Text">
         <img src="icons/type.svg" alt="Text" />
       </button>

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -11,6 +11,8 @@ export class Editor {
   fillMode: HTMLInputElement;
   fontFamily: HTMLSelectElement | null;
   fontSize: HTMLInputElement | null;
+  private polygonVerticesInput: HTMLInputElement;
+  private polygonStarModeInput: HTMLInputElement;
   private onChange?: () => void;
 
   constructor(
@@ -21,6 +23,8 @@ export class Editor {
     onChange?: () => void,
     fontFamily?: HTMLSelectElement | null,
     fontSize?: HTMLInputElement | null,
+    polygonVertices?: HTMLInputElement | null,
+    polygonStarMode?: HTMLInputElement | null,
   ) {
     this.canvas = canvas;
     const ctx = canvas.getContext("2d");
@@ -32,6 +36,19 @@ export class Editor {
     this.onChange = onChange;
     this.fontFamily = fontFamily ?? null;
     this.fontSize = fontSize ?? null;
+    const verticesInput = polygonVertices ?? document.createElement("input");
+    if (!verticesInput.type) {
+      verticesInput.type = "number";
+    }
+    if (!verticesInput.value) {
+      verticesInput.value = "5";
+    }
+    const starInput = polygonStarMode ?? document.createElement("input");
+    if (!starInput.type) {
+      starInput.type = "checkbox";
+    }
+    this.polygonVerticesInput = verticesInput;
+    this.polygonStarModeInput = starInput;
     this.adjustForPixelRatio();
     window.addEventListener("resize", this.handleResize);
 
@@ -141,6 +158,31 @@ export class Editor {
 
   get fontSizeValue() {
     return parseInt(this.fontSize?.value ?? "", 10) || 16;
+  }
+
+  get polygonVertexCount() {
+    const value = parseInt(this.polygonVerticesInput.value, 10);
+    if (!Number.isFinite(value)) {
+      return 5;
+    }
+    const clamped = Math.min(Math.max(value, 3), 48);
+    if (clamped !== value) {
+      this.polygonVerticesInput.value = String(clamped);
+    }
+    return clamped;
+  }
+
+  get polygonStarMode() {
+    return this.polygonStarModeInput.checked;
+  }
+
+  get polygonStarInset() {
+    const attr = this.polygonStarModeInput.dataset.inset;
+    const parsed = attr ? Number.parseFloat(attr) : NaN;
+    if (Number.isFinite(parsed)) {
+      return Math.min(Math.max(parsed, 0.05), 0.95);
+    }
+    return 0.5;
   }
 
   /**

--- a/src/core/Shortcuts.ts
+++ b/src/core/Shortcuts.ts
@@ -7,6 +7,7 @@ import { TextTool } from "../tools/TextTool.js";
 import { EraserTool } from "../tools/EraserTool.js";
 import { BucketFillTool } from "../tools/BucketFillTool.js";
 import { EyedropperTool } from "../tools/EyedropperTool.js";
+import { PolygonTool } from "../tools/PolygonTool.js";
 
 
 /**
@@ -62,6 +63,10 @@ export class Shortcuts {
       case "c":
         e.preventDefault();
         this.editor.setTool(new CircleTool());
+        break;
+      case "o":
+        e.preventDefault();
+        this.editor.setTool(new PolygonTool());
         break;
       case "e":
         e.preventDefault();

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -8,6 +8,7 @@ import { CircleTool } from "./tools/CircleTool.js";
 import { TextTool } from "./tools/TextTool.js";
 import { BucketFillTool } from "./tools/BucketFillTool.js";
 import { EyedropperTool } from "./tools/EyedropperTool.js";
+import { PolygonTool } from "./tools/PolygonTool.js";
 import type { Tool } from "./tools/Tool.js";
 
 /** Utility to listen to events and auto-remove on destroy. */
@@ -45,6 +46,7 @@ export function initEditor(): EditorHandle {
     rectangle: RectangleTool,
     line: LineTool,
     circle: CircleTool,
+    polygon: PolygonTool,
     text: TextTool,
     bucket: BucketFillTool,
     eyedropper: EyedropperTool,
@@ -91,6 +93,12 @@ export function initEditor(): EditorHandle {
   const fillMode = document.getElementById("fillMode") as HTMLInputElement | null;
   const fontFamily = document.getElementById("fontFamily") as HTMLSelectElement | null;
   const fontSize = document.getElementById("fontSize") as HTMLInputElement | null;
+  const polygonVertices = document.getElementById(
+    "polygonVertices",
+  ) as HTMLInputElement | null;
+  const polygonStarMode = document.getElementById(
+    "polygonStarMode",
+  ) as HTMLInputElement | null;
   const layerSelect = document.getElementById("layerSelect") as HTMLSelectElement | null;
   const toolbar = document.getElementById("toolbar") || document.body;
   const saveBtn = document.getElementById("save") as HTMLButtonElement | null;
@@ -108,6 +116,12 @@ export function initEditor(): EditorHandle {
   }
   if (!fillMode) {
     throw new Error("Missing #fillMode input");
+  }
+  if (!polygonVertices) {
+    throw new Error("Missing #polygonVertices input");
+  }
+  if (!polygonStarMode) {
+    throw new Error("Missing #polygonStarMode input");
   }
   if (!saveBtn) {
     throw new Error("Missing #save button");
@@ -212,6 +226,8 @@ export function initEditor(): EditorHandle {
         },
         fontFamily ?? undefined,
         fontSize ?? undefined,
+        polygonVertices,
+        polygonStarMode,
       );
       editors.push(e);
     } catch {

--- a/src/tools/PolygonTool.ts
+++ b/src/tools/PolygonTool.ts
@@ -1,0 +1,116 @@
+import { Editor } from "../core/Editor.js";
+import { DrawingTool } from "./DrawingTool.js";
+
+const SNAP_ANGLE = Math.PI / 12; // 15 degrees
+
+export class PolygonTool extends DrawingTool {
+  private startX = 0;
+  private startY = 0;
+  private imageData: ImageData | null = null;
+  private lockedRadius: number | null = null;
+
+  onPointerDown(e: PointerEvent, editor: Editor): void {
+    this.startX = e.offsetX;
+    this.startY = e.offsetY;
+    this.lockedRadius = null;
+    const ctx = editor.ctx;
+    this.applyStroke(ctx, editor);
+    if (typeof ctx.getImageData === "function") {
+      this.imageData = ctx.getImageData(
+        0,
+        0,
+        editor.canvas.width,
+        editor.canvas.height,
+      );
+    } else {
+      this.imageData = null;
+    }
+  }
+
+  onPointerMove(e: PointerEvent, editor: Editor): void {
+    if (e.buttons !== 1 || !this.imageData) return;
+    const ctx = editor.ctx;
+    ctx.putImageData(this.imageData, 0, 0);
+    this.applyStroke(ctx, editor);
+    this.drawPolygon(ctx, editor, e);
+  }
+
+  onPointerUp(e: PointerEvent, editor: Editor): void {
+    const ctx = editor.ctx;
+    if (this.imageData) {
+      ctx.putImageData(this.imageData, 0, 0);
+    }
+    this.applyStroke(ctx, editor);
+    this.drawPolygon(ctx, editor, e);
+    this.imageData = null;
+    this.lockedRadius = null;
+  }
+
+  private drawPolygon(
+    ctx: CanvasRenderingContext2D,
+    editor: Editor,
+    e: PointerEvent,
+  ) {
+    const dx = e.offsetX - this.startX;
+    const dy = e.offsetY - this.startY;
+    let radius = Math.hypot(dx, dy);
+    if (radius < 0.5) {
+      return;
+    }
+
+    let angle = Math.atan2(dy, dx);
+    if (e.shiftKey) {
+      angle = Math.round(angle / SNAP_ANGLE) * SNAP_ANGLE;
+    }
+
+    if (e.altKey) {
+      if (this.lockedRadius === null) {
+        this.lockedRadius = radius;
+      }
+      radius = this.lockedRadius;
+    } else {
+      this.lockedRadius = null;
+    }
+
+    const sides = Math.max(3, editor.polygonVertexCount);
+    const isStar = editor.polygonStarMode;
+    const inset = Math.max(0.05, Math.min(0.95, editor.polygonStarInset));
+    const step = (Math.PI * 2) / sides;
+
+    ctx.beginPath();
+    if (isStar) {
+      const innerRadius = radius * inset;
+      for (let i = 0; i < sides; i += 1) {
+        const outerAngle = angle + step * i;
+        const innerAngle = outerAngle + step / 2;
+        const outerX = this.startX + Math.cos(outerAngle) * radius;
+        const outerY = this.startY + Math.sin(outerAngle) * radius;
+        const innerX = this.startX + Math.cos(innerAngle) * innerRadius;
+        const innerY = this.startY + Math.sin(innerAngle) * innerRadius;
+        if (i === 0) {
+          ctx.moveTo(outerX, outerY);
+        } else {
+          ctx.lineTo(outerX, outerY);
+        }
+        ctx.lineTo(innerX, innerY);
+      }
+    } else {
+      for (let i = 0; i < sides; i += 1) {
+        const theta = angle + step * i;
+        const x = this.startX + Math.cos(theta) * radius;
+        const y = this.startY + Math.sin(theta) * radius;
+        if (i === 0) {
+          ctx.moveTo(x, y);
+        } else {
+          ctx.lineTo(x, y);
+        }
+      }
+    }
+
+    ctx.closePath();
+    ctx.stroke();
+    if (editor.fill) {
+      ctx.fill();
+    }
+  }
+}

--- a/tests/bucketIntegration.test.ts
+++ b/tests/bucketIntegration.test.ts
@@ -17,6 +17,9 @@ describe("bucket tool integration", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="polygon"></button>
+      <input id="polygonVertices" type="number" value="5" />
+      <input id="polygonStarMode" type="checkbox" />
       <button id="text"></button>
       <button id="bucket">Bucket</button>
       <button id="eyedropper"></button>

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -18,6 +18,9 @@ describe("editor toolbar controls", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="polygon"></button>
+      <input id="polygonVertices" type="number" value="5" />
+      <input id="polygonStarMode" type="checkbox" />
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>

--- a/tests/eyedropperTool.test.ts
+++ b/tests/eyedropperTool.test.ts
@@ -102,6 +102,9 @@ describe("EyedropperTool color history", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="polygon"></button>
+      <input id="polygonVertices" type="number" value="5" />
+      <input id="polygonStarMode" type="checkbox" />
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -20,6 +20,9 @@ describe("image load and save", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="polygon"></button>
+      <input id="polygonVertices" type="number" value="5" />
+      <input id="polygonStarMode" type="checkbox" />
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>

--- a/tests/layers.test.ts
+++ b/tests/layers.test.ts
@@ -21,6 +21,9 @@ describe("layer-specific undo/redo", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="polygon"></button>
+      <input id="polygonVertices" type="number" value="5" />
+      <input id="polygonStarMode" type="checkbox" />
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>

--- a/tests/opacity.test.ts
+++ b/tests/opacity.test.ts
@@ -18,6 +18,9 @@ describe("layer opacity", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="polygon"></button>
+      <input id="polygonVertices" type="number" value="5" />
+      <input id="polygonStarMode" type="checkbox" />
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -12,6 +12,9 @@ describe("save button", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="polygon"></button>
+      <input id="polygonVertices" type="number" value="5" />
+      <input id="polygonStarMode" type="checkbox" />
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
@@ -60,6 +63,9 @@ describe("save button", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="polygon"></button>
+      <input id="polygonVertices" type="number" value="5" />
+      <input id="polygonStarMode" type="checkbox" />
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -9,6 +9,7 @@ import { TextTool } from "../src/tools/TextTool.js";
 import { BucketFillTool } from "../src/tools/BucketFillTool.js";
 import { Shortcuts } from "../src/core/Shortcuts.js";
 import { Editor } from "../src/core/Editor.js";
+import { PolygonTool } from "../src/tools/PolygonTool.js";
 
 describe("keyboard shortcuts", () => {
   let handle: EditorHandle;
@@ -26,6 +27,9 @@ describe("keyboard shortcuts", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="polygon"></button>
+      <input id="polygonVertices" type="number" value="5" />
+      <input id="polygonStarMode" type="checkbox" />
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
@@ -70,6 +74,7 @@ describe("keyboard shortcuts", () => {
       ["i", EyedropperTool],
       ["l", LineTool],
       ["c", CircleTool],
+      ["o", PolygonTool],
       ["t", TextTool],
       ["b", BucketFillTool],
     ];

--- a/tests/toolbar.test.ts
+++ b/tests/toolbar.test.ts
@@ -6,6 +6,7 @@ import { LineTool } from "../src/tools/LineTool.js";
 import { CircleTool } from "../src/tools/CircleTool.js";
 import { TextTool } from "../src/tools/TextTool.js";
 import { EyedropperTool } from "../src/tools/EyedropperTool.js";
+import { PolygonTool } from "../src/tools/PolygonTool.js";
 
 describe("toolbar controls", () => {
   let handle: EditorHandle;
@@ -25,6 +26,9 @@ describe("toolbar controls", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="polygon"></button>
+      <input id="polygonVertices" type="number" value="5" />
+      <input id="polygonStarMode" type="checkbox" />
       <button id="text"></button>
       <button id="eyedropper"></button>
       <button id="bucket"></button>
@@ -79,26 +83,21 @@ describe("toolbar controls", () => {
 
     it("switches tools when buttons are clicked", () => {
       const spy = jest.spyOn(handle.editor, "setTool");
-      (document.getElementById("pencil") as HTMLButtonElement).click();
-      expect(spy.mock.calls[0][0]).toBeInstanceOf(PencilTool);
+      const cases: Array<[string, new () => unknown]> = [
+        ["pencil", PencilTool],
+        ["eraser", EraserTool],
+        ["rectangle", RectangleTool],
+        ["line", LineTool],
+        ["circle", CircleTool],
+        ["polygon", PolygonTool],
+        ["text", TextTool],
+        ["eyedropper", EyedropperTool],
+      ];
 
-      (document.getElementById("eraser") as HTMLButtonElement).click();
-      expect(spy.mock.calls[1][0]).toBeInstanceOf(EraserTool);
-
-      (document.getElementById("rectangle") as HTMLButtonElement).click();
-      expect(spy.mock.calls[2][0]).toBeInstanceOf(RectangleTool);
-
-      (document.getElementById("line") as HTMLButtonElement).click();
-      expect(spy.mock.calls[3][0]).toBeInstanceOf(LineTool);
-
-      (document.getElementById("circle") as HTMLButtonElement).click();
-      expect(spy.mock.calls[4][0]).toBeInstanceOf(CircleTool);
-
-      (document.getElementById("text") as HTMLButtonElement).click();
-      expect(spy.mock.calls[5][0]).toBeInstanceOf(TextTool);
-
-      (document.getElementById("eyedropper") as HTMLButtonElement).click();
-      expect(spy.mock.calls[6][0]).toBeInstanceOf(EyedropperTool);
+      cases.forEach(([id, ToolCtor], index) => {
+        (document.getElementById(id) as HTMLButtonElement).click();
+        expect(spy.mock.calls[index][0]).toBeInstanceOf(ToolCtor);
+      });
     });
 
     it("routes tool changes to the selected layer", () => {


### PR DESCRIPTION
## Summary
- add a polygon drawing tool that supports star mode plus shift/alt rotation and radius locks
- expose polygon controls in the toolbar and wire them into the editor and keyboard shortcuts
- update automated tests and assets for the new tool button and configuration inputs

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60d1aecf88328bcc36e3ad6bf3653