### PR TITLE
Add gradient editing tool and controls

### DIFF
--- a/icons/gradient.svg
+++ b/icons/gradient.svg
@@ -1,0 +1,11 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g" x1="4" y1="4" x2="20" y2="20" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#4facfe" />
+      <stop offset="1" stop-color="#f093fb" />
+    </linearGradient>
+  </defs>
+  <rect x="3" y="3" width="18" height="18" rx="2" fill="url(#g)" stroke="#111" stroke-width="1.5" />
+  <circle cx="8" cy="8" r="2" fill="#fff" stroke="#111" stroke-width="1" />
+  <circle cx="16" cy="16" r="2" fill="#fff" stroke="#111" stroke-width="1" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -36,6 +36,9 @@
       <button id="circle" class="tool-button" title="Circle">
         <img src="icons/circle.svg" alt="Circle" />
       </button>
+      <button id="gradient" class="tool-button" title="Gradient">
+        <img src="icons/gradient.svg" alt="Gradient" />
+      </button>
       <button id="text" class="tool-button" title="Text">
         <img src="icons/type.svg" alt="Text" />
       </button>

--- a/src/core/Shortcuts.ts
+++ b/src/core/Shortcuts.ts
@@ -7,6 +7,7 @@ import { TextTool } from "../tools/TextTool.js";
 import { EraserTool } from "../tools/EraserTool.js";
 import { BucketFillTool } from "../tools/BucketFillTool.js";
 import { EyedropperTool } from "../tools/EyedropperTool.js";
+import type { Tool } from "../tools/Tool.js";
 
 
 /**
@@ -16,9 +17,11 @@ import { EyedropperTool } from "../tools/EyedropperTool.js";
 export class Shortcuts {
   private readonly handler: (e: KeyboardEvent) => void;
   private editor: Editor;
+  private readonly gradientFactory?: () => Tool;
 
-  constructor(editor: Editor) {
+  constructor(editor: Editor, gradientFactory?: () => Tool) {
     this.editor = editor;
+    this.gradientFactory = gradientFactory;
     this.handler = (e: KeyboardEvent) => this.onKeyDown(e);
     document.addEventListener("keydown", this.handler);
   }
@@ -74,6 +77,12 @@ export class Shortcuts {
       case "b":
         e.preventDefault();
         this.editor.setTool(new BucketFillTool());
+        break;
+      case "g":
+        if (this.gradientFactory) {
+          e.preventDefault();
+          this.editor.setTool(this.gradientFactory());
+        }
         break;
       case "i":
         e.preventDefault();

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -8,6 +8,12 @@ import { CircleTool } from "./tools/CircleTool.js";
 import { TextTool } from "./tools/TextTool.js";
 import { BucketFillTool } from "./tools/BucketFillTool.js";
 import { EyedropperTool } from "./tools/EyedropperTool.js";
+import {
+  GradientTool,
+  type GradientConfig,
+  type GradientStop,
+  type GradientType,
+} from "./tools/GradientTool.js";
 import type { Tool } from "./tools/Tool.js";
 
 /** Utility to listen to events and auto-remove on destroy. */
@@ -39,6 +45,12 @@ export function initEditor(): EditorHandle {
     document.querySelectorAll<HTMLCanvasElement>("canvas"),
   );
 
+  class ConfiguredGradientTool extends GradientTool {
+    constructor() {
+      super(gradientConfig);
+    }
+  }
+
   const toolConstructors: Record<string, new () => Tool> = {
     pencil: PencilTool,
     eraser: EraserTool,
@@ -48,6 +60,7 @@ export function initEditor(): EditorHandle {
     text: TextTool,
     bucket: BucketFillTool,
     eyedropper: EyedropperTool,
+    gradient: ConfiguredGradientTool,
   };
 
   const toolButtons: Record<string, HTMLButtonElement> = {};
@@ -115,6 +128,213 @@ export function initEditor(): EditorHandle {
   if (!formatSelect) {
     throw new Error("Missing #formatSelect select");
   }
+
+  const clamp = (value: number, min: number, max: number) =>
+    Math.min(max, Math.max(min, value));
+
+  const gradientListeners = new Set<() => void>();
+  let gradientStopId = 0;
+  const gradientConfig: GradientConfig = {
+    type: "linear",
+    stops: [
+      { id: gradientStopId++, offset: 0, color: colorPicker.value },
+      { id: gradientStopId++, offset: 1, color: "#ffffff" },
+    ],
+    addListener(listener: () => void) {
+      gradientListeners.add(listener);
+      return () => {
+        gradientListeners.delete(listener);
+      };
+    },
+    notifyChange() {
+      gradientListeners.forEach((fn) => fn());
+    },
+  };
+
+  const gradientControls = document.createElement("div");
+  gradientControls.className = "group gradient-controls";
+
+  const gradientTitle = document.createElement("span");
+  gradientTitle.textContent = "Gradient";
+  gradientControls.appendChild(gradientTitle);
+
+  const gradientTypeSelect = document.createElement("select");
+  gradientTypeSelect.id = "gradientType";
+  const typeOptions: Array<[GradientType, string]> = [
+    ["linear", "Linear"],
+    ["radial", "Radial"],
+  ];
+  typeOptions.forEach(([value, label]) => {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = label;
+    gradientTypeSelect.appendChild(option);
+  });
+  gradientTypeSelect.value = gradientConfig.type;
+  gradientTypeSelect.addEventListener("change", () => {
+    gradientConfig.type = gradientTypeSelect.value as GradientType;
+    gradientConfig.notifyChange();
+  });
+  gradientControls.appendChild(gradientTypeSelect);
+
+  const stopList = document.createElement("div");
+  stopList.id = "gradientStops";
+  gradientControls.appendChild(stopList);
+
+  const stopElements = new Map<
+    number,
+    {
+      row: HTMLDivElement;
+      color: HTMLInputElement;
+      offset: HTMLInputElement;
+      percent: HTMLSpanElement;
+      remove: HTMLButtonElement;
+    }
+  >();
+
+  const updateRemoveButtons = () => {
+    const disable = gradientConfig.stops.length <= 2;
+    stopElements.forEach(({ remove }) => {
+      remove.disabled = disable;
+    });
+  };
+
+  const syncStopInputs = () => {
+    const sorted = [...gradientConfig.stops].sort((a, b) => a.offset - b.offset);
+    sorted.forEach((stop) => {
+      const entry = stopElements.get(stop.id);
+      if (!entry) return;
+      if (entry.color.value !== stop.color) {
+        entry.color.value = stop.color;
+      }
+      const percentValue = Math.round(stop.offset * 100);
+      if (entry.offset.value !== String(percentValue)) {
+        entry.offset.value = String(percentValue);
+      }
+      entry.percent.textContent = `${percentValue}%`;
+      stopList.appendChild(entry.row);
+    });
+    updateRemoveButtons();
+  };
+
+  const ensureStopRow = (stop: GradientStop) => {
+    if (stopElements.has(stop.id)) {
+      return stopElements.get(stop.id)!;
+    }
+
+    const row = document.createElement("div");
+    row.className = "gradient-stop";
+
+    const colorInput = document.createElement("input");
+    colorInput.type = "color";
+    colorInput.addEventListener("input", () => {
+      stop.color = colorInput.value;
+      gradientConfig.notifyChange();
+    });
+    row.appendChild(colorInput);
+
+    const offsetInput = document.createElement("input");
+    offsetInput.type = "range";
+    offsetInput.min = "0";
+    offsetInput.max = "100";
+    offsetInput.step = "1";
+    offsetInput.addEventListener("input", () => {
+      const parsed = parseInt(offsetInput.value, 10);
+      const normalized = clamp(isNaN(parsed) ? stop.offset : parsed / 100, 0, 1);
+      stop.offset = normalized;
+      percent.textContent = `${Math.round(normalized * 100)}%`;
+      gradientConfig.notifyChange();
+    });
+    offsetInput.addEventListener("change", () => {
+      gradientConfig.stops.sort((a, b) => a.offset - b.offset);
+      renderStopList();
+    });
+    row.appendChild(offsetInput);
+
+    const percent = document.createElement("span");
+    percent.className = "gradient-stop-percent";
+    row.appendChild(percent);
+
+    const removeButton = document.createElement("button");
+    removeButton.type = "button";
+    removeButton.textContent = "Remove";
+    removeButton.addEventListener("click", () => {
+      if (gradientConfig.stops.length <= 2) return;
+      const index = gradientConfig.stops.findIndex((s) => s.id === stop.id);
+      if (index !== -1) {
+        gradientConfig.stops.splice(index, 1);
+        stopElements.delete(stop.id);
+        row.remove();
+        updateRemoveButtons();
+        gradientConfig.notifyChange();
+      }
+    });
+    row.appendChild(removeButton);
+
+    const entry = {
+      row,
+      color: colorInput,
+      offset: offsetInput,
+      percent,
+      remove: removeButton,
+    };
+    stopElements.set(stop.id, entry);
+    return entry;
+  };
+
+  const renderStopList = () => {
+    const sorted = [...gradientConfig.stops].sort((a, b) => a.offset - b.offset);
+    sorted.forEach((stop) => ensureStopRow(stop));
+
+    // remove stale rows
+    Array.from(stopElements.keys()).forEach((id) => {
+      if (!gradientConfig.stops.some((s) => s.id === id)) {
+        const entry = stopElements.get(id);
+        if (entry) {
+          entry.row.remove();
+        }
+        stopElements.delete(id);
+      }
+    });
+
+    sorted.forEach((stop) => {
+      const entry = stopElements.get(stop.id);
+      if (entry) {
+        stopList.appendChild(entry.row);
+      }
+    });
+    syncStopInputs();
+  };
+
+  gradientConfig.addListener(() => {
+    gradientTypeSelect.value = gradientConfig.type;
+    syncStopInputs();
+  });
+
+  const addStopButton = document.createElement("button");
+  addStopButton.type = "button";
+  addStopButton.textContent = "Add Stop";
+  addStopButton.addEventListener("click", () => {
+    const midpoint = gradientConfig.stops.reduce((sum, stop) => sum + stop.offset, 0);
+    const offset =
+      gradientConfig.stops.length === 0
+        ? 0.5
+        : clamp(midpoint / gradientConfig.stops.length, 0, 1);
+    const newStop: GradientStop = {
+      id: gradientStopId++,
+      offset,
+      color: colorPicker.value,
+    };
+    gradientConfig.stops.push(newStop);
+    gradientConfig.stops.sort((a, b) => a.offset - b.offset);
+    renderStopList();
+    updateRemoveButtons();
+    gradientConfig.notifyChange();
+  });
+  gradientControls.appendChild(addStopButton);
+
+  renderStopList();
+  toolbar.appendChild(gradientControls);
 
   if (layerSelect) {
     layerSelect.innerHTML = "";
@@ -245,7 +465,7 @@ export function initEditor(): EditorHandle {
   updateLayerInteractivity();
 
   // keyboard shortcuts
-  const shortcuts = new Shortcuts(editor);
+  const shortcuts = new Shortcuts(editor, () => new ConfiguredGradientTool());
 
   // map button id to tool constructor
   Object.entries(toolConstructors).forEach(([id, ToolCtor]) =>

--- a/src/tools/GradientTool.ts
+++ b/src/tools/GradientTool.ts
@@ -1,0 +1,331 @@
+import { Editor } from "../core/Editor.js";
+import { Tool } from "./Tool.js";
+
+export type GradientType = "linear" | "radial";
+
+export interface GradientStop {
+  id: number;
+  offset: number;
+  color: string;
+}
+
+export interface GradientConfig {
+  type: GradientType;
+  stops: GradientStop[];
+  addListener(listener: () => void): () => void;
+  notifyChange(): void;
+}
+
+const STOP_RADIUS = 6;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+export class GradientTool implements Tool {
+  cursor = "crosshair";
+
+  private readonly config: GradientConfig;
+  private start: { x: number; y: number } | null = null;
+  private end: { x: number; y: number } | null = null;
+  private overlayCanvas: HTMLCanvasElement | null = null;
+  private overlayCtx: CanvasRenderingContext2D | null = null;
+  private baseImage: ImageData | null = null;
+  private previewing = false;
+  private draggingStop: GradientStop | null = null;
+  private removeListener: (() => void) | null = null;
+
+  constructor(config: GradientConfig) {
+    this.config = config;
+    this.removeListener = this.config.addListener(() => {
+      if (!this.start || !this.end) return;
+      if (this.previewing) {
+        this.renderPreview(this.lastEditor);
+      } else {
+        this.renderHandles(this.lastEditor);
+      }
+    });
+  }
+
+  private lastEditor: Editor | null = null;
+
+  onPointerDown(e: PointerEvent, editor: Editor): void {
+    this.lastEditor = editor;
+    if (this.start && this.end) {
+      const hitStop = this.hitTestStop(e);
+      if (hitStop) {
+        this.draggingStop = hitStop;
+        return;
+      }
+    }
+
+    this.start = { x: e.offsetX, y: e.offsetY };
+    this.end = { x: e.offsetX, y: e.offsetY };
+    this.previewing = true;
+    this.draggingStop = null;
+    this.captureBaseImage(editor);
+    this.ensureOverlay(editor);
+    this.renderPreview(editor);
+  }
+
+  onPointerMove(e: PointerEvent, editor: Editor): void {
+    this.lastEditor = editor;
+    if (this.draggingStop && this.start && this.end) {
+      const offset = this.offsetFromPointer(e);
+      if (offset !== null) {
+        this.draggingStop.offset = clamp(offset, 0, 1);
+        this.sortStops();
+        this.applyGradientToCanvas(editor);
+        this.renderHandles(editor);
+        this.config.notifyChange();
+      }
+      return;
+    }
+
+    if (!this.previewing || !this.start || !this.end || e.buttons !== 1) {
+      return;
+    }
+
+    this.end = { x: e.offsetX, y: e.offsetY };
+    this.renderPreview(editor);
+  }
+
+  onPointerUp(e: PointerEvent, editor: Editor): void {
+    this.lastEditor = editor;
+    if (this.draggingStop) {
+      this.draggingStop = null;
+      this.sortStops();
+      this.config.notifyChange();
+      return;
+    }
+
+    if (!this.previewing || !this.start || !this.end) {
+      return;
+    }
+
+    this.previewing = false;
+    this.applyGradientToCanvas(editor);
+    this.renderHandles(editor);
+  }
+
+  destroy(): void {
+    this.cleanupOverlay();
+    this.baseImage = null;
+    this.start = null;
+    this.end = null;
+    this.draggingStop = null;
+    this.removeListener?.();
+    this.removeListener = null;
+  }
+
+  private captureBaseImage(editor: Editor) {
+    try {
+      this.baseImage = editor.ctx.getImageData(
+        0,
+        0,
+        editor.canvas.width,
+        editor.canvas.height,
+      );
+    } catch {
+      this.baseImage = null;
+    }
+  }
+
+  private ensureOverlay(editor: Editor) {
+    const parent = editor.canvas.parentElement || editor.canvas;
+    if (!this.overlayCanvas) {
+      this.overlayCanvas = document.createElement("canvas");
+      this.overlayCanvas.style.position = "absolute";
+      this.overlayCanvas.style.top = "0";
+      this.overlayCanvas.style.left = "0";
+      this.overlayCanvas.style.pointerEvents = "none";
+      parent.appendChild(this.overlayCanvas);
+    }
+
+    const rect = editor.canvas.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+    this.overlayCanvas.width = rect.width * dpr;
+    this.overlayCanvas.height = rect.height * dpr;
+    this.overlayCanvas.style.width = `${rect.width}px`;
+    this.overlayCanvas.style.height = `${rect.height}px`;
+
+    const ctx = this.overlayCanvas.getContext("2d");
+    if (!ctx) {
+      this.overlayCanvas.remove();
+      this.overlayCanvas = null;
+      this.overlayCtx = null;
+      return;
+    }
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    this.overlayCtx = ctx;
+  }
+
+  private cleanupOverlay() {
+    this.overlayCtx = null;
+    if (this.overlayCanvas) {
+      this.overlayCanvas.remove();
+      this.overlayCanvas = null;
+    }
+  }
+
+  private renderPreview(editor: Editor | null) {
+    if (!editor || !this.start || !this.end) return;
+    this.ensureOverlay(editor);
+    if (!this.overlayCanvas || !this.overlayCtx) return;
+
+    this.overlayCtx.clearRect(0, 0, this.overlayCanvas.width, this.overlayCanvas.height);
+    const gradient = this.createGradient(this.overlayCtx);
+    if (!gradient) {
+      return;
+    }
+
+    this.overlayCtx.save();
+    this.overlayCtx.globalAlpha = 0.75;
+    this.overlayCtx.fillStyle = gradient;
+    this.overlayCtx.fillRect(0, 0, this.overlayCanvas.width, this.overlayCanvas.height);
+    this.overlayCtx.restore();
+    this.drawHandles();
+  }
+
+  private renderHandles(editor: Editor | null) {
+    if (!editor || !this.start || !this.end) return;
+    this.ensureOverlay(editor);
+    if (!this.overlayCanvas || !this.overlayCtx) return;
+    this.overlayCtx.clearRect(0, 0, this.overlayCanvas.width, this.overlayCanvas.height);
+    this.drawHandles();
+  }
+
+  private drawHandles() {
+    if (!this.overlayCtx || !this.start || !this.end) return;
+    const ctx = this.overlayCtx;
+    ctx.save();
+    ctx.strokeStyle = "rgba(255, 255, 255, 0.9)";
+    ctx.lineWidth = 1;
+    ctx.setLineDash([4, 4]);
+    ctx.beginPath();
+    ctx.moveTo(this.start.x, this.start.y);
+    ctx.lineTo(this.end.x, this.end.y);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    const stops = [...this.config.stops].sort((a, b) => a.offset - b.offset);
+    for (const stop of stops) {
+      const pos = this.positionForOffset(stop.offset);
+      if (!pos) continue;
+      ctx.beginPath();
+      ctx.fillStyle = stop.color;
+      ctx.strokeStyle = "rgba(0, 0, 0, 0.7)";
+      ctx.lineWidth = 1;
+      ctx.arc(pos.x, pos.y, STOP_RADIUS, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.stroke();
+    }
+    ctx.restore();
+  }
+
+  private createGradient(
+    ctx: CanvasRenderingContext2D,
+  ): CanvasGradient | null {
+    if (!this.start || !this.end) return null;
+    const dx = this.end.x - this.start.x;
+    const dy = this.end.y - this.start.y;
+
+    let gradient: CanvasGradient | null = null;
+    if (this.config.type === "linear") {
+      if (typeof ctx.createLinearGradient !== "function" || (dx === 0 && dy === 0)) {
+        return null;
+      }
+      gradient = ctx.createLinearGradient(this.start.x, this.start.y, this.end.x, this.end.y);
+    } else {
+      const radius = Math.hypot(dx, dy);
+      if (typeof ctx.createRadialGradient !== "function" || radius === 0) {
+        return null;
+      }
+      gradient = ctx.createRadialGradient(
+        this.start.x,
+        this.start.y,
+        0,
+        this.start.x,
+        this.start.y,
+        radius,
+      );
+    }
+
+    const stops = [...this.config.stops].sort((a, b) => a.offset - b.offset);
+    stops.forEach((stop) => {
+      gradient!.addColorStop(clamp(stop.offset, 0, 1), stop.color);
+    });
+
+    return gradient;
+  }
+
+  private applyGradientToCanvas(editor: Editor) {
+    if (!this.start || !this.end) return;
+    const ctx = editor.ctx;
+    if (this.baseImage) {
+      ctx.putImageData(this.baseImage, 0, 0);
+    }
+    const gradient = this.createGradient(ctx);
+    if (!gradient) return;
+    ctx.save();
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, editor.canvas.width, editor.canvas.height);
+    ctx.restore();
+  }
+
+  private positionForOffset(offset: number) {
+    if (!this.start || !this.end) return null;
+    const dx = this.end.x - this.start.x;
+    const dy = this.end.y - this.start.y;
+    if (this.config.type === "linear") {
+      return {
+        x: this.start.x + dx * offset,
+        y: this.start.y + dy * offset,
+      };
+    }
+
+    const length = Math.hypot(dx, dy);
+    if (length === 0) return null;
+    const ux = dx / length;
+    const uy = dy / length;
+    return {
+      x: this.start.x + ux * length * offset,
+      y: this.start.y + uy * length * offset,
+    };
+  }
+
+  private offsetFromPointer(e: PointerEvent): number | null {
+    if (!this.start || !this.end) return null;
+    const dx = this.end.x - this.start.x;
+    const dy = this.end.y - this.start.y;
+    if (this.config.type === "linear") {
+      const lengthSq = dx * dx + dy * dy;
+      if (lengthSq === 0) return null;
+      const t =
+        ((e.offsetX - this.start.x) * dx + (e.offsetY - this.start.y) * dy) / lengthSq;
+      return t;
+    }
+    const radius = Math.hypot(dx, dy);
+    if (radius === 0) return null;
+    const dist = Math.hypot(e.offsetX - this.start.x, e.offsetY - this.start.y);
+    return dist / radius;
+  }
+
+  private hitTestStop(e: PointerEvent): GradientStop | null {
+    if (!this.start || !this.end) return null;
+    const stops = [...this.config.stops].sort((a, b) => a.offset - b.offset);
+    for (const stop of stops) {
+      const pos = this.positionForOffset(stop.offset);
+      if (!pos) continue;
+      const dist = Math.hypot(e.offsetX - pos.x, e.offsetY - pos.y);
+      if (dist <= STOP_RADIUS * 1.5) {
+        return stop;
+      }
+    }
+    return null;
+  }
+
+  private sortStops() {
+    this.config.stops.sort((a, b) => a.offset - b.offset);
+  }
+}

--- a/style.css
+++ b/style.css
@@ -47,6 +47,30 @@ body {
   gap: 8px;
 }
 
+.gradient-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+#gradientStops {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.gradient-stop {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.gradient-stop-percent {
+  min-width: 3ch;
+  text-align: right;
+}
+
 .tool-button {
   width: 32px;
   height: 32px;

--- a/tests/bucketIntegration.test.ts
+++ b/tests/bucketIntegration.test.ts
@@ -17,6 +17,7 @@ describe("bucket tool integration", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="gradient"></button>
       <button id="text"></button>
       <button id="bucket">Bucket</button>
       <button id="eyedropper"></button>

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -18,6 +18,7 @@ describe("editor toolbar controls", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="gradient"></button>
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>

--- a/tests/eyedropperTool.test.ts
+++ b/tests/eyedropperTool.test.ts
@@ -102,6 +102,7 @@ describe("EyedropperTool color history", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="gradient"></button>
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>

--- a/tests/gradientTool.test.ts
+++ b/tests/gradientTool.test.ts
@@ -1,0 +1,134 @@
+import { GradientTool, type GradientConfig } from "../src/tools/GradientTool.js";
+import type { GradientStop } from "../src/tools/GradientTool.js";
+import type { Editor } from "../src/core/Editor.js";
+
+describe("GradientTool", () => {
+  let canvas: HTMLCanvasElement;
+  let ctx: any;
+  let editor: Editor;
+  let notifyChange: jest.Mock;
+
+  const createConfig = (stops: GradientStop[]): GradientConfig => {
+    const listeners = new Set<() => void>();
+    notifyChange = jest.fn(() => {
+      listeners.forEach((listener) => listener());
+    });
+    return {
+      type: "linear",
+      stops,
+      addListener(listener: () => void) {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+      notifyChange,
+    };
+  };
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    canvas = document.createElement("canvas");
+    document.body.appendChild(canvas);
+    Object.defineProperty(canvas, "width", { value: 200, writable: true });
+    Object.defineProperty(canvas, "height", { value: 200, writable: true });
+    canvas.getBoundingClientRect = () => ({
+      width: 200,
+      height: 200,
+      top: 0,
+      left: 0,
+      bottom: 200,
+      right: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+
+    const addColorStop = jest.fn();
+    ctx = {
+      getImageData: jest
+        .fn()
+        .mockReturnValue({
+          data: new Uint8ClampedArray(40000),
+          width: 200,
+          height: 200,
+        } as ImageData),
+      putImageData: jest.fn(),
+      createLinearGradient: jest.fn(() => ({ addColorStop })),
+      createRadialGradient: jest.fn(() => ({ addColorStop })),
+      fillRect: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
+    };
+    editor = { canvas, ctx } as unknown as Editor;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders a linear gradient when released", () => {
+    const config = createConfig([
+      { id: 1, offset: 0, color: "#000000" },
+      { id: 2, offset: 1, color: "#ffffff" },
+    ]);
+    const tool = new GradientTool(config);
+
+    tool.onPointerDown({ offsetX: 10, offsetY: 10 } as PointerEvent, editor);
+    tool.onPointerMove(
+      { offsetX: 110, offsetY: 10, buttons: 1 } as PointerEvent,
+      editor,
+    );
+    tool.onPointerUp({ offsetX: 110, offsetY: 10 } as PointerEvent, editor);
+
+    expect(ctx.createLinearGradient).toHaveBeenCalledWith(10, 10, 110, 10);
+    expect(ctx.fillRect).toHaveBeenCalledWith(0, 0, 200, 200);
+    const gradient = ctx.createLinearGradient.mock.results[0].value;
+    expect(gradient.addColorStop).toHaveBeenCalledWith(0, "#000000");
+    expect(gradient.addColorStop).toHaveBeenCalledWith(1, "#ffffff");
+  });
+
+  it("allows dragging stops to update the gradient", () => {
+    const stops: GradientStop[] = [
+      { id: 1, offset: 0, color: "#000000" },
+      { id: 2, offset: 0.5, color: "#ff0000" },
+      { id: 3, offset: 1, color: "#ffffff" },
+    ];
+    const config = createConfig(stops);
+    const tool = new GradientTool(config);
+
+    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+    tool.onPointerMove({ offsetX: 100, offsetY: 0, buttons: 1 } as PointerEvent, editor);
+    tool.onPointerUp({ offsetX: 100, offsetY: 0 } as PointerEvent, editor);
+
+    ctx.putImageData.mockClear();
+    ctx.fillRect.mockClear();
+    notifyChange.mockClear();
+
+    tool.onPointerDown({ offsetX: 50, offsetY: 0 } as PointerEvent, editor);
+    tool.onPointerMove({ offsetX: 150, offsetY: 0 } as PointerEvent, editor);
+    tool.onPointerUp({ offsetX: 150, offsetY: 0 } as PointerEvent, editor);
+
+    expect(ctx.putImageData).toHaveBeenCalled();
+    expect(ctx.fillRect).toHaveBeenCalled();
+    expect(stops[1].offset).toBeGreaterThan(0.5);
+    expect(stops[1].offset).toBeLessThanOrEqual(1);
+    expect(notifyChange).toHaveBeenCalled();
+  });
+
+  it("supports radial gradients", () => {
+    const config = createConfig([
+      { id: 1, offset: 0, color: "#000000" },
+      { id: 2, offset: 1, color: "#ffffff" },
+    ]);
+    config.type = "radial";
+    const tool = new GradientTool(config);
+
+    tool.onPointerDown({ offsetX: 30, offsetY: 40 } as PointerEvent, editor);
+    tool.onPointerMove(
+      { offsetX: 80, offsetY: 90, buttons: 1 } as PointerEvent,
+      editor,
+    );
+    tool.onPointerUp({ offsetX: 80, offsetY: 90 } as PointerEvent, editor);
+
+    expect(ctx.createRadialGradient).toHaveBeenCalled();
+  });
+});

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -20,6 +20,7 @@ describe("image load and save", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="gradient"></button>
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
@@ -59,9 +60,15 @@ describe("image load and save", () => {
     });
 
     anchor = { href: "", download: "", click: jest.fn() };
+    const realCreateElement = document.createElement.bind(document);
     createElementSpy = jest
       .spyOn(document, "createElement")
-      .mockReturnValue(anchor as any);
+      .mockImplementation((tagName: string, options?: unknown) => {
+        if (tagName.toLowerCase() === "a") {
+          return anchor as any;
+        }
+        return realCreateElement(tagName, options as any);
+      });
 
     class MockFileReader {
       result: string | ArrayBuffer | null = null;

--- a/tests/layers.test.ts
+++ b/tests/layers.test.ts
@@ -21,6 +21,7 @@ describe("layer-specific undo/redo", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="gradient"></button>
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>

--- a/tests/opacity.test.ts
+++ b/tests/opacity.test.ts
@@ -18,6 +18,7 @@ describe("layer opacity", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="gradient"></button>
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -12,6 +12,7 @@ describe("save button", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="gradient"></button>
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
@@ -38,7 +39,17 @@ describe("save button", () => {
     const click = jest.fn();
     const anchor = { href: "", download: "", click } as any;
 
-    jest.spyOn(document, "createElement").mockReturnValue(anchor);
+    const originalCreateElement = document.createElement;
+    (document as unknown as { createElement: typeof document.createElement }).createElement = function (
+      this: Document,
+      tagName: string,
+      options?: unknown,
+    ) {
+      if (tagName.toLowerCase() === "a") {
+        return anchor;
+      }
+      return originalCreateElement.call(this, tagName, options as any);
+    };
 
     const handle = initEditor();
 
@@ -47,6 +58,8 @@ describe("save button", () => {
     expect(click).toHaveBeenCalled();
 
     handle.destroy();
+    (document as unknown as { createElement: typeof document.createElement }).createElement =
+      originalCreateElement;
   });
 
   it("supports selecting jpeg format", () => {
@@ -60,6 +73,7 @@ describe("save button", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="gradient"></button>
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
@@ -85,7 +99,17 @@ describe("save button", () => {
 
     const click = jest.fn();
     const anchor = { href: "", download: "", click } as any;
-    jest.spyOn(document, "createElement").mockReturnValue(anchor);
+    const originalCreateElement = document.createElement;
+    (document as unknown as { createElement: typeof document.createElement }).createElement = function (
+      this: Document,
+      tagName: string,
+      options?: unknown,
+    ) {
+      if (tagName.toLowerCase() === "a") {
+        return anchor;
+      }
+      return originalCreateElement.call(this, tagName, options as any);
+    };
 
     const handle = initEditor();
 
@@ -95,5 +119,7 @@ describe("save button", () => {
     expect(click).toHaveBeenCalled();
 
     handle.destroy();
+    (document as unknown as { createElement: typeof document.createElement }).createElement =
+      originalCreateElement;
   });
 });

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -7,6 +7,7 @@ import { LineTool } from "../src/tools/LineTool.js";
 import { CircleTool } from "../src/tools/CircleTool.js";
 import { TextTool } from "../src/tools/TextTool.js";
 import { BucketFillTool } from "../src/tools/BucketFillTool.js";
+import { GradientTool } from "../src/tools/GradientTool.js";
 import { Shortcuts } from "../src/core/Shortcuts.js";
 import { Editor } from "../src/core/Editor.js";
 
@@ -26,6 +27,7 @@ describe("keyboard shortcuts", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="gradient"></button>
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
@@ -72,6 +74,7 @@ describe("keyboard shortcuts", () => {
       ["c", CircleTool],
       ["t", TextTool],
       ["b", BucketFillTool],
+      ["g", GradientTool],
     ];
 
     cases.forEach(([key, ToolClass], index) => {

--- a/tests/toolbar.test.ts
+++ b/tests/toolbar.test.ts
@@ -6,6 +6,7 @@ import { LineTool } from "../src/tools/LineTool.js";
 import { CircleTool } from "../src/tools/CircleTool.js";
 import { TextTool } from "../src/tools/TextTool.js";
 import { EyedropperTool } from "../src/tools/EyedropperTool.js";
+import { GradientTool } from "../src/tools/GradientTool.js";
 
 describe("toolbar controls", () => {
   let handle: EditorHandle;
@@ -25,6 +26,7 @@ describe("toolbar controls", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="gradient"></button>
       <button id="text"></button>
       <button id="eyedropper"></button>
       <button id="bucket"></button>
@@ -99,6 +101,9 @@ describe("toolbar controls", () => {
 
       (document.getElementById("eyedropper") as HTMLButtonElement).click();
       expect(spy.mock.calls[6][0]).toBeInstanceOf(EyedropperTool);
+
+      (document.getElementById("gradient") as HTMLButtonElement).click();
+      expect(spy.mock.calls[7][0]).toBeInstanceOf(GradientTool);
     });
 
     it("routes tool changes to the selected layer", () => {


### PR DESCRIPTION
## Summary
- implement a gradient tool with draggable stops, preview overlays, and linear/radial support
- add UI controls for managing gradient stops and type along with toolbar/shortcut wiring
- cover the new behavior with dedicated tests and update existing suites

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60d1abcd8832898b625c3472ee822