### PR TITLE
Add transform tool with selection management

### DIFF
--- a/icons/transform.svg
+++ b/icons/transform.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 3v18" />
+  <path d="M3 12h18" />
+  <path d="M15 6l-3-3-3 3" />
+  <path d="M9 18l3 3 3-3" />
+  <path d="M18 9l3 3-3 3" />
+  <path d="M6 9l-3 3 3 3" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -42,6 +42,9 @@
       <button id="eyedropper" class="tool-button" title="Eyedropper">
         <img src="icons/pipette.svg" alt="Eyedropper" />
       </button>
+      <button id="transform" class="tool-button" title="Transform">
+        <img src="icons/transform.svg" alt="Transform" />
+      </button>
       <button id="bucket" class="tool-button" title="Bucket">
         <img src="icons/paint-bucket.svg" alt="Bucket" />
       </button>

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -1,5 +1,19 @@
 import { Tool } from "../tools/Tool.js";
 
+export interface SelectionBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface SelectionState {
+  layer: HTMLCanvasElement;
+  bounds: SelectionBounds;
+}
+
+type SelectionListener = (selection: SelectionState | null) => void;
+
 export class Editor {
   canvas: HTMLCanvasElement;
   ctx: CanvasRenderingContext2D;
@@ -12,6 +26,8 @@ export class Editor {
   fontFamily: HTMLSelectElement | null;
   fontSize: HTMLInputElement | null;
   private onChange?: () => void;
+  private selection: SelectionState | null = null;
+  private selectionListeners: Set<SelectionListener> = new Set();
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -44,6 +60,7 @@ export class Editor {
     this.currentTool?.destroy?.();
     this.currentTool = tool;
     this.canvas.style.cursor = tool.cursor || "crosshair";
+    tool.onActivate?.(this);
   }
 
   private handlePointerDown = (e: PointerEvent) => {
@@ -153,5 +170,52 @@ export class Editor {
     this.canvas.removeEventListener("pointerdown", this.handlePointerDown);
     this.canvas.removeEventListener("pointermove", this.handlePointerMove);
     this.canvas.removeEventListener("pointerup", this.handlePointerUp);
+    this.selectionListeners.clear();
+  }
+
+  getSelection(): SelectionState | null {
+    if (!this.selection) return null;
+    return {
+      layer: this.selection.layer,
+      bounds: { ...this.selection.bounds },
+    };
+  }
+
+  setSelection(selection: SelectionState | null): void {
+    if (!selection) {
+      this.selection = null;
+    } else {
+      this.selection = {
+        layer: selection.layer,
+        bounds: { ...selection.bounds },
+      };
+    }
+    this.notifySelectionChange();
+  }
+
+  clearSelection(): void {
+    this.setSelection(null);
+  }
+
+  updateSelectionBounds(bounds: SelectionBounds): void {
+    if (!this.selection) return;
+    this.selection = {
+      ...this.selection,
+      bounds: { ...bounds },
+    };
+    this.notifySelectionChange();
+  }
+
+  onSelectionChange(listener: SelectionListener): () => void {
+    this.selectionListeners.add(listener);
+    listener(this.getSelection());
+    return () => {
+      this.selectionListeners.delete(listener);
+    };
+  }
+
+  private notifySelectionChange() {
+    const selection = this.getSelection();
+    this.selectionListeners.forEach((listener) => listener(selection));
   }
 }

--- a/src/core/Shortcuts.ts
+++ b/src/core/Shortcuts.ts
@@ -7,6 +7,7 @@ import { TextTool } from "../tools/TextTool.js";
 import { EraserTool } from "../tools/EraserTool.js";
 import { BucketFillTool } from "../tools/BucketFillTool.js";
 import { EyedropperTool } from "../tools/EyedropperTool.js";
+import { TransformTool } from "../tools/TransformTool.js";
 
 
 /**
@@ -78,6 +79,10 @@ export class Shortcuts {
       case "i":
         e.preventDefault();
         this.editor.setTool(new EyedropperTool());
+        break;
+      case "v":
+        e.preventDefault();
+        this.editor.setTool(new TransformTool());
         break;
     }
   }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -8,6 +8,7 @@ import { CircleTool } from "./tools/CircleTool.js";
 import { TextTool } from "./tools/TextTool.js";
 import { BucketFillTool } from "./tools/BucketFillTool.js";
 import { EyedropperTool } from "./tools/EyedropperTool.js";
+import { TransformTool } from "./tools/TransformTool.js";
 import type { Tool } from "./tools/Tool.js";
 
 /** Utility to listen to events and auto-remove on destroy. */
@@ -48,6 +49,7 @@ export function initEditor(): EditorHandle {
     text: TextTool,
     bucket: BucketFillTool,
     eyedropper: EyedropperTool,
+    transform: TransformTool,
   };
 
   const toolButtons: Record<string, HTMLButtonElement> = {};

--- a/src/tools/Tool.ts
+++ b/src/tools/Tool.ts
@@ -5,5 +5,6 @@ export interface Tool {
   onPointerDown(e: PointerEvent, editor: Editor): void;
   onPointerMove(e: PointerEvent, editor: Editor): void;
   onPointerUp(e: PointerEvent, editor: Editor): void;
+  onActivate?(editor: Editor): void;
   destroy?(): void;
 }

--- a/src/tools/TransformTool.ts
+++ b/src/tools/TransformTool.ts
@@ -1,0 +1,598 @@
+import {
+  type SelectionBounds,
+  type SelectionState,
+} from "../core/Editor.js";
+import { Editor } from "../core/Editor.js";
+import type { Tool } from "./Tool.js";
+
+type HandlePosition =
+  | "n"
+  | "ne"
+  | "e"
+  | "se"
+  | "s"
+  | "sw"
+  | "w"
+  | "nw";
+
+interface ActiveInteraction {
+  id: number;
+  mode: "move" | "resize";
+  startX: number;
+  startY: number;
+  initialBounds: SelectionBounds;
+  handle?: HandlePosition;
+}
+
+export class TransformTool implements Tool {
+  cursor = "move";
+
+  private overlay: HTMLDivElement | null = null;
+  private handles: Map<HandlePosition, HTMLDivElement> = new Map();
+  private editor: Editor | null = null;
+  private interaction: ActiveInteraction | null = null;
+  private baseImage: ImageData | null = null;
+  private snapshotCanvas: HTMLCanvasElement | null = null;
+  private selectionSubscription: (() => void) | null = null;
+  private overlayListeners: Array<() => void> = [];
+  private latestBounds: SelectionBounds | null = null;
+
+  onActivate(editor: Editor): void {
+    this.editor = editor;
+    this.ensureSelection(editor);
+    this.ensureOverlay(editor);
+    this.subscribeToSelection(editor);
+    this.updateOverlay(editor.getSelection());
+  }
+
+  onPointerDown(e: PointerEvent, editor: Editor): void {
+    const selection = this.ensureSelection(editor);
+    if (!selection || e.button !== 0) return;
+    const { offsetX, offsetY } = e;
+    if (this.pointInBounds(offsetX, offsetY, selection.bounds)) {
+      this.beginMoveInteraction(e.pointerId, offsetX, offsetY, editor, false);
+    }
+  }
+
+  onPointerMove(e: PointerEvent): void {
+    if (!this.editor || !this.interaction) return;
+    if (this.interaction.id !== e.pointerId) return;
+    this.updateInteraction(e.offsetX, e.offsetY, this.editor);
+  }
+
+  onPointerUp(e: PointerEvent): void {
+    if (!this.editor || !this.interaction) return;
+    if (this.interaction.id !== e.pointerId) return;
+    this.finishInteraction(this.editor);
+  }
+
+  destroy(): void {
+    this.detachOverlay();
+    this.selectionSubscription?.();
+    this.selectionSubscription = null;
+    this.editor = null;
+    this.interaction = null;
+    this.baseImage = null;
+    this.snapshotCanvas = null;
+    this.latestBounds = null;
+  }
+
+  private ensureSelection(editor: Editor): SelectionState | null {
+    const selection = editor.getSelection();
+    if (selection) {
+      return selection;
+    }
+    const rect = editor.canvas.getBoundingClientRect();
+    if (!rect.width || !rect.height) {
+      return null;
+    }
+    const contentBounds = this.getContentBounds(editor);
+    const nextSelection: SelectionState = {
+      layer: editor.canvas,
+      bounds:
+        contentBounds ?? {
+          x: 0,
+          y: 0,
+          width: rect.width,
+          height: rect.height,
+        },
+    };
+    editor.setSelection(nextSelection);
+    return nextSelection;
+  }
+
+  private getContentBounds(editor: Editor): SelectionBounds | null {
+    const rect = editor.canvas.getBoundingClientRect();
+    if (!rect.width || !rect.height) {
+      return null;
+    }
+    const { width, height } = editor.canvas;
+    if (!width || !height) {
+      return null;
+    }
+    const image = editor.ctx.getImageData(0, 0, width, height);
+    const data = image.data;
+    let minX = width;
+    let minY = height;
+    let maxX = -1;
+    let maxY = -1;
+    for (let y = 0; y < height; y += 1) {
+      for (let x = 0; x < width; x += 1) {
+        const alpha = data[(y * width + x) * 4 + 3];
+        if (alpha !== 0) {
+          if (x < minX) minX = x;
+          if (y < minY) minY = y;
+          if (x > maxX) maxX = x;
+          if (y > maxY) maxY = y;
+        }
+      }
+    }
+    if (maxX < minX || maxY < minY) {
+      return null;
+    }
+    const dpr = width / rect.width || 1;
+    return {
+      x: minX / dpr,
+      y: minY / dpr,
+      width: Math.max(1, (maxX - minX + 1) / dpr),
+      height: Math.max(1, (maxY - minY + 1) / dpr),
+    };
+  }
+
+  private subscribeToSelection(editor: Editor) {
+    this.selectionSubscription?.();
+    this.selectionSubscription = editor.onSelectionChange((selection) => {
+      this.updateOverlay(selection);
+    });
+  }
+
+  private ensureOverlay(editor: Editor) {
+    if (this.overlay) return;
+    const container = editor.canvas.parentElement;
+    if (!container) return;
+    const overlay = document.createElement("div");
+    overlay.className = "selection-overlay";
+    container.appendChild(overlay);
+    this.overlay = overlay;
+    this.overlayListeners.push(
+      this.listen(overlay, "pointerdown", (e) => {
+        if (!this.isPointerLike(e) || e.button !== 0) return;
+        if (!this.editor) return;
+        const rect = this.editor.canvas.getBoundingClientRect();
+        const startX = e.clientX - rect.left;
+        const startY = e.clientY - rect.top;
+        const selection = this.ensureSelection(this.editor);
+        if (!selection) return;
+        if ((e.target as HTMLElement).dataset.handle) {
+          return;
+        }
+        this.beginMoveInteraction(e.pointerId, startX, startY, this.editor, true);
+        this.trySetPointerCapture(overlay, e.pointerId);
+      }),
+    );
+
+    const handlePositions: HandlePosition[] = [
+      "nw",
+      "n",
+      "ne",
+      "e",
+      "se",
+      "s",
+      "sw",
+      "w",
+    ];
+
+    handlePositions.forEach((pos) => {
+      const handle = document.createElement("div");
+      handle.className = "selection-handle";
+      handle.dataset.handle = pos;
+      overlay.appendChild(handle);
+      this.overlayListeners.push(
+        this.listen(handle, "pointerdown", (event) => {
+          if (!this.isPointerLike(event) || event.button !== 0) return;
+          if (!this.editor) return;
+          event.stopPropagation();
+          const rect = this.editor.canvas.getBoundingClientRect();
+          const startX = event.clientX - rect.left;
+          const startY = event.clientY - rect.top;
+          this.beginResizeInteraction(
+            event.pointerId,
+            startX,
+            startY,
+            this.editor,
+            pos,
+          );
+          this.trySetPointerCapture(handle, event.pointerId);
+        }),
+      );
+      this.overlayListeners.push(
+        this.listen(handle, "pointerup", (event) => {
+          if (this.isPointerLike(event)) {
+            this.tryReleasePointerCapture(handle, event.pointerId);
+          }
+        }),
+      );
+      this.overlayListeners.push(
+        this.listen(handle, "pointercancel", (event) => {
+          if (this.isPointerLike(event)) {
+            this.tryReleasePointerCapture(handle, event.pointerId);
+          }
+        }),
+      );
+      this.overlayListeners.push(
+        this.listen(handle, "pointermove", (event) => {
+          if (!this.isPointerLike(event)) return;
+          if (!this.editor || !this.interaction) return;
+          if (this.interaction.id !== event.pointerId) return;
+          const rect = this.editor.canvas.getBoundingClientRect();
+          const currentX = event.clientX - rect.left;
+          const currentY = event.clientY - rect.top;
+          this.updateInteraction(currentX, currentY, this.editor);
+        }),
+      );
+      this.overlayListeners.push(
+        this.listen(handle, "lostpointercapture", () => {
+          if (this.editor && this.interaction) {
+            this.finishInteraction(this.editor);
+          }
+        }),
+      );
+      this.handles.set(pos, handle);
+    });
+
+    this.overlayListeners.push(
+      this.listen(overlay, "pointermove", (event) => {
+        if (!this.isPointerLike(event)) return;
+        if (!this.editor || !this.interaction) return;
+        if (this.interaction.id !== event.pointerId) return;
+        const rect = this.editor.canvas.getBoundingClientRect();
+        const currentX = event.clientX - rect.left;
+        const currentY = event.clientY - rect.top;
+        this.updateInteraction(currentX, currentY, this.editor);
+      }),
+    );
+    this.overlayListeners.push(
+      this.listen(overlay, "pointerup", (event) => {
+        if (this.isPointerLike(event)) {
+          this.tryReleasePointerCapture(overlay, event.pointerId);
+        }
+        if (this.editor) {
+          this.finishInteraction(this.editor);
+        }
+      }),
+    );
+    this.overlayListeners.push(
+      this.listen(overlay, "pointercancel", (event) => {
+        if (this.isPointerLike(event)) {
+          this.tryReleasePointerCapture(overlay, event.pointerId);
+        }
+        if (this.editor) {
+          this.finishInteraction(this.editor);
+        }
+      }),
+    );
+  }
+
+  private beginMoveInteraction(
+    pointerId: number,
+    startX: number,
+    startY: number,
+    editor: Editor,
+    initiatedOutsideCanvas: boolean,
+  ) {
+    const selection = this.ensureSelection(editor);
+    if (!selection) return;
+    if (this.interaction) return;
+    this.prepareSnapshot(editor, selection.bounds);
+    if (initiatedOutsideCanvas) {
+      editor.saveState();
+    }
+    this.interaction = {
+      id: pointerId,
+      mode: "move",
+      startX,
+      startY,
+      initialBounds: { ...selection.bounds },
+    };
+  }
+
+  private beginResizeInteraction(
+    pointerId: number,
+    startX: number,
+    startY: number,
+    editor: Editor,
+    handle: HandlePosition,
+  ) {
+    const selection = this.ensureSelection(editor);
+    if (!selection) return;
+    if (this.interaction) return;
+    this.prepareSnapshot(editor, selection.bounds);
+    editor.saveState();
+    this.interaction = {
+      id: pointerId,
+      mode: "resize",
+      startX,
+      startY,
+      handle,
+      initialBounds: { ...selection.bounds },
+    };
+  }
+
+  private prepareSnapshot(editor: Editor, bounds: SelectionBounds) {
+    const rect = editor.canvas.getBoundingClientRect();
+    if (!rect.width || !rect.height || bounds.width === 0 || bounds.height === 0) {
+      return;
+    }
+    const dpr = editor.canvas.width / rect.width;
+    const pixelX = Math.round(bounds.x * dpr);
+    const pixelY = Math.round(bounds.y * dpr);
+    const pixelWidth = Math.max(1, Math.round(bounds.width * dpr));
+    const pixelHeight = Math.max(1, Math.round(bounds.height * dpr));
+    this.baseImage = editor.ctx.getImageData(
+      0,
+      0,
+      editor.canvas.width,
+      editor.canvas.height,
+    );
+    const selectionImage = editor.ctx.getImageData(
+      pixelX,
+      pixelY,
+      pixelWidth,
+      pixelHeight,
+    );
+    const snapshotCanvas = document.createElement("canvas");
+    snapshotCanvas.width = pixelWidth;
+    snapshotCanvas.height = pixelHeight;
+    const snapshotCtx = snapshotCanvas.getContext("2d");
+    if (!snapshotCtx) return;
+    snapshotCtx.putImageData(selectionImage, 0, 0);
+    this.snapshotCanvas = snapshotCanvas;
+    editor.ctx.putImageData(this.baseImage, 0, 0);
+    editor.ctx.clearRect(bounds.x, bounds.y, bounds.width, bounds.height);
+    this.baseImage = editor.ctx.getImageData(
+      0,
+      0,
+      editor.canvas.width,
+      editor.canvas.height,
+    );
+    this.latestBounds = { ...bounds };
+    this.renderPreview(bounds, editor);
+  }
+
+  private updateInteraction(x: number, y: number, editor: Editor) {
+    if (!this.interaction || !this.snapshotCanvas || !this.baseImage) return;
+    const bounds = this.computeBounds(x, y, editor);
+    if (!bounds) return;
+    editor.updateSelectionBounds(bounds);
+    this.renderPreview(bounds, editor);
+    this.updateOverlayForBounds(bounds);
+    this.latestBounds = bounds;
+  }
+
+  private finishInteraction(editor: Editor) {
+    if (!this.interaction) return;
+    const selection = editor.getSelection();
+    if (!selection || !this.snapshotCanvas || !this.baseImage) {
+      this.resetInteraction();
+      return;
+    }
+    const finalBounds = this.latestBounds ?? selection.bounds;
+    editor.updateSelectionBounds(finalBounds);
+    this.renderPreview(finalBounds, editor);
+    this.resetInteraction();
+  }
+
+  private computeBounds(x: number, y: number, editor: Editor): SelectionBounds | null {
+    if (!this.interaction || !editor.getSelection()) return null;
+    const { initialBounds, mode, startX, startY, handle } = this.interaction;
+    const rect = editor.canvas.getBoundingClientRect();
+    const maxWidth = rect.width;
+    const maxHeight = rect.height;
+    let next: SelectionBounds = { ...initialBounds };
+    if (mode === "move") {
+      const dx = x - startX;
+      const dy = y - startY;
+      next = {
+        ...next,
+        x: this.clamp(
+          initialBounds.x + dx,
+          0,
+          Math.max(0, maxWidth - initialBounds.width),
+        ),
+        y: this.clamp(
+          initialBounds.y + dy,
+          0,
+          Math.max(0, maxHeight - initialBounds.height),
+        ),
+      };
+    } else if (mode === "resize" && handle) {
+      const dx = x - startX;
+      const dy = y - startY;
+      switch (handle) {
+        case "n": {
+          const newY = Math.min(
+            initialBounds.y + dy,
+            initialBounds.y + initialBounds.height - 1,
+          );
+          const clampedY = Math.max(0, newY);
+          next.y = clampedY;
+          next.height = Math.max(1, initialBounds.height + (initialBounds.y - clampedY));
+          break;
+        }
+        case "s":
+          next.height = Math.max(1, initialBounds.height + dy);
+          break;
+        case "e":
+          next.width = Math.max(1, initialBounds.width + dx);
+          break;
+        case "w": {
+          const newX = Math.min(
+            initialBounds.x + dx,
+            initialBounds.x + initialBounds.width - 1,
+          );
+          const clampedX = Math.max(0, newX);
+          next.x = clampedX;
+          next.width = Math.max(1, initialBounds.width + (initialBounds.x - clampedX));
+          break;
+        }
+        case "ne": {
+          const newY = Math.min(
+            initialBounds.y + dy,
+            initialBounds.y + initialBounds.height - 1,
+          );
+          const clampedY = Math.max(0, newY);
+          next.width = Math.max(1, initialBounds.width + dx);
+          next.y = clampedY;
+          next.height = Math.max(1, initialBounds.height + (initialBounds.y - clampedY));
+          break;
+        }
+        case "nw": {
+          const newX = Math.min(
+            initialBounds.x + dx,
+            initialBounds.x + initialBounds.width - 1,
+          );
+          const clampedX = Math.max(0, newX);
+          const newY = Math.min(
+            initialBounds.y + dy,
+            initialBounds.y + initialBounds.height - 1,
+          );
+          const clampedY = Math.max(0, newY);
+          next.x = clampedX;
+          next.width = Math.max(1, initialBounds.width + (initialBounds.x - clampedX));
+          next.y = clampedY;
+          next.height = Math.max(1, initialBounds.height + (initialBounds.y - clampedY));
+          break;
+        }
+        case "se":
+          next.width = Math.max(1, initialBounds.width + dx);
+          next.height = Math.max(1, initialBounds.height + dy);
+          break;
+        case "sw": {
+          const newX = Math.min(
+            initialBounds.x + dx,
+            initialBounds.x + initialBounds.width - 1,
+          );
+          const clampedX = Math.max(0, newX);
+          next.x = clampedX;
+          next.width = Math.max(1, initialBounds.width + (initialBounds.x - clampedX));
+          next.height = Math.max(1, initialBounds.height + dy);
+          break;
+        }
+      }
+      next.width = Math.max(1, Math.min(next.width, maxWidth - next.x));
+      next.height = Math.max(1, Math.min(next.height, maxHeight - next.y));
+    }
+    return next;
+  }
+
+  private renderPreview(bounds: SelectionBounds, editor: Editor) {
+    if (!this.snapshotCanvas || !this.baseImage) return;
+    editor.ctx.putImageData(this.baseImage, 0, 0);
+    editor.ctx.drawImage(
+      this.snapshotCanvas,
+      0,
+      0,
+      this.snapshotCanvas.width,
+      this.snapshotCanvas.height,
+      bounds.x,
+      bounds.y,
+      bounds.width,
+      bounds.height,
+    );
+  }
+
+  private updateOverlay(selection: SelectionState | null) {
+    if (!this.overlay) return;
+    if (!selection) {
+      this.overlay.style.display = "none";
+      return;
+    }
+    this.overlay.style.display = "block";
+    this.updateOverlayForBounds(selection.bounds);
+  }
+
+  private updateOverlayForBounds(bounds: SelectionBounds) {
+    if (!this.overlay) return;
+    this.overlay.style.left = `${bounds.x}px`;
+    this.overlay.style.top = `${bounds.y}px`;
+    this.overlay.style.width = `${bounds.width}px`;
+    this.overlay.style.height = `${bounds.height}px`;
+    this.positionHandles(bounds);
+  }
+
+  private positionHandles(bounds: SelectionBounds) {
+    const positions: Record<HandlePosition, [number, number]> = {
+      n: [bounds.width / 2, 0],
+      ne: [bounds.width, 0],
+      e: [bounds.width, bounds.height / 2],
+      se: [bounds.width, bounds.height],
+      s: [bounds.width / 2, bounds.height],
+      sw: [0, bounds.height],
+      w: [0, bounds.height / 2],
+      nw: [0, 0],
+    };
+
+    this.handles.forEach((handle, key) => {
+      const [x, y] = positions[key];
+      handle.style.left = `${x}px`;
+      handle.style.top = `${y}px`;
+    });
+  }
+
+  private resetInteraction() {
+    this.interaction = null;
+    this.baseImage = null;
+    this.snapshotCanvas = null;
+    this.latestBounds = null;
+  }
+
+  private detachOverlay() {
+    this.overlayListeners.forEach((dispose) => dispose());
+    this.overlayListeners = [];
+    if (this.overlay?.parentElement) {
+      this.overlay.parentElement.removeChild(this.overlay);
+    }
+    this.overlay = null;
+    this.handles.clear();
+    this.latestBounds = null;
+  }
+
+  private pointInBounds(x: number, y: number, bounds: SelectionBounds) {
+    return (
+      x >= bounds.x &&
+      y >= bounds.y &&
+      x <= bounds.x + bounds.width &&
+      y <= bounds.y + bounds.height
+    );
+  }
+
+  private clamp(value: number, min: number, max: number) {
+    if (max < min) return min;
+    return Math.min(Math.max(value, min), max);
+  }
+
+  private isPointerLike(event: Event): event is PointerEvent {
+    return typeof (event as PointerEvent).pointerId === "number";
+  }
+
+  private trySetPointerCapture(target: Element, pointerId: number) {
+    (target as unknown as { setPointerCapture?: (id: number) => void }).setPointerCapture?.(
+      pointerId,
+    );
+  }
+
+  private tryReleasePointerCapture(target: Element, pointerId: number) {
+    (target as unknown as { releasePointerCapture?: (id: number) => void }).releasePointerCapture?.(
+      pointerId,
+    );
+  }
+
+  private listen<T extends Event>(
+    target: EventTarget,
+    type: string,
+    handler: (event: T) => void,
+  ) {
+    target.addEventListener(type, handler as EventListener);
+    return () => target.removeEventListener(type, handler as EventListener);
+  }
+}

--- a/style.css
+++ b/style.css
@@ -99,4 +99,45 @@ body {
   box-sizing: border-box;
 }
 
+.selection-overlay {
+  position: absolute;
+  border: 1px dashed #007bff;
+  box-sizing: border-box;
+  pointer-events: auto;
+  display: none;
+  z-index: 10;
+  cursor: move;
+}
+
+.selection-handle {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background: #fff;
+  border: 1px solid #007bff;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  pointer-events: auto;
+}
+
+.selection-handle[data-handle="n"],
+.selection-handle[data-handle="s"] {
+  cursor: ns-resize;
+}
+
+.selection-handle[data-handle="e"],
+.selection-handle[data-handle="w"] {
+  cursor: ew-resize;
+}
+
+.selection-handle[data-handle="ne"],
+.selection-handle[data-handle="sw"] {
+  cursor: nesw-resize;
+}
+
+.selection-handle[data-handle="nw"],
+.selection-handle[data-handle="se"] {
+  cursor: nwse-resize;
+}
+
 

--- a/tests/bucketIntegration.test.ts
+++ b/tests/bucketIntegration.test.ts
@@ -18,8 +18,9 @@ describe("bucket tool integration", () => {
       <button id="line"></button>
       <button id="circle"></button>
       <button id="text"></button>
-      <button id="bucket">Bucket</button>
       <button id="eyedropper"></button>
+      <button id="transform"></button>
+      <button id="bucket">Bucket</button>
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>
     `;

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -19,8 +19,9 @@ describe("editor toolbar controls", () => {
       <button id="line"></button>
       <button id="circle"></button>
       <button id="text"></button>
-      <button id="bucket"></button>
       <button id="eyedropper"></button>
+      <button id="transform"></button>
+      <button id="bucket"></button>
       <select id="formatSelect"><option value="png">PNG</option></select>
       <input id="imageLoader" type="file" />
       <button id="undo"></button>

--- a/tests/eyedropperTool.test.ts
+++ b/tests/eyedropperTool.test.ts
@@ -103,8 +103,9 @@ describe("EyedropperTool color history", () => {
       <button id="line"></button>
       <button id="circle"></button>
       <button id="text"></button>
-      <button id="bucket"></button>
       <button id="eyedropper"></button>
+      <button id="transform"></button>
+      <button id="bucket"></button>
 
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -21,8 +21,9 @@ describe("image load and save", () => {
       <button id="line"></button>
       <button id="circle"></button>
       <button id="text"></button>
-      <button id="bucket"></button>
       <button id="eyedropper"></button>
+      <button id="transform"></button>
+      <button id="bucket"></button>
       <input id="imageLoader" type="file" />
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>

--- a/tests/layers.test.ts
+++ b/tests/layers.test.ts
@@ -22,8 +22,9 @@ describe("layer-specific undo/redo", () => {
       <button id="line"></button>
       <button id="circle"></button>
       <button id="text"></button>
-      <button id="bucket"></button>
       <button id="eyedropper"></button>
+      <button id="transform"></button>
+      <button id="bucket"></button>
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>
       <button id="undo"></button>

--- a/tests/opacity.test.ts
+++ b/tests/opacity.test.ts
@@ -19,8 +19,9 @@ describe("layer opacity", () => {
       <button id="line"></button>
       <button id="circle"></button>
       <button id="text"></button>
-      <button id="bucket"></button>
       <button id="eyedropper"></button>
+      <button id="transform"></button>
+      <button id="bucket"></button>
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>
     `;

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -13,8 +13,9 @@ describe("save button", () => {
       <button id="line"></button>
       <button id="circle"></button>
       <button id="text"></button>
-      <button id="bucket"></button>
       <button id="eyedropper"></button>
+      <button id="transform"></button>
+      <button id="bucket"></button>
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>
     `;
@@ -61,8 +62,9 @@ describe("save button", () => {
       <button id="line"></button>
       <button id="circle"></button>
       <button id="text"></button>
-      <button id="bucket"></button>
       <button id="eyedropper"></button>
+      <button id="transform"></button>
+      <button id="bucket"></button>
       <select id="formatSelect"><option value="png">PNG</option><option value="jpeg" selected>JPEG</option></select>
       <button id="save"></button>
     `;

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -7,6 +7,7 @@ import { LineTool } from "../src/tools/LineTool.js";
 import { CircleTool } from "../src/tools/CircleTool.js";
 import { TextTool } from "../src/tools/TextTool.js";
 import { BucketFillTool } from "../src/tools/BucketFillTool.js";
+import { TransformTool } from "../src/tools/TransformTool.js";
 import { Shortcuts } from "../src/core/Shortcuts.js";
 import { Editor } from "../src/core/Editor.js";
 
@@ -27,18 +28,30 @@ describe("keyboard shortcuts", () => {
       <button id="line"></button>
       <button id="circle"></button>
       <button id="text"></button>
-      <button id="bucket"></button>
       <button id="eyedropper"></button>
+      <button id="transform"></button>
+      <button id="bucket"></button>
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>
     `;
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
     (canvas as any).setPointerCapture = jest.fn();
     (canvas as any).releasePointerCapture = jest.fn();
+    const imageFor = (sw: number, sh: number): ImageData =>
+      ({
+        data: new Uint8ClampedArray(sw * sh * 4),
+        width: sw,
+        height: sh,
+      } as ImageData);
+
     ctx = {
       setTransform: jest.fn(),
       scale: jest.fn(),
-      getImageData: jest.fn(),
+      getImageData: jest
+        .fn()
+        .mockImplementation((sx: number, sy: number, sw: number, sh: number) =>
+          imageFor(sw, sh),
+        ),
       putImageData: jest.fn(),
       clearRect: jest.fn(),
     };
@@ -72,6 +85,7 @@ describe("keyboard shortcuts", () => {
       ["c", CircleTool],
       ["t", TextTool],
       ["b", BucketFillTool],
+      ["v", TransformTool],
     ];
 
     cases.forEach(([key, ToolClass], index) => {

--- a/tests/toolbar.test.ts
+++ b/tests/toolbar.test.ts
@@ -6,6 +6,7 @@ import { LineTool } from "../src/tools/LineTool.js";
 import { CircleTool } from "../src/tools/CircleTool.js";
 import { TextTool } from "../src/tools/TextTool.js";
 import { EyedropperTool } from "../src/tools/EyedropperTool.js";
+import { TransformTool } from "../src/tools/TransformTool.js";
 
 describe("toolbar controls", () => {
   let handle: EditorHandle;
@@ -27,6 +28,7 @@ describe("toolbar controls", () => {
       <button id="circle"></button>
       <button id="text"></button>
       <button id="eyedropper"></button>
+      <button id="transform"></button>
       <button id="bucket"></button>
 
       <select id="formatSelect"><option value="png">PNG</option></select>
@@ -39,14 +41,35 @@ describe("toolbar controls", () => {
 
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
     const canvas2 = document.getElementById("canvas2") as HTMLCanvasElement;
+    const imageFor = (sw: number, sh: number): ImageData =>
+      ({
+        data: new Uint8ClampedArray(sw * sh * 4),
+        width: sw,
+        height: sh,
+      } as ImageData);
+
     ctx = {
       setTransform: jest.fn(),
       scale: jest.fn(),
-      getImageData: jest.fn(),
+      getImageData: jest
+        .fn()
+        .mockImplementation((sx: number, sy: number, sw: number, sh: number) =>
+          imageFor(sw, sh),
+        ),
       putImageData: jest.fn(),
       clearRect: jest.fn(),
     };
-    const ctx2 = { ...ctx } as Partial<CanvasRenderingContext2D>;
+    const ctx2 = {
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+      getImageData: jest
+        .fn()
+        .mockImplementation((sx: number, sy: number, sw: number, sh: number) =>
+          imageFor(sw, sh),
+        ),
+      putImageData: jest.fn(),
+      clearRect: jest.fn(),
+    } as Partial<CanvasRenderingContext2D>;
     canvas.getContext = jest.fn().mockReturnValue(ctx as CanvasRenderingContext2D);
     canvas2.getContext = jest.fn().mockReturnValue(ctx2 as CanvasRenderingContext2D);
 
@@ -99,6 +122,9 @@ describe("toolbar controls", () => {
 
       (document.getElementById("eyedropper") as HTMLButtonElement).click();
       expect(spy.mock.calls[6][0]).toBeInstanceOf(EyedropperTool);
+
+      (document.getElementById("transform") as HTMLButtonElement).click();
+      expect(spy.mock.calls[7][0]).toBeInstanceOf(TransformTool);
     });
 
     it("routes tool changes to the selected layer", () => {

--- a/tests/transformTool.test.ts
+++ b/tests/transformTool.test.ts
@@ -1,0 +1,190 @@
+import { Editor } from "../src/core/Editor.js";
+import { TransformTool } from "../src/tools/TransformTool.js";
+
+describe("TransformTool", () => {
+  function createEditor() {
+    document.body.innerHTML = `
+      <div id="container"><canvas id="canvas"></canvas></div>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
+    `;
+
+    const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    const color = document.getElementById("colorPicker") as HTMLInputElement;
+    const width = document.getElementById("lineWidth") as HTMLInputElement;
+    const fill = document.getElementById("fillMode") as HTMLInputElement;
+
+    const rect = {
+      width: 10,
+      height: 10,
+      top: 0,
+      left: 0,
+      right: 10,
+      bottom: 10,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    } as DOMRect;
+    canvas.getBoundingClientRect = () => rect;
+
+    const basePixels = new Uint8ClampedArray(10 * 10 * 4);
+    for (let y = 2; y < 6; y += 1) {
+      for (let x = 2; x < 6; x += 1) {
+        const index = (y * 10 + x) * 4;
+        basePixels[index] = 255;
+        basePixels[index + 3] = 255;
+      }
+    }
+    let currentPixels = new Uint8ClampedArray(basePixels);
+
+    const makeImageData = (sw: number, sh: number): ImageData =>
+      ({
+        data: new Uint8ClampedArray(sw * sh * 4),
+        width: sw,
+        height: sh,
+      } as ImageData);
+
+    const originalCreateElement = document.createElement.bind(document);
+    document.createElement = ((tag: string) => {
+      if (tag.toLowerCase() === "canvas") {
+        const offscreen = originalCreateElement(tag) as HTMLCanvasElement;
+        offscreen.getContext = jest.fn().mockImplementation((type: string) => {
+          if (type !== "2d") return null;
+          return {
+            putImageData: jest.fn(),
+            drawImage: jest.fn(),
+            clearRect: jest.fn(),
+            getImageData: jest
+              .fn()
+              .mockImplementation((sx: number, sy: number, sw: number, sh: number) =>
+                makeImageData(sw, sh),
+              ),
+          } as unknown as CanvasRenderingContext2D;
+        });
+        return offscreen as any;
+      }
+      return originalCreateElement(tag);
+    }) as typeof document.createElement;
+
+    const getImageData = jest.fn(
+      (sx: number, sy: number, sw: number, sh: number) => {
+        const image = makeImageData(sw, sh);
+        for (let y = 0; y < sh; y += 1) {
+          for (let x = 0; x < sw; x += 1) {
+            const src = ((sy + y) * 10 + (sx + x)) * 4;
+            const dest = (y * sw + x) * 4;
+            image.data[dest] = currentPixels[src];
+            image.data[dest + 1] = currentPixels[src + 1];
+            image.data[dest + 2] = currentPixels[src + 2];
+            image.data[dest + 3] = currentPixels[src + 3];
+          }
+        }
+        return image;
+      },
+    );
+
+    const putImageData = jest.fn((image: ImageData, dx: number, dy: number) => {
+      for (let y = 0; y < image.height; y += 1) {
+        for (let x = 0; x < image.width; x += 1) {
+          const src = (y * image.width + x) * 4;
+          const dest = ((dy + y) * 10 + (dx + x)) * 4;
+          currentPixels[dest] = image.data[src];
+          currentPixels[dest + 1] = image.data[src + 1];
+          currentPixels[dest + 2] = image.data[src + 2];
+          currentPixels[dest + 3] = image.data[src + 3];
+        }
+      }
+    });
+
+    const clearRect = jest.fn((x: number, y: number, w: number, h: number) => {
+      const startX = Math.floor(x);
+      const startY = Math.floor(y);
+      const endX = Math.min(10, Math.ceil(x + w));
+      const endY = Math.min(10, Math.ceil(y + h));
+      for (let yy = startY; yy < endY; yy += 1) {
+        for (let xx = startX; xx < endX; xx += 1) {
+          currentPixels[(yy * 10 + xx) * 4 + 3] = 0;
+        }
+      }
+    });
+
+    const drawImage = jest.fn();
+
+    const ctx = {
+      getImageData,
+      putImageData,
+      clearRect,
+      drawImage,
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+    } as unknown as CanvasRenderingContext2D;
+
+    canvas.getContext = jest.fn().mockReturnValue(ctx);
+
+    const editor = new Editor(canvas, color, width, fill);
+    const restore = () => {
+      document.createElement = originalCreateElement;
+    };
+    return { editor, drawImage, restore };
+  }
+
+  it("moves the current selection when dragged", () => {
+    const { editor, drawImage, restore } = createEditor();
+    const tool = new TransformTool();
+    editor.setTool(tool);
+
+    try {
+      const down = { offsetX: 3, offsetY: 3, pointerId: 1, button: 0 } as PointerEvent;
+      tool.onPointerDown(down, editor);
+      tool.onPointerMove({ offsetX: 5, offsetY: 6, pointerId: 1 } as PointerEvent, editor);
+      tool.onPointerUp({ offsetX: 5, offsetY: 6, pointerId: 1 } as PointerEvent, editor);
+
+      const selection = editor.getSelection();
+      expect(selection?.bounds).toEqual({ x: 4, y: 5, width: 4, height: 4 });
+      const lastCall = drawImage.mock.calls.at(-1);
+      expect(lastCall?.slice(5)).toEqual([4, 5, 4, 4]);
+    } finally {
+      restore();
+      editor.destroy();
+    }
+  });
+
+  it("resizes the selection via handles", () => {
+    const { editor, drawImage, restore } = createEditor();
+    const tool = new TransformTool();
+    editor.setTool(tool);
+
+    try {
+      const handle = document.querySelector(
+        ".selection-handle[data-handle=\"se\"]",
+      ) as HTMLDivElement;
+      const pointerDown = new MouseEvent("pointerdown", { bubbles: true });
+      Object.defineProperty(pointerDown, "pointerId", { value: 2 });
+      Object.defineProperty(pointerDown, "button", { value: 0 });
+      Object.defineProperty(pointerDown, "clientX", { value: 6 });
+      Object.defineProperty(pointerDown, "clientY", { value: 6 });
+      handle.dispatchEvent(pointerDown);
+
+      const pointerMove = new MouseEvent("pointermove", { bubbles: true });
+      Object.defineProperty(pointerMove, "pointerId", { value: 2 });
+      Object.defineProperty(pointerMove, "clientX", { value: 8 });
+      Object.defineProperty(pointerMove, "clientY", { value: 9 });
+      handle.dispatchEvent(pointerMove);
+
+      const pointerUp = new MouseEvent("pointerup", { bubbles: true });
+      Object.defineProperty(pointerUp, "pointerId", { value: 2 });
+      Object.defineProperty(pointerUp, "clientX", { value: 8 });
+      Object.defineProperty(pointerUp, "clientY", { value: 9 });
+      handle.dispatchEvent(pointerUp);
+
+      const selection = editor.getSelection();
+      expect(selection?.bounds).toEqual({ x: 2, y: 2, width: 6, height: 7 });
+      const lastCall = drawImage.mock.calls.at(-1);
+      expect(lastCall?.slice(5)).toEqual([2, 2, 6, 7]);
+    } finally {
+      restore();
+      editor.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- implement a TransformTool that creates selection overlays, supports move/resize handles, and keeps editor selection state in sync
- expose the transform feature through a toolbar button, keyboard shortcut, new icon, and overlay styling
- add focused transform tests and update existing fixtures to include the tool in shortcut and toolbar flows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60d17d7088328a6843b75870f5ca7