### PR TITLE
Enhance text tool with typography controls

### DIFF
--- a/dist/core/Editor.js
+++ b/dist/core/Editor.js
@@ -1,5 +1,5 @@
 export class Editor {
-    constructor(canvas, colorPicker, lineWidth, fillMode, onChange, fontFamily, fontSize) {
+    constructor(canvas, colorPicker, lineWidth, fillMode, onChange, fontFamily, fontSize, fontWeight, fontStyleControl, textAlignControl, textMultilineToggle) {
         this.undoStack = [];
         this.redoStack = [];
         this.currentTool = null;
@@ -32,6 +32,10 @@ export class Editor {
         this.onChange = onChange;
         this.fontFamily = fontFamily ?? null;
         this.fontSize = fontSize ?? null;
+        this.fontWeight = fontWeight ?? null;
+        this.fontStyleControl = fontStyleControl ?? null;
+        this.textAlignControl = textAlignControl ?? null;
+        this.textMultilineToggle = textMultilineToggle ?? null;
         this.adjustForPixelRatio();
         window.addEventListener("resize", this.handleResize);
         this.canvas.addEventListener("pointerdown", this.handlePointerDown);
@@ -97,6 +101,22 @@ export class Editor {
     }
     get fontSizeValue() {
         return parseInt(this.fontSize?.value ?? "", 10) || 16;
+    }
+    get fontWeightValue() {
+        return this.fontWeight?.value || "normal";
+    }
+    get fontStyleValue() {
+        return this.fontStyleControl?.value || "normal";
+    }
+    get textAlignValue() {
+        const value = this.textAlignControl?.value || "left";
+        if (value === "center" || value === "right" || value === "left") {
+            return value;
+        }
+        return "left";
+    }
+    get textMultiline() {
+        return Boolean(this.textMultilineToggle?.checked ?? true);
     }
     /**
      * Remove all event listeners registered by the editor.

--- a/dist/editor.js
+++ b/dist/editor.js
@@ -71,6 +71,10 @@ export function initEditor() {
     const fillMode = document.getElementById("fillMode");
     const fontFamily = document.getElementById("fontFamily");
     const fontSize = document.getElementById("fontSize");
+    const fontWeight = document.getElementById("fontWeight");
+    const fontStyleControl = document.getElementById("fontStyle");
+    const textAlignControl = document.getElementById("textAlign");
+    const textMultilineToggle = document.getElementById("textMultiline");
     const layerSelect = document.getElementById("layerSelect");
     const toolbar = document.getElementById("toolbar") || document.body;
     const saveBtn = document.getElementById("save");
@@ -166,7 +170,7 @@ export function initEditor() {
         try {
             const e = new Editor(c, colorPicker, lineWidth, fillMode, () => {
                 updateHistoryButtons();
-            }, fontFamily ?? undefined, fontSize ?? undefined);
+            }, fontFamily ?? undefined, fontSize ?? undefined, fontWeight ?? undefined, fontStyleControl ?? undefined, textAlignControl ?? undefined, textMultilineToggle ?? undefined);
             editors.push(e);
         }
         catch {

--- a/dist/tools/TextTool.js
+++ b/dist/tools/TextTool.js
@@ -3,38 +3,78 @@ export class TextTool {
         this.textarea = null;
         this.blurListener = null;
         this.keydownListener = null;
+        this.startX = 0;
+        this.startY = 0;
+        this.fontWeight = "normal";
+        this.fontStyle = "normal";
+        this.textAlign = "left";
+        this.multiline = true;
+        this.defaultWidth = 200;
+        this.defaultHeight = 48;
     }
     onPointerDown(e, editor) {
         this.cleanup();
+        this.startX = e.offsetX;
+        this.startY = e.offsetY;
+        this.fontWeight = editor.fontWeightValue;
+        this.fontStyle = editor.fontStyleValue;
+        this.textAlign = editor.textAlignValue;
+        this.multiline = editor.textMultiline;
         const textarea = document.createElement("textarea");
         textarea.style.position = "absolute";
         const parent = editor.canvas.parentElement || document.body;
-        textarea.style.left = `${e.offsetX}px`;
-        textarea.style.top = `${e.offsetY}px`;
+        textarea.style.left = `${this.startX}px`;
+        textarea.style.top = `${this.startY}px`;
         textarea.style.color = editor.strokeStyle;
         textarea.style.fontSize = `${editor.fontSizeValue}px`;
         textarea.style.fontFamily = editor.fontFamilyValue;
+        textarea.style.fontWeight = this.fontWeight;
+        textarea.style.fontStyle = this.fontStyle;
         textarea.style.background = "transparent";
-        textarea.style.border = "none";
+        textarea.style.border = "1px dashed #888";
         textarea.style.outline = "none";
+        textarea.style.resize = this.multiline ? "both" : "horizontal";
+        textarea.style.overflow = this.multiline ? "auto" : "hidden";
+        textarea.wrap = this.multiline ? "soft" : "off";
+        textarea.style.whiteSpace = this.multiline ? "pre-wrap" : "nowrap";
+        textarea.style.minWidth = "80px";
+        textarea.style.minHeight = `${Math.max(32, editor.fontSizeValue * 1.5)}px`;
+        textarea.style.width = `${this.defaultWidth}px`;
+        textarea.style.height = `${this.defaultHeight}px`;
+        textarea.style.padding = "0";
+        textarea.style.textAlign = this.textAlign;
         parent.appendChild(textarea);
         textarea.focus();
         const commit = () => {
-            const text = textarea.value;
-            this.cleanup();
-            if (text) {
-                editor.ctx.fillStyle = editor.strokeStyle;
-                editor.ctx.font = `${editor.fontSizeValue}px ${editor.fontFamilyValue}`;
-                editor.ctx.fillText(text, e.offsetX, e.offsetY);
+            if (!this.textarea) {
+                return;
             }
+            const currentTextarea = this.textarea;
+            const text = this.multiline
+                ? currentTextarea.value
+                : currentTextarea.value.split(/\r?\n/)[0] ?? "";
+            if (!text.trim()) {
+                this.cleanup();
+                return;
+            }
+            const width = this.getDimension(currentTextarea, "width");
+            const font = this.composeFont(editor);
+            const lines = this.computeLines(text, width, editor, font);
+            this.drawLines(lines, width, editor, font);
+            this.cleanup();
         };
         const cancel = () => {
             this.cleanup();
         };
-        this.blurListener = cancel;
+        this.blurListener = () => {
+            commit();
+        };
         textarea.addEventListener("blur", this.blurListener);
         this.keydownListener = (ev) => {
             if (ev.key === "Enter") {
+                if (this.multiline && !(ev.metaKey || ev.ctrlKey)) {
+                    return;
+                }
                 ev.preventDefault();
                 commit();
             }
@@ -72,5 +112,105 @@ export class TextTool {
         this.textarea = null;
         this.blurListener = null;
         this.keydownListener = null;
+    }
+    composeFont(editor) {
+        const parts = [];
+        if (this.fontStyle !== "normal") {
+            parts.push(this.fontStyle);
+        }
+        if (this.fontWeight !== "normal") {
+            parts.push(this.fontWeight);
+        }
+        parts.push(`${editor.fontSizeValue}px`);
+        parts.push(editor.fontFamilyValue);
+        return parts.join(" ");
+    }
+    getDimension(textarea, prop) {
+        const clientValue = prop === "width" ? textarea.clientWidth : textarea.clientHeight;
+        if (clientValue)
+            return clientValue;
+        const fromStyle = parseFloat(window.getComputedStyle(textarea)[prop]);
+        if (!Number.isNaN(fromStyle) && fromStyle > 0) {
+            return fromStyle;
+        }
+        return prop === "width" ? this.defaultWidth : this.defaultHeight;
+    }
+    computeLines(text, maxWidth, editor, font) {
+        const ctx = editor.ctx;
+        ctx.save();
+        ctx.font = font;
+        const lines = [];
+        if (!this.multiline || maxWidth <= 0) {
+            text
+                .split(/\r?\n/)
+                .forEach((line) => lines.push(line));
+            ctx.restore();
+            return lines;
+        }
+        const paragraphs = text.split(/\r?\n/);
+        paragraphs.forEach((paragraph, index) => {
+            if (!paragraph.length) {
+                lines.push("");
+                return;
+            }
+            const words = paragraph.split(/\s+/);
+            let current = "";
+            words.forEach((word) => {
+                if (!word)
+                    return;
+                const tentative = current ? `${current} ${word}` : word;
+                if (ctx.measureText(tentative).width > maxWidth && current) {
+                    lines.push(current);
+                    current = word;
+                }
+                else {
+                    current = tentative;
+                }
+            });
+            if (current) {
+                lines.push(current);
+            }
+            if (index < paragraphs.length - 1 && paragraph.endsWith(" ")) {
+                lines.push("");
+            }
+        });
+        ctx.restore();
+        return lines;
+    }
+    drawLines(lines, width, editor, font) {
+        const ctx = editor.ctx;
+        ctx.save();
+        ctx.fillStyle = editor.strokeStyle;
+        ctx.font = font;
+        ctx.textAlign = this.textAlign;
+        ctx.textBaseline = "alphabetic";
+        const defaultAscent = editor.fontSizeValue * 0.8;
+        const defaultDescent = editor.fontSizeValue * 0.2;
+        let y = this.startY;
+        lines.forEach((line, index) => {
+            const metrics = ctx.measureText(line || " ");
+            const ascent = metrics.actualBoundingBoxAscent || defaultAscent;
+            const descent = metrics.actualBoundingBoxDescent || defaultDescent;
+            y += ascent;
+            ctx.fillText(line, this.resolveX(width), y);
+            y += descent;
+            if (this.multiline && index < lines.length - 1) {
+                y += defaultDescent;
+            }
+        });
+        ctx.restore();
+    }
+    resolveX(width) {
+        switch (this.textAlign) {
+            case "center":
+                return this.startX + width / 2;
+            case "right":
+            case "end":
+                return this.startX + width;
+            case "left":
+            case "start":
+            default:
+                return this.startX;
+        }
     }
 }

--- a/index.html
+++ b/index.html
@@ -17,6 +17,26 @@
         <option value="monospace">Monospace</option>
       </select>
       <input type="number" id="fontSize" min="1" value="16" />
+      <select id="fontWeight">
+        <option value="normal">Normal</option>
+        <option value="bold">Bold</option>
+        <option value="bolder">Bolder</option>
+        <option value="lighter">Lighter</option>
+      </select>
+      <select id="fontStyle">
+        <option value="normal">Regular</option>
+        <option value="italic">Italic</option>
+        <option value="oblique">Oblique</option>
+      </select>
+      <select id="textAlign">
+        <option value="left">Left</option>
+        <option value="center">Center</option>
+        <option value="right">Right</option>
+      </select>
+      <label>
+        <input type="checkbox" id="textMultiline" checked />
+        Multiline
+      </label>
       <label>
         <input type="checkbox" id="fillMode" />
         Fill

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -11,6 +11,10 @@ export class Editor {
   fillMode: HTMLInputElement;
   fontFamily: HTMLSelectElement | null;
   fontSize: HTMLInputElement | null;
+  fontWeight: HTMLSelectElement | null;
+  fontStyleControl: HTMLSelectElement | null;
+  textAlignControl: HTMLSelectElement | null;
+  textMultilineToggle: HTMLInputElement | null;
   private onChange?: () => void;
 
   constructor(
@@ -21,6 +25,10 @@ export class Editor {
     onChange?: () => void,
     fontFamily?: HTMLSelectElement | null,
     fontSize?: HTMLInputElement | null,
+    fontWeight?: HTMLSelectElement | null,
+    fontStyleControl?: HTMLSelectElement | null,
+    textAlignControl?: HTMLSelectElement | null,
+    textMultilineToggle?: HTMLInputElement | null,
   ) {
     this.canvas = canvas;
     const ctx = canvas.getContext("2d");
@@ -32,6 +40,10 @@ export class Editor {
     this.onChange = onChange;
     this.fontFamily = fontFamily ?? null;
     this.fontSize = fontSize ?? null;
+    this.fontWeight = fontWeight ?? null;
+    this.fontStyleControl = fontStyleControl ?? null;
+    this.textAlignControl = textAlignControl ?? null;
+    this.textMultilineToggle = textMultilineToggle ?? null;
     this.adjustForPixelRatio();
     window.addEventListener("resize", this.handleResize);
 
@@ -141,6 +153,26 @@ export class Editor {
 
   get fontSizeValue() {
     return parseInt(this.fontSize?.value ?? "", 10) || 16;
+  }
+
+  get fontWeightValue() {
+    return this.fontWeight?.value || "normal";
+  }
+
+  get fontStyleValue() {
+    return this.fontStyleControl?.value || "normal";
+  }
+
+  get textAlignValue(): CanvasTextAlign {
+    const value = this.textAlignControl?.value || "left";
+    if (value === "center" || value === "right" || value === "left") {
+      return value;
+    }
+    return "left";
+  }
+
+  get textMultiline() {
+    return Boolean(this.textMultilineToggle?.checked ?? true);
   }
 
   /**

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -91,6 +91,16 @@ export function initEditor(): EditorHandle {
   const fillMode = document.getElementById("fillMode") as HTMLInputElement | null;
   const fontFamily = document.getElementById("fontFamily") as HTMLSelectElement | null;
   const fontSize = document.getElementById("fontSize") as HTMLInputElement | null;
+  const fontWeight = document.getElementById("fontWeight") as HTMLSelectElement | null;
+  const fontStyleControl = document.getElementById(
+    "fontStyle",
+  ) as HTMLSelectElement | null;
+  const textAlignControl = document.getElementById(
+    "textAlign",
+  ) as HTMLSelectElement | null;
+  const textMultilineToggle = document.getElementById(
+    "textMultiline",
+  ) as HTMLInputElement | null;
   const layerSelect = document.getElementById("layerSelect") as HTMLSelectElement | null;
   const toolbar = document.getElementById("toolbar") || document.body;
   const saveBtn = document.getElementById("save") as HTMLButtonElement | null;
@@ -212,6 +222,10 @@ export function initEditor(): EditorHandle {
         },
         fontFamily ?? undefined,
         fontSize ?? undefined,
+        fontWeight ?? undefined,
+        fontStyleControl ?? undefined,
+        textAlignControl ?? undefined,
+        textMultilineToggle ?? undefined,
       );
       editors.push(e);
     } catch {

--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -7,42 +7,82 @@ export class TextTool implements Tool {
   keydownListener:
     | ((this: HTMLTextAreaElement, ev: KeyboardEvent) => void)
     | null = null;
+  startX = 0;
+  startY = 0;
+  fontWeight = "normal";
+  fontStyle = "normal";
+  textAlign: CanvasTextAlign = "left";
+  multiline = true;
+  defaultWidth = 200;
+  defaultHeight = 48;
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
     this.cleanup();
+    this.startX = e.offsetX;
+    this.startY = e.offsetY;
+    this.fontWeight = editor.fontWeightValue;
+    this.fontStyle = editor.fontStyleValue;
+    this.textAlign = editor.textAlignValue;
+    this.multiline = editor.textMultiline;
     const textarea = document.createElement("textarea");
     textarea.style.position = "absolute";
     const parent = editor.canvas.parentElement || document.body;
-    textarea.style.left = `${e.offsetX}px`;
-    textarea.style.top = `${e.offsetY}px`;
+    textarea.style.left = `${this.startX}px`;
+    textarea.style.top = `${this.startY}px`;
     textarea.style.color = editor.strokeStyle;
     textarea.style.fontSize = `${editor.fontSizeValue}px`;
     textarea.style.fontFamily = editor.fontFamilyValue;
+    textarea.style.fontWeight = this.fontWeight;
+    textarea.style.fontStyle = this.fontStyle;
     textarea.style.background = "transparent";
-    textarea.style.border = "none";
+    textarea.style.border = "1px dashed #888";
     textarea.style.outline = "none";
+    textarea.style.resize = this.multiline ? "both" : "horizontal";
+    textarea.style.overflow = this.multiline ? "auto" : "hidden";
+    textarea.wrap = this.multiline ? "soft" : "off";
+    textarea.style.whiteSpace = this.multiline ? "pre-wrap" : "nowrap";
+    textarea.style.minWidth = "80px";
+    textarea.style.minHeight = `${Math.max(32, editor.fontSizeValue * 1.5)}px`;
+    textarea.style.width = `${this.defaultWidth}px`;
+    textarea.style.height = `${this.defaultHeight}px`;
+    textarea.style.padding = "0";
+    textarea.style.textAlign = this.textAlign;
     parent.appendChild(textarea);
     textarea.focus();
 
     const commit = () => {
-      const text = textarea.value;
-      this.cleanup();
-      if (text) {
-        editor.ctx.fillStyle = editor.strokeStyle;
-        editor.ctx.font = `${editor.fontSizeValue}px ${editor.fontFamilyValue}`;
-        editor.ctx.fillText(text, e.offsetX, e.offsetY);
+      if (!this.textarea) {
+        return;
       }
+      const currentTextarea = this.textarea;
+      const text = this.multiline
+        ? currentTextarea.value
+        : currentTextarea.value.split(/\r?\n/)[0] ?? "";
+      if (!text.trim()) {
+        this.cleanup();
+        return;
+      }
+      const width = this.getDimension(currentTextarea, "width");
+      const font = this.composeFont(editor);
+      const lines = this.computeLines(text, width, editor, font);
+      this.drawLines(lines, width, editor, font);
+      this.cleanup();
     };
 
     const cancel = () => {
       this.cleanup();
     };
 
-    this.blurListener = cancel;
+    this.blurListener = () => {
+      commit();
+    };
     textarea.addEventListener("blur", this.blurListener);
 
     this.keydownListener = (ev: KeyboardEvent) => {
       if (ev.key === "Enter") {
+        if (this.multiline && !(ev.metaKey || ev.ctrlKey)) {
+          return;
+        }
         ev.preventDefault();
         commit();
       } else if (ev.key === "Escape") {
@@ -83,5 +123,112 @@ export class TextTool implements Tool {
     this.textarea = null;
     this.blurListener = null;
     this.keydownListener = null;
+  }
+
+  private composeFont(editor: Editor) {
+    const parts = [] as string[];
+    if (this.fontStyle !== "normal") {
+      parts.push(this.fontStyle);
+    }
+    if (this.fontWeight !== "normal") {
+      parts.push(this.fontWeight);
+    }
+    parts.push(`${editor.fontSizeValue}px`);
+    parts.push(editor.fontFamilyValue);
+    return parts.join(" ");
+  }
+
+  private getDimension(textarea: HTMLTextAreaElement, prop: "width" | "height") {
+    const clientValue = prop === "width" ? textarea.clientWidth : textarea.clientHeight;
+    if (clientValue) return clientValue;
+    const fromStyle = parseFloat(window.getComputedStyle(textarea)[prop]);
+    if (!Number.isNaN(fromStyle) && fromStyle > 0) {
+      return fromStyle;
+    }
+    return prop === "width" ? this.defaultWidth : this.defaultHeight;
+  }
+
+  private computeLines(
+    text: string,
+    maxWidth: number,
+    editor: Editor,
+    font: string,
+  ) {
+    const ctx = editor.ctx;
+    ctx.save();
+    ctx.font = font;
+    const lines: string[] = [];
+    if (!this.multiline || maxWidth <= 0) {
+      text
+        .split(/\r?\n/)
+        .forEach((line) => lines.push(line));
+      ctx.restore();
+      return lines;
+    }
+    const paragraphs = text.split(/\r?\n/);
+    paragraphs.forEach((paragraph, index) => {
+      if (!paragraph.length) {
+        lines.push("");
+        return;
+      }
+      const words = paragraph.split(/\s+/);
+      let current = "";
+      words.forEach((word) => {
+        if (!word) return;
+        const tentative = current ? `${current} ${word}` : word;
+        if (ctx.measureText(tentative).width > maxWidth && current) {
+          lines.push(current);
+          current = word;
+        } else {
+          current = tentative;
+        }
+      });
+      if (current) {
+        lines.push(current);
+      }
+      if (index < paragraphs.length - 1 && paragraph.endsWith(" ")) {
+        lines.push("");
+      }
+    });
+    ctx.restore();
+    return lines;
+  }
+
+  private drawLines(lines: string[], width: number, editor: Editor, font: string) {
+    const ctx = editor.ctx;
+    ctx.save();
+    ctx.fillStyle = editor.strokeStyle;
+    ctx.font = font;
+    ctx.textAlign = this.textAlign;
+    ctx.textBaseline = "alphabetic";
+    const defaultAscent = editor.fontSizeValue * 0.8;
+    const defaultDescent = editor.fontSizeValue * 0.2;
+    let y = this.startY;
+    lines.forEach((line, index) => {
+      const metrics = ctx.measureText(line || " ");
+      const ascent = metrics.actualBoundingBoxAscent || defaultAscent;
+      const descent = metrics.actualBoundingBoxDescent || defaultDescent;
+      y += ascent;
+      ctx.fillText(line, this.resolveX(width), y);
+      y += descent;
+      if (this.multiline && index < lines.length - 1) {
+        y += defaultDescent;
+      }
+    });
+    ctx.restore();
+  }
+
+  private resolveX(width: number) {
+    switch (this.textAlign) {
+      case "center":
+        return this.startX + width / 2;
+      case "right":
+      case "end":
+        return this.startX + width;
+      case "left":
+      case "start":
+      default:
+        return this.startX;
+    }
   }
 }

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -13,6 +13,12 @@ describe("editor toolbar controls", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
+      <select id="fontFamily"><option value="sans-serif">sans-serif</option></select>
+      <input id="fontSize" value="16" />
+      <select id="fontWeight"><option value="normal">normal</option></select>
+      <select id="fontStyle"><option value="normal">normal</option></select>
+      <select id="textAlign"><option value="left">left</option></select>
+      <input id="textMultiline" type="checkbox" />
       <button id="pencil"></button>
       <button id="eraser"></button>
       <button id="rectangle"></button>
@@ -54,6 +60,13 @@ describe("editor toolbar controls", () => {
       fillText: jest.fn(),
       setTransform: jest.fn(),
       scale: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
+      measureText: jest.fn().mockReturnValue({
+        width: 40,
+        actualBoundingBoxAscent: 12,
+        actualBoundingBoxDescent: 4,
+      }),
       globalCompositeOperation: "source-over" as GlobalCompositeOperation,
     };
 
@@ -160,7 +173,7 @@ describe("editor toolbar controls", () => {
     textarea.dispatchEvent(
       new KeyboardEvent("keydown", { key: "Enter", bubbles: true })
     );
-    expect(ctx.fillText).toHaveBeenCalledWith("hi", 10, 10);
+    expect(ctx.fillText).toHaveBeenCalledWith("hi", 10, 22);
     expect(document.querySelector("textarea")).toBeNull();
   });
 });

--- a/tests/textTool.test.ts
+++ b/tests/textTool.test.ts
@@ -17,6 +17,20 @@ describe("TextTool", () => {
       <input id="fillMode" type="checkbox" />
       <select id="fontFamily"><option value="serif">serif</option></select>
       <input id="fontSize" value="20" />
+      <select id="fontWeight">
+        <option value="normal" selected>normal</option>
+        <option value="bold">bold</option>
+      </select>
+      <select id="fontStyle">
+        <option value="normal" selected>normal</option>
+        <option value="italic">italic</option>
+      </select>
+      <select id="textAlign">
+        <option value="left">left</option>
+        <option value="center">center</option>
+        <option value="right">right</option>
+      </select>
+      <input id="textMultiline" type="checkbox" />
     `;
 
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
@@ -37,6 +51,13 @@ describe("TextTool", () => {
       putImageData: jest.fn(),
       setTransform: jest.fn(),
       scale: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
+      measureText: jest.fn().mockReturnValue({
+        width: 40,
+        actualBoundingBoxAscent: 12,
+        actualBoundingBoxDescent: 4,
+      }),
     };
 
     canvas.getContext = jest
@@ -73,6 +94,10 @@ describe("TextTool", () => {
       undefined,
       document.getElementById("fontFamily") as HTMLSelectElement,
       document.getElementById("fontSize") as HTMLInputElement,
+      document.getElementById("fontWeight") as HTMLSelectElement,
+      document.getElementById("fontStyle") as HTMLSelectElement,
+      document.getElementById("textAlign") as HTMLSelectElement,
+      document.getElementById("textMultiline") as HTMLInputElement,
     );
   });
 
@@ -97,17 +122,43 @@ describe("TextTool", () => {
     expect(ta.style.color).toBe(hexToRgb(editor.strokeStyle));
     expect(ta.style.fontSize).toBe(`${editor.fontSizeValue}px`);
     expect(ta.style.fontFamily).toBe(editor.fontFamilyValue);
+    expect(ta.style.fontWeight).toBe(editor.fontWeightValue);
+    expect(ta.style.fontStyle).toBe(editor.fontStyleValue);
   });
 
   it("commits text on Enter", () => {
     const tool = new TextTool();
+    const multilineToggle = document.getElementById(
+      "textMultiline",
+    ) as HTMLInputElement;
+    multilineToggle.checked = false;
     tool.onPointerDown({ offsetX: 5, offsetY: 6 } as PointerEvent, editor);
     const ta = document.querySelector("textarea") as HTMLTextAreaElement;
     ta.value = "hello";
     ta.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
     expect(ctx.font).toBe(`${editor.fontSizeValue}px ${editor.fontFamilyValue}`);
-    expect(ctx.fillText).toHaveBeenCalledWith("hello", 5, 6);
+    expect(ctx.fillText).toHaveBeenCalledWith("hello", 5, 18);
     expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("keeps multiline edits until commit", () => {
+    const tool = new TextTool();
+    const alignSelect = document.getElementById("textAlign") as HTMLSelectElement;
+    alignSelect.value = "center";
+    const multilineToggle = document.getElementById("textMultiline") as HTMLInputElement;
+    multilineToggle.checked = true;
+    const weightSelect = document.getElementById("fontWeight") as HTMLSelectElement;
+    weightSelect.value = "bold";
+    const styleSelect = document.getElementById("fontStyle") as HTMLSelectElement;
+    styleSelect.value = "italic";
+    tool.onPointerDown({ offsetX: 15, offsetY: 25 } as PointerEvent, editor);
+    const ta = document.querySelector("textarea") as HTMLTextAreaElement;
+    ta.value = "multi line text";
+    ta.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true, ctrlKey: true }),
+    );
+    expect(ctx.fillText).toHaveBeenNthCalledWith(1, "multi line text", 115, 37);
+    expect(ctx.font).toBe(`italic bold ${editor.fontSizeValue}px ${editor.fontFamilyValue}`);
   });
 
   it("cancels text on Escape", () => {
@@ -129,7 +180,7 @@ describe("TextTool", () => {
     ta.dispatchEvent(
       new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
     );
-    expect(ctx.fillText).toHaveBeenCalledWith("undo", 9, 10);
+    expect(ctx.fillText).toHaveBeenCalledWith("undo", 9, 22);
     // Only one undo should revert the text addition
     editor.undo();
     expect(ctx.clearRect).toHaveBeenCalledTimes(1);

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -15,6 +15,16 @@ describe("additional tools", () => {
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
+      <select id="fontFamily"><option value="sans-serif">sans-serif</option></select>
+      <input id="fontSize" value="16" />
+      <select id="fontWeight"><option value="normal">normal</option></select>
+      <select id="fontStyle"><option value="normal">normal</option></select>
+      <select id="textAlign">
+        <option value="left">left</option>
+        <option value="center">center</option>
+        <option value="right">right</option>
+      </select>
+      <input id="textMultiline" type="checkbox" />
     `;
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
     (canvas as any).setPointerCapture = jest.fn();
@@ -37,6 +47,13 @@ describe("additional tools", () => {
           height: 1,
         } as ImageData),
       putImageData: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
+      measureText: jest.fn().mockReturnValue({
+        width: 40,
+        actualBoundingBoxAscent: 12,
+        actualBoundingBoxDescent: 4,
+      }),
     };
     canvas.getContext = jest
       .fn()
@@ -46,6 +63,13 @@ describe("additional tools", () => {
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
       document.getElementById("fillMode") as HTMLInputElement,
+      undefined,
+      document.getElementById("fontFamily") as HTMLSelectElement,
+      document.getElementById("fontSize") as HTMLInputElement,
+      document.getElementById("fontWeight") as HTMLSelectElement,
+      document.getElementById("fontStyle") as HTMLSelectElement,
+      document.getElementById("textAlign") as HTMLSelectElement,
+      document.getElementById("textMultiline") as HTMLInputElement,
     );
   });
 
@@ -79,21 +103,23 @@ describe("additional tools", () => {
 
   it("text tool commits text on Enter", () => {
     const tool = new TextTool();
+    const multilineToggle = document.getElementById("textMultiline") as HTMLInputElement;
+    multilineToggle.checked = false;
     tool.onPointerDown({ offsetX: 1, offsetY: 2 } as PointerEvent, editor);
     const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
     textarea.value = "Hi";
     textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
-    expect(ctx.fillText).toHaveBeenCalledWith("Hi", 1, 2);
+    expect(ctx.fillText).toHaveBeenCalledWith("Hi", 1, 14);
     expect(document.querySelector("textarea")).toBeNull();
   });
 
-  it("text tool cancels on blur", () => {
+  it("text tool commits on blur", () => {
     const tool = new TextTool();
     tool.onPointerDown({ offsetX: 1, offsetY: 2 } as PointerEvent, editor);
     const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
     textarea.value = "Blur";
     textarea.dispatchEvent(new Event("blur"));
-    expect(ctx.fillText).not.toHaveBeenCalled();
+    expect(ctx.fillText).toHaveBeenCalledWith("Blur", 1, 14);
     expect(document.querySelector("textarea")).toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- add toolbar controls for font weight, font style, alignment, and multiline text
- render a resizable text overlay that wraps and aligns content before committing to the canvas with baseline-aware drawing
- update automated tests to cover the new text tool behavior and controls

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d60d18d1b8832885c915d8dcd945c0