### PR TITLE
Add magic wand selection tool with tolerance controls

### DIFF
--- a/icons/magic-wand.svg
+++ b/icons/magic-wand.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="3" y1="21" x2="21" y2="3" />
+  <path d="M15 3l6 6" />
+  <path d="M3 15l6 6" />
+  <path d="M9 3l1.5 1.5" />
+  <path d="M3 9l1.5 1.5" />
+  <path d="M20 13l1 3" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -45,6 +45,9 @@
       <button id="bucket" class="tool-button" title="Bucket">
         <img src="icons/paint-bucket.svg" alt="Bucket" />
       </button>
+      <button id="magicWand" class="tool-button" title="Magic Wand">
+        <img src="icons/magic-wand.svg" alt="Magic Wand" />
+      </button>
       <input type="file" id="imageLoader" accept="image/*" />
       <button id="undo" class="tool-button" title="Undo" disabled>
         <img src="icons/undo.svg" alt="Undo" />

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -1,5 +1,11 @@
 import { Tool } from "../tools/Tool.js";
 
+export interface SelectionMask {
+  data: Uint8Array;
+  width: number;
+  height: number;
+}
+
 export class Editor {
   canvas: HTMLCanvasElement;
   ctx: CanvasRenderingContext2D;
@@ -11,6 +17,9 @@ export class Editor {
   fillMode: HTMLInputElement;
   fontFamily: HTMLSelectElement | null;
   fontSize: HTMLInputElement | null;
+  private selectionToleranceInput: HTMLInputElement | null;
+  private selectionConnectivitySelect: HTMLSelectElement | null;
+  selectionMask: SelectionMask | null = null;
   private onChange?: () => void;
 
   constructor(
@@ -21,6 +30,8 @@ export class Editor {
     onChange?: () => void,
     fontFamily?: HTMLSelectElement | null,
     fontSize?: HTMLInputElement | null,
+    selectionTolerance?: HTMLInputElement | null,
+    selectionConnectivity?: HTMLSelectElement | null,
   ) {
     this.canvas = canvas;
     const ctx = canvas.getContext("2d");
@@ -32,6 +43,8 @@ export class Editor {
     this.onChange = onChange;
     this.fontFamily = fontFamily ?? null;
     this.fontSize = fontSize ?? null;
+    this.selectionToleranceInput = selectionTolerance ?? null;
+    this.selectionConnectivitySelect = selectionConnectivity ?? null;
     this.adjustForPixelRatio();
     window.addEventListener("resize", this.handleResize);
 
@@ -141,6 +154,24 @@ export class Editor {
 
   get fontSizeValue() {
     return parseInt(this.fontSize?.value ?? "", 10) || 16;
+  }
+
+  get selectionTolerance() {
+    const value = parseInt(this.selectionToleranceInput?.value ?? "", 10);
+    if (Number.isNaN(value)) return 0;
+    return Math.min(255, Math.max(0, value));
+  }
+
+  get selectionConnectivity(): 4 | 8 {
+    const value = parseInt(
+      this.selectionConnectivitySelect?.value ?? "",
+      10,
+    );
+    return value === 8 ? 8 : 4;
+  }
+
+  setSelectionMask(mask: SelectionMask | null) {
+    this.selectionMask = mask;
   }
 
   /**

--- a/src/core/Shortcuts.ts
+++ b/src/core/Shortcuts.ts
@@ -7,6 +7,7 @@ import { TextTool } from "../tools/TextTool.js";
 import { EraserTool } from "../tools/EraserTool.js";
 import { BucketFillTool } from "../tools/BucketFillTool.js";
 import { EyedropperTool } from "../tools/EyedropperTool.js";
+import { MagicWandTool } from "../tools/MagicWandTool.js";
 
 
 /**
@@ -78,6 +79,10 @@ export class Shortcuts {
       case "i":
         e.preventDefault();
         this.editor.setTool(new EyedropperTool());
+        break;
+      case "w":
+        e.preventDefault();
+        this.editor.setTool(new MagicWandTool());
         break;
     }
   }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -8,6 +8,7 @@ import { CircleTool } from "./tools/CircleTool.js";
 import { TextTool } from "./tools/TextTool.js";
 import { BucketFillTool } from "./tools/BucketFillTool.js";
 import { EyedropperTool } from "./tools/EyedropperTool.js";
+import { MagicWandTool } from "./tools/MagicWandTool.js";
 import type { Tool } from "./tools/Tool.js";
 
 /** Utility to listen to events and auto-remove on destroy. */
@@ -48,6 +49,7 @@ export function initEditor(): EditorHandle {
     text: TextTool,
     bucket: BucketFillTool,
     eyedropper: EyedropperTool,
+    magicWand: MagicWandTool,
   };
 
   const toolButtons: Record<string, HTMLButtonElement> = {};
@@ -99,6 +101,12 @@ export function initEditor(): EditorHandle {
   const colorHistory = document.getElementById(
     "colorHistory",
   ) as HTMLDivElement | null;
+  let toleranceInput = document.getElementById(
+    "magicTolerance",
+  ) as HTMLInputElement | null;
+  let connectivitySelect = document.getElementById(
+    "magicConnectivity",
+  ) as HTMLSelectElement | null;
 
   if (!colorPicker) {
     throw new Error("Missing #colorPicker input");
@@ -114,6 +122,51 @@ export function initEditor(): EditorHandle {
   }
   if (!formatSelect) {
     throw new Error("Missing #formatSelect select");
+  }
+
+  if (!toleranceInput) {
+    const group = document.createElement("div");
+    group.className = "group";
+
+    const label = document.createElement("label");
+    label.htmlFor = "magicTolerance";
+    label.textContent = "Tolerance";
+
+    toleranceInput = document.createElement("input");
+    toleranceInput.id = "magicTolerance";
+    toleranceInput.type = "number";
+    toleranceInput.min = "0";
+    toleranceInput.max = "255";
+    toleranceInput.value = "32";
+
+    group.appendChild(label);
+    group.appendChild(toleranceInput);
+    toolbar.appendChild(group);
+  }
+
+  if (!connectivitySelect) {
+    const group = document.createElement("div");
+    group.className = "group";
+
+    const label = document.createElement("label");
+    label.htmlFor = "magicConnectivity";
+    label.textContent = "Connectivity";
+
+    connectivitySelect = document.createElement("select");
+    connectivitySelect.id = "magicConnectivity";
+
+    const option4 = document.createElement("option");
+    option4.value = "4";
+    option4.textContent = "4-way";
+    const option8 = document.createElement("option");
+    option8.value = "8";
+    option8.textContent = "8-way";
+
+    connectivitySelect.append(option4, option8);
+    connectivitySelect.value = "4";
+
+    group.append(label, connectivitySelect);
+    toolbar.appendChild(group);
   }
 
   if (layerSelect) {
@@ -212,6 +265,8 @@ export function initEditor(): EditorHandle {
         },
         fontFamily ?? undefined,
         fontSize ?? undefined,
+        toleranceInput ?? undefined,
+        connectivitySelect ?? undefined,
       );
       editors.push(e);
     } catch {

--- a/src/tools/MagicWandTool.ts
+++ b/src/tools/MagicWandTool.ts
@@ -1,0 +1,144 @@
+import { Editor, type SelectionMask } from "../core/Editor.js";
+import { Tool } from "./Tool.js";
+
+/**
+ * Magic wand selection tool. Creates a binary mask for pixels connected to the
+ * sampled pixel whose color difference is within the configured tolerance.
+ */
+export class MagicWandTool implements Tool {
+  cursor = "crosshair";
+
+  onPointerDown(e: PointerEvent, editor: Editor): void {
+    const image = editor.ctx.getImageData(
+      0,
+      0,
+      editor.canvas.width,
+      editor.canvas.height,
+    );
+
+    const mask = this.createMask(e, editor, image);
+    editor.setSelectionMask(mask);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  onPointerMove(_e: PointerEvent, _editor: Editor): void {
+    // selections are created on pointer down only
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  onPointerUp(_e: PointerEvent, _editor: Editor): void {
+    // nothing to clean up
+  }
+
+  private createMask(
+    e: PointerEvent,
+    editor: Editor,
+    image: ImageData,
+  ): SelectionMask | null {
+    const { width, height, data } = image;
+    if (width === 0 || height === 0) return null;
+
+    const dpr = window.devicePixelRatio || 1;
+    const startX = Math.max(
+      0,
+      Math.min(width - 1, Math.floor(e.offsetX * dpr)),
+    );
+    const startY = Math.max(
+      0,
+      Math.min(height - 1, Math.floor(e.offsetY * dpr)),
+    );
+    const startIndex = startY * width + startX;
+    const offset = startIndex * 4;
+
+    const sr = data[offset];
+    const sg = data[offset + 1];
+    const sb = data[offset + 2];
+    const sa = data[offset + 3];
+
+    const tolerance = editor.selectionTolerance;
+    const connectivity = editor.selectionConnectivity;
+
+    const pixelCount = width * height;
+    const queue = new Uint32Array(pixelCount);
+    const visited = new Uint8Array(pixelCount);
+    const mask = new Uint8Array(pixelCount);
+
+    let head = 0;
+    let tail = 0;
+    queue[tail++] = startIndex;
+    visited[startIndex] = 1;
+
+    const neighbors =
+      connectivity === 8
+        ? (
+            [
+              [-1, 0],
+              [1, 0],
+              [0, -1],
+              [0, 1],
+              [-1, -1],
+              [1, -1],
+              [-1, 1],
+              [1, 1],
+            ] as const
+          )
+        : ([
+            [-1, 0],
+            [1, 0],
+            [0, -1],
+            [0, 1],
+          ] as const);
+
+    while (head < tail) {
+      const index = queue[head++];
+      const iOffset = index * 4;
+      const r = data[iOffset];
+      const g = data[iOffset + 1];
+      const b = data[iOffset + 2];
+      const a = data[iOffset + 3];
+
+      if (!this.withinTolerance(r, g, b, a, sr, sg, sb, sa, tolerance)) {
+        continue;
+      }
+
+      mask[index] = 255;
+
+      const x = index % width;
+      const y = (index / width) | 0;
+      for (const [dx, dy] of neighbors) {
+        const nx = x + dx;
+        const ny = y + dy;
+        if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
+        const nIndex = ny * width + nx;
+        if (visited[nIndex]) continue;
+        visited[nIndex] = 1;
+        queue[tail++] = nIndex;
+      }
+    }
+
+    return {
+      data: mask,
+      width,
+      height,
+    };
+  }
+
+  private withinTolerance(
+    r: number,
+    g: number,
+    b: number,
+    a: number,
+    sr: number,
+    sg: number,
+    sb: number,
+    sa: number,
+    tolerance: number,
+  ): boolean {
+    return (
+      Math.abs(r - sr) <= tolerance &&
+      Math.abs(g - sg) <= tolerance &&
+      Math.abs(b - sb) <= tolerance &&
+      Math.abs(a - sa) <= tolerance
+    );
+  }
+}

--- a/tests/bucketIntegration.test.ts
+++ b/tests/bucketIntegration.test.ts
@@ -20,6 +20,7 @@ describe("bucket tool integration", () => {
       <button id="text"></button>
       <button id="bucket">Bucket</button>
       <button id="eyedropper"></button>
+      <button id="magicWand"></button>
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>
     `;

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -21,6 +21,7 @@ describe("editor toolbar controls", () => {
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
+      <button id="magicWand"></button>
       <select id="formatSelect"><option value="png">PNG</option></select>
       <input id="imageLoader" type="file" />
       <button id="undo"></button>

--- a/tests/eyedropperTool.test.ts
+++ b/tests/eyedropperTool.test.ts
@@ -105,6 +105,7 @@ describe("EyedropperTool color history", () => {
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
+      <button id="magicWand"></button>
 
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -4,8 +4,9 @@ describe("image load and save", () => {
   let canvas: HTMLCanvasElement;
   let ctx: Partial<CanvasRenderingContext2D>;
   let handle: EditorHandle;
-  let anchor: { href: string; download: string; click: jest.Mock };
+  let anchor: HTMLAnchorElement | null;
   let createElementSpy: jest.SpyInstance;
+  let clickSpy: jest.SpyInstance | null;
   let fileReaderSpy: jest.SpyInstance;
   let imageSpy: jest.SpyInstance;
 
@@ -23,6 +24,7 @@ describe("image load and save", () => {
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
+      <button id="magicWand"></button>
       <input id="imageLoader" type="file" />
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>
@@ -58,10 +60,23 @@ describe("image load and save", () => {
       toJSON: () => {},
     });
 
-    anchor = { href: "", download: "", click: jest.fn() };
+    anchor = null;
+    clickSpy = null;
     createElementSpy = jest
       .spyOn(document, "createElement")
-      .mockReturnValue(anchor as any);
+      .mockImplementation((tag: string) => {
+        const element = Document.prototype.createElement.call(
+          document,
+          tag,
+        );
+        if (tag === "a") {
+          anchor = element as HTMLAnchorElement;
+          clickSpy = jest
+            .spyOn(anchor, "click")
+            .mockImplementation(() => undefined);
+        }
+        return element;
+      });
 
     class MockFileReader {
       result: string | ArrayBuffer | null = null;
@@ -159,8 +174,8 @@ describe("image load and save", () => {
     const save = document.getElementById("save") as HTMLButtonElement;
     save.click();
     expect(canvas.toDataURL).toHaveBeenCalledWith("image/png");
-    expect(anchor.href).toBe("data:image/png;base64,SAVE");
-    expect(anchor.download).toBe("canvas.png");
-    expect(anchor.click).toHaveBeenCalled();
+    expect(anchor?.href).toBe("data:image/png;base64,SAVE");
+    expect(anchor?.download).toBe("canvas.png");
+    expect(clickSpy?.mock.calls.length).toBe(1);
   });
 });

--- a/tests/layers.test.ts
+++ b/tests/layers.test.ts
@@ -24,6 +24,7 @@ describe("layer-specific undo/redo", () => {
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
+      <button id="magicWand"></button>
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>
       <button id="undo"></button>

--- a/tests/magicWandTool.test.ts
+++ b/tests/magicWandTool.test.ts
@@ -1,0 +1,189 @@
+import { Editor } from "../src/core/Editor.js";
+import { MagicWandTool } from "../src/tools/MagicWandTool.js";
+
+describe("MagicWandTool", () => {
+  let canvas: HTMLCanvasElement;
+  let ctx: Partial<CanvasRenderingContext2D>;
+  let editor: Editor;
+  let toleranceInput: HTMLInputElement;
+  let connectivitySelect: HTMLSelectElement;
+  const width = 3;
+  const height = 3;
+  let data: Uint8ClampedArray;
+  let setPixel: (
+    x: number,
+    y: number,
+    r: number,
+    g: number,
+    b: number,
+    a?: number,
+  ) => void;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <canvas id="canvas"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="1" />
+      <input id="fillMode" type="checkbox" />
+      <input id="magicTolerance" value="10" />
+      <select id="magicConnectivity">
+        <option value="4" selected>4</option>
+        <option value="8">8</option>
+      </select>
+    `;
+
+    canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    canvas.width = width;
+    canvas.height = height;
+    canvas.getBoundingClientRect = () => ({
+      width,
+      height,
+      top: 0,
+      left: 0,
+      bottom: height,
+      right: width,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+
+    data = new Uint8ClampedArray(width * height * 4);
+    setPixel = (
+      x: number,
+      y: number,
+      r: number,
+      g: number,
+      b: number,
+      a = 255,
+    ) => {
+      const idx = (y * width + x) * 4;
+      data[idx] = r;
+      data[idx + 1] = g;
+      data[idx + 2] = b;
+      data[idx + 3] = a;
+    };
+
+    const image = { data, width, height } as ImageData;
+    ctx = {
+      getImageData: jest.fn().mockReturnValue(image),
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+      putImageData: jest.fn(),
+      clearRect: jest.fn(),
+    };
+    canvas.getContext = jest
+      .fn()
+      .mockReturnValue(ctx as CanvasRenderingContext2D);
+
+    toleranceInput = document.getElementById(
+      "magicTolerance",
+    ) as HTMLInputElement;
+    connectivitySelect = document.getElementById(
+      "magicConnectivity",
+    ) as HTMLSelectElement;
+
+    editor = new Editor(
+      canvas,
+      document.getElementById("colorPicker") as HTMLInputElement,
+      document.getElementById("lineWidth") as HTMLInputElement,
+      document.getElementById("fillMode") as HTMLInputElement,
+      undefined,
+      undefined,
+      undefined,
+      toleranceInput,
+      connectivitySelect,
+    );
+  });
+
+  it("creates a mask constrained by tolerance", () => {
+    const tool = new MagicWandTool();
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        setPixel(x, y, 230, 230, 230);
+      }
+    }
+    setPixel(1, 1, 200, 200, 200);
+    setPixel(1, 0, 205, 205, 205);
+    setPixel(1, 2, 205, 205, 205);
+    setPixel(0, 1, 205, 205, 205);
+    setPixel(2, 1, 205, 205, 205);
+
+    toleranceInput.value = "4";
+
+    tool.onPointerDown({ offsetX: 1, offsetY: 1 } as PointerEvent, editor);
+
+    const mask = editor.selectionMask;
+    expect(mask).not.toBeNull();
+    expect(mask?.width).toBe(width);
+    expect(mask?.height).toBe(height);
+    // only center pixel should be selected with low tolerance
+    expect(Array.from(mask!.data)).toEqual([
+      0,
+      0,
+      0,
+      0,
+      255,
+      0,
+      0,
+      0,
+      0,
+    ]);
+
+    toleranceInput.value = "6";
+    tool.onPointerDown({ offsetX: 1, offsetY: 1 } as PointerEvent, editor);
+    expect(Array.from(editor.selectionMask!.data)).toEqual([
+      0,
+      255,
+      0,
+      255,
+      255,
+      255,
+      0,
+      255,
+      0,
+    ]);
+  });
+
+  it("expands selection based on connectivity", () => {
+    const tool = new MagicWandTool();
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        setPixel(x, y, 230, 230, 230);
+      }
+    }
+    setPixel(1, 1, 200, 200, 200);
+    setPixel(2, 2, 205, 205, 205);
+
+    toleranceInput.value = "10";
+
+    // 4-way connectivity should not include diagonal neighbor
+    connectivitySelect.value = "4";
+    tool.onPointerDown({ offsetX: 1, offsetY: 1 } as PointerEvent, editor);
+    expect(Array.from(editor.selectionMask!.data)).toEqual([
+      0,
+      0,
+      0,
+      0,
+      255,
+      0,
+      0,
+      0,
+      0,
+    ]);
+
+    // 8-way connectivity should include the diagonal pixel as well
+    connectivitySelect.value = "8";
+    tool.onPointerDown({ offsetX: 1, offsetY: 1 } as PointerEvent, editor);
+    expect(Array.from(editor.selectionMask!.data)).toEqual([
+      0,
+      0,
+      0,
+      0,
+      255,
+      0,
+      0,
+      0,
+      255,
+    ]);
+  });
+});

--- a/tests/opacity.test.ts
+++ b/tests/opacity.test.ts
@@ -21,6 +21,7 @@ describe("layer opacity", () => {
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
+      <button id="magicWand"></button>
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>
     `;

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -15,6 +15,7 @@ describe("save button", () => {
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
+      <button id="magicWand"></button>
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>
     `;
@@ -35,19 +36,33 @@ describe("save button", () => {
       toJSON: () => {},
     });
 
-    const click = jest.fn();
-    const anchor = { href: "", download: "", click } as any;
-
-    jest.spyOn(document, "createElement").mockReturnValue(anchor);
+      let anchor: HTMLAnchorElement | null = null;
+      let clickSpy: jest.SpyInstance | null = null;
+      jest
+        .spyOn(document, "createElement")
+        .mockImplementation((tag: string) => {
+          const element = Document.prototype.createElement.call(
+            document,
+            tag,
+          );
+          if (tag === "a") {
+            anchor = element as HTMLAnchorElement;
+            clickSpy = jest
+              .spyOn(anchor, "click")
+              .mockImplementation(() => undefined);
+          }
+          return element;
+        });
 
     const handle = initEditor();
 
     (document.getElementById("save") as HTMLButtonElement).click();
-    expect(canvas.toDataURL).toHaveBeenCalledWith("image/png");
-    expect(click).toHaveBeenCalled();
+      expect(canvas.toDataURL).toHaveBeenCalledWith("image/png");
+      expect(clickSpy).not.toBeNull();
+      expect(clickSpy?.mock.calls.length).toBe(1);
 
-    handle.destroy();
-  });
+      handle.destroy();
+    });
 
   it("supports selecting jpeg format", () => {
     document.body.innerHTML = `
@@ -63,6 +78,7 @@ describe("save button", () => {
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
+      <button id="magicWand"></button>
       <select id="formatSelect"><option value="png">PNG</option><option value="jpeg" selected>JPEG</option></select>
       <button id="save"></button>
     `;
@@ -83,17 +99,31 @@ describe("save button", () => {
       toJSON: () => {},
     });
 
-    const click = jest.fn();
-    const anchor = { href: "", download: "", click } as any;
-    jest.spyOn(document, "createElement").mockReturnValue(anchor);
+      let anchor: HTMLAnchorElement | null = null;
+      let clickSpy: jest.SpyInstance | null = null;
+      jest
+        .spyOn(document, "createElement")
+        .mockImplementation((tag: string) => {
+          const element = Document.prototype.createElement.call(
+            document,
+            tag,
+          );
+          if (tag === "a") {
+            anchor = element as HTMLAnchorElement;
+            clickSpy = jest
+              .spyOn(anchor, "click")
+              .mockImplementation(() => undefined);
+          }
+          return element;
+        });
 
-    const handle = initEditor();
+      const handle = initEditor();
 
-    (document.getElementById("save") as HTMLButtonElement).click();
-    expect(canvas.toDataURL).toHaveBeenCalledWith("image/jpeg", 0.9);
-    expect(anchor.download).toBe("canvas.jpg");
-    expect(click).toHaveBeenCalled();
+      (document.getElementById("save") as HTMLButtonElement).click();
+      expect(canvas.toDataURL).toHaveBeenCalledWith("image/jpeg", 0.9);
+      expect(anchor?.download).toBe("canvas.jpg");
+      expect(clickSpy?.mock.calls.length).toBe(1);
 
-    handle.destroy();
-  });
+      handle.destroy();
+    });
 });

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -9,6 +9,7 @@ import { TextTool } from "../src/tools/TextTool.js";
 import { BucketFillTool } from "../src/tools/BucketFillTool.js";
 import { Shortcuts } from "../src/core/Shortcuts.js";
 import { Editor } from "../src/core/Editor.js";
+import { MagicWandTool } from "../src/tools/MagicWandTool.js";
 
 describe("keyboard shortcuts", () => {
   let handle: EditorHandle;
@@ -29,6 +30,7 @@ describe("keyboard shortcuts", () => {
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
+      <button id="magicWand"></button>
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>
     `;
@@ -72,6 +74,7 @@ describe("keyboard shortcuts", () => {
       ["c", CircleTool],
       ["t", TextTool],
       ["b", BucketFillTool],
+      ["w", MagicWandTool],
     ];
 
     cases.forEach(([key, ToolClass], index) => {

--- a/tests/toolbar.test.ts
+++ b/tests/toolbar.test.ts
@@ -6,6 +6,7 @@ import { LineTool } from "../src/tools/LineTool.js";
 import { CircleTool } from "../src/tools/CircleTool.js";
 import { TextTool } from "../src/tools/TextTool.js";
 import { EyedropperTool } from "../src/tools/EyedropperTool.js";
+import { MagicWandTool } from "../src/tools/MagicWandTool.js";
 
 describe("toolbar controls", () => {
   let handle: EditorHandle;
@@ -28,6 +29,7 @@ describe("toolbar controls", () => {
       <button id="text"></button>
       <button id="eyedropper"></button>
       <button id="bucket"></button>
+      <button id="magicWand"></button>
 
       <select id="formatSelect"><option value="png">PNG</option></select>
       <button id="save"></button>
@@ -79,26 +81,21 @@ describe("toolbar controls", () => {
 
     it("switches tools when buttons are clicked", () => {
       const spy = jest.spyOn(handle.editor, "setTool");
-      (document.getElementById("pencil") as HTMLButtonElement).click();
-      expect(spy.mock.calls[0][0]).toBeInstanceOf(PencilTool);
+      const sequence: Array<[string, new () => unknown]> = [
+        ["pencil", PencilTool],
+        ["eraser", EraserTool],
+        ["rectangle", RectangleTool],
+        ["line", LineTool],
+        ["circle", CircleTool],
+        ["text", TextTool],
+        ["eyedropper", EyedropperTool],
+        ["magicWand", MagicWandTool],
+      ];
 
-      (document.getElementById("eraser") as HTMLButtonElement).click();
-      expect(spy.mock.calls[1][0]).toBeInstanceOf(EraserTool);
-
-      (document.getElementById("rectangle") as HTMLButtonElement).click();
-      expect(spy.mock.calls[2][0]).toBeInstanceOf(RectangleTool);
-
-      (document.getElementById("line") as HTMLButtonElement).click();
-      expect(spy.mock.calls[3][0]).toBeInstanceOf(LineTool);
-
-      (document.getElementById("circle") as HTMLButtonElement).click();
-      expect(spy.mock.calls[4][0]).toBeInstanceOf(CircleTool);
-
-      (document.getElementById("text") as HTMLButtonElement).click();
-      expect(spy.mock.calls[5][0]).toBeInstanceOf(TextTool);
-
-      (document.getElementById("eyedropper") as HTMLButtonElement).click();
-      expect(spy.mock.calls[6][0]).toBeInstanceOf(EyedropperTool);
+      sequence.forEach(([id, ToolCtor], index) => {
+        (document.getElementById(id) as HTMLButtonElement).click();
+        expect(spy.mock.calls[index][0]).toBeInstanceOf(ToolCtor);
+      });
     });
 
     it("routes tool changes to the selected layer", () => {


### PR DESCRIPTION
## Summary
- add a magic wand selection tool that builds tolerance-aware selection masks and records them on the editor
- register the tool in the toolbar/shortcuts, add tolerance & connectivity controls, and expose a new icon button
- extend and add tests to cover magic wand behavior alongside updated toolbar expectations

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d60d158ea08328a754f8de7a29a2c3