### PR TITLE
Add lasso selection tooling and selection mask support

### DIFF
--- a/dist/core/Editor.js
+++ b/dist/core/Editor.js
@@ -3,6 +3,8 @@ export class Editor {
         this.undoStack = [];
         this.redoStack = [];
         this.currentTool = null;
+        this.selectionMaskValue = null;
+        this.selectionListeners = new Set();
         this.handlePointerDown = (e) => {
             // Capture the pointer once before recording canvas state
             this.canvas.setPointerCapture(e.pointerId);
@@ -98,6 +100,28 @@ export class Editor {
     get fontSizeValue() {
         return parseInt(this.fontSize?.value ?? "", 10) || 16;
     }
+    get selectionMask() {
+        return this.selectionMaskValue;
+    }
+    setSelectionMask(mask) {
+        this.selectionMaskValue = mask;
+        this.notifySelectionListeners(mask);
+    }
+    clearSelectionMask() {
+        if (this.selectionMaskValue) {
+            this.selectionMaskValue = null;
+            this.notifySelectionListeners(null);
+        }
+    }
+    onSelectionChange(listener) {
+        this.selectionListeners.add(listener);
+        return () => {
+            this.selectionListeners.delete(listener);
+        };
+    }
+    notifySelectionListeners(mask) {
+        this.selectionListeners.forEach((listener) => listener(mask));
+    }
     /**
      * Remove all event listeners registered by the editor.
      * Should be called before discarding the instance to prevent leaks.
@@ -108,5 +132,7 @@ export class Editor {
         this.canvas.removeEventListener("pointerdown", this.handlePointerDown);
         this.canvas.removeEventListener("pointermove", this.handlePointerMove);
         this.canvas.removeEventListener("pointerup", this.handlePointerUp);
+        this.selectionListeners.clear();
+        this.selectionMaskValue = null;
     }
 }

--- a/dist/editor.js
+++ b/dist/editor.js
@@ -8,6 +8,7 @@ import { CircleTool } from "./tools/CircleTool.js";
 import { TextTool } from "./tools/TextTool.js";
 import { BucketFillTool } from "./tools/BucketFillTool.js";
 import { EyedropperTool } from "./tools/EyedropperTool.js";
+import { LassoTool } from "./tools/LassoTool.js";
 /** Utility to listen to events and auto-remove on destroy. */
 function listen(el, type, handler, list) {
     if (!el)
@@ -31,11 +32,13 @@ export function initEditor() {
         text: TextTool,
         bucket: BucketFillTool,
         eyedropper: EyedropperTool,
+        lasso: LassoTool,
     };
     const toolButtons = {};
     const constructorToId = new Map();
     const editorToolConstructors = new Map();
     let activeToolCtor = PencilTool;
+    let activeTool = null;
     let activeLayerIndex = 0;
     Object.entries(toolConstructors).forEach(([id, Ctor]) => {
         const btn = document.getElementById(id);
@@ -76,6 +79,55 @@ export function initEditor() {
     const saveBtn = document.getElementById("save");
     const formatSelect = document.getElementById("formatSelect");
     const colorHistory = document.getElementById("colorHistory");
+    const selectionControls = document.createElement("div");
+    selectionControls.className = "group selection-controls";
+    selectionControls.style.display = "none";
+    const closePathBtn = document.createElement("button");
+    closePathBtn.type = "button";
+    closePathBtn.id = "lassoClosePath";
+    closePathBtn.textContent = "Close Path";
+    closePathBtn.disabled = true;
+    const commitSelectionBtn = document.createElement("button");
+    commitSelectionBtn.type = "button";
+    commitSelectionBtn.id = "lassoCommit";
+    commitSelectionBtn.textContent = "Commit Selection";
+    commitSelectionBtn.disabled = true;
+    const cancelSelectionBtn = document.createElement("button");
+    cancelSelectionBtn.type = "button";
+    cancelSelectionBtn.id = "lassoCancel";
+    cancelSelectionBtn.textContent = "Cancel Selection";
+    cancelSelectionBtn.disabled = true;
+    selectionControls.append(closePathBtn, commitSelectionBtn, cancelSelectionBtn);
+    toolbar.appendChild(selectionControls);
+    const updateSelectionControls = (state) => {
+        if (!state) {
+            closePathBtn.disabled = true;
+            commitSelectionBtn.disabled = true;
+            cancelSelectionBtn.disabled = true;
+            return;
+        }
+        closePathBtn.disabled = !state.canClose;
+        commitSelectionBtn.disabled = !state.canCommit;
+        cancelSelectionBtn.disabled = !(state.hasPath || state.hasSelection);
+    };
+    updateSelectionControls();
+    const attachTool = (tool) => {
+        if (activeTool instanceof LassoTool) {
+            activeTool.onStateChange = undefined;
+        }
+        activeTool = tool;
+        setActiveButton(buttonForTool(tool));
+        if (tool instanceof LassoTool) {
+            selectionControls.style.display = "flex";
+            const handler = (state) => updateSelectionControls(state);
+            tool.onStateChange = handler;
+            updateSelectionControls(tool.state);
+        }
+        else {
+            selectionControls.style.display = "none";
+            updateSelectionControls();
+        }
+    };
     if (!colorPicker) {
         throw new Error("Missing #colorPicker input");
     }
@@ -182,8 +234,10 @@ export function initEditor() {
             original(tool);
             const ctor = tool.constructor;
             editorToolConstructors.set(e, ctor);
-            activeToolCtor = ctor;
-            setActiveButton(buttonForTool(tool));
+            if (e === editor) {
+                activeToolCtor = ctor;
+                attachTool(tool);
+            }
         };
     });
     // active editor defaults to the first successfully created editor
@@ -195,7 +249,25 @@ export function initEditor() {
     // keyboard shortcuts
     const shortcuts = new Shortcuts(editor);
     // map button id to tool constructor
-    Object.entries(toolConstructors).forEach(([id, ToolCtor]) => listen(toolButtons[id], "click", () => editor.setTool(new ToolCtor()), listeners));
+    Object.entries(toolConstructors).forEach(([id, ToolCtor]) => listen(toolButtons[id], "click", () => {
+        const tool = new ToolCtor();
+        editor.setTool(tool);
+    }, listeners));
+    listen(closePathBtn, "click", () => {
+        if (activeTool instanceof LassoTool) {
+            activeTool.closePath();
+        }
+    }, listeners);
+    listen(commitSelectionBtn, "click", () => {
+        if (activeTool instanceof LassoTool) {
+            activeTool.commitSelection();
+        }
+    }, listeners);
+    listen(cancelSelectionBtn, "click", () => {
+        if (activeTool instanceof LassoTool) {
+            activeTool.cancelSelection();
+        }
+    }, listeners);
     listen(undoBtn, "click", () => {
         editor.undo();
         updateHistoryButtons();

--- a/dist/tools/LassoTool.js
+++ b/dist/tools/LassoTool.js
@@ -1,0 +1,224 @@
+export class LassoTool {
+    constructor() {
+        this.cursor = "crosshair";
+        this.points = [];
+        this.drawing = false;
+        this.closed = false;
+        this.committed = false;
+        this.overlay = null;
+        this.overlayCtx = null;
+        this.editor = null;
+        this.selectionMask = null;
+    }
+    onPointerDown(e, editor) {
+        this.editor = editor;
+        this.ensureOverlay(editor);
+        this.resetPath(this.committed);
+        this.drawing = true;
+        this.closed = false;
+        this.committed = false;
+        this.selectionMask = null;
+        this.points = [this.eventToPoint(e, editor)];
+        this.renderOverlay();
+        this.emitState();
+    }
+    onPointerMove(e, editor) {
+        if (!this.drawing || this.closed || e.buttons === 0)
+            return;
+        const point = this.eventToPoint(e, editor);
+        const last = this.points[this.points.length - 1];
+        if (!last || Math.hypot(point.x - last.x, point.y - last.y) >= 1) {
+            this.points.push(point);
+            this.renderOverlay();
+            this.emitState();
+        }
+    }
+    onPointerUp(_e, _editor) {
+        if (!this.drawing)
+            return;
+        this.drawing = false;
+        this.emitState();
+    }
+    closePath() {
+        if (this.closed || this.points.length < 3)
+            return;
+        this.closed = true;
+        this.generateMask();
+        this.renderOverlay();
+        this.emitState();
+    }
+    commitSelection() {
+        if (!this.closed || !this.selectionMask || !this.editor)
+            return;
+        this.editor.setSelectionMask(this.selectionMask);
+        this.committed = true;
+        this.renderOverlay();
+        this.emitState();
+    }
+    cancelSelection() {
+        if (!this.editor)
+            return;
+        this.resetPath(this.committed);
+        this.renderOverlay();
+        this.emitState();
+    }
+    destroy() {
+        this.removeOverlay();
+        this.points = [];
+        this.selectionMask = null;
+    }
+    get state() {
+        return {
+            isDrawing: this.drawing,
+            hasPath: this.points.length > 1,
+            canClose: !this.closed && this.points.length >= 3,
+            isClosed: this.closed,
+            canCommit: this.closed && !!this.selectionMask,
+            hasSelection: this.committed,
+        };
+    }
+    eventToPoint(e, editor) {
+        const rect = editor.canvas.getBoundingClientRect();
+        const scaleX = editor.canvas.width / rect.width;
+        const scaleY = editor.canvas.height / rect.height;
+        return {
+            x: (e.clientX - rect.left) * scaleX,
+            y: (e.clientY - rect.top) * scaleY,
+        };
+    }
+    ensureOverlay(editor) {
+        if (this.overlay && this.overlayCtx) {
+            this.syncOverlaySize(editor);
+            return;
+        }
+        const canvas = document.createElement("canvas");
+        canvas.width = editor.canvas.width;
+        canvas.height = editor.canvas.height;
+        canvas.style.pointerEvents = "none";
+        canvas.classList.add("lasso-overlay");
+        editor.canvas.parentElement?.appendChild(canvas);
+        this.overlay = canvas;
+        this.overlayCtx = canvas.getContext("2d");
+        this.syncOverlaySize(editor);
+    }
+    syncOverlaySize(editor) {
+        if (!this.overlay)
+            return;
+        if (this.overlay.width !== editor.canvas.width) {
+            this.overlay.width = editor.canvas.width;
+        }
+        if (this.overlay.height !== editor.canvas.height) {
+            this.overlay.height = editor.canvas.height;
+        }
+    }
+    renderOverlay() {
+        if (!this.overlayCtx || !this.overlay)
+            return;
+        const ctx = this.overlayCtx;
+        ctx.clearRect(0, 0, this.overlay.width, this.overlay.height);
+        if (this.points.length < 2)
+            return;
+        ctx.save();
+        ctx.lineWidth = 1;
+        ctx.strokeStyle = "rgba(0, 123, 255, 0.8)";
+        ctx.setLineDash([6, 4]);
+        ctx.beginPath();
+        ctx.moveTo(this.points[0].x, this.points[0].y);
+        for (let i = 1; i < this.points.length; i += 1) {
+            const pt = this.points[i];
+            ctx.lineTo(pt.x, pt.y);
+        }
+        if (this.closed) {
+            ctx.closePath();
+        }
+        ctx.stroke();
+        if (this.closed) {
+            ctx.fillStyle = this.committed
+                ? "rgba(0, 123, 255, 0.1)"
+                : "rgba(0, 123, 255, 0.2)";
+            ctx.fill();
+        }
+        ctx.restore();
+    }
+    generateMask() {
+        if (!this.editor || this.points.length < 3) {
+            this.selectionMask = null;
+            return;
+        }
+        const offscreen = document.createElement("canvas");
+        offscreen.width = this.editor.canvas.width;
+        offscreen.height = this.editor.canvas.height;
+        const ctx = offscreen.getContext("2d");
+        if (!ctx) {
+            this.selectionMask = null;
+            return;
+        }
+        ctx.fillStyle = "#fff";
+        ctx.beginPath();
+        ctx.moveTo(this.points[0].x, this.points[0].y);
+        for (let i = 1; i < this.points.length; i += 1) {
+            const pt = this.points[i];
+            ctx.lineTo(pt.x, pt.y);
+        }
+        ctx.closePath();
+        ctx.fill();
+        const imageData = ctx.getImageData(0, 0, offscreen.width, offscreen.height);
+        const { data, width, height } = imageData;
+        let minX = width;
+        let minY = height;
+        let maxX = 0;
+        let maxY = 0;
+        let hasMask = false;
+        for (let y = 0; y < height; y += 1) {
+            for (let x = 0; x < width; x += 1) {
+                const alpha = data[(y * width + x) * 4 + 3];
+                if (alpha !== 0) {
+                    hasMask = true;
+                    if (x < minX)
+                        minX = x;
+                    if (y < minY)
+                        minY = y;
+                    if (x > maxX)
+                        maxX = x;
+                    if (y > maxY)
+                        maxY = y;
+                }
+            }
+        }
+        if (!hasMask) {
+            this.selectionMask = null;
+            return;
+        }
+        this.selectionMask = {
+            width,
+            height,
+            data: new Uint8ClampedArray(data),
+            path: this.points.map((pt) => ({ ...pt })),
+            bounds: {
+                x: minX,
+                y: minY,
+                width: maxX - minX + 1,
+                height: maxY - minY + 1,
+            },
+        };
+    }
+    resetPath(clearSelection) {
+        this.points = [];
+        this.closed = false;
+        this.committed = false;
+        this.selectionMask = null;
+        if (clearSelection && this.editor) {
+            this.editor.clearSelectionMask();
+        }
+    }
+    removeOverlay() {
+        if (this.overlay?.parentElement) {
+            this.overlay.parentElement.removeChild(this.overlay);
+        }
+        this.overlay = null;
+        this.overlayCtx = null;
+    }
+    emitState() {
+        this.onStateChange?.(this.state);
+    }
+}

--- a/icons/lasso.svg
+++ b/icons/lasso.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 7c3-4 10-5 14 0s3 11-2 12-7-2-8-4-5-4-4-8z" />
+  <circle cx="6" cy="19" r="2" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -36,6 +36,9 @@
       <button id="circle" class="tool-button" title="Circle">
         <img src="icons/circle.svg" alt="Circle" />
       </button>
+      <button id="lasso" class="tool-button" title="Lasso">
+        <img src="icons/lasso.svg" alt="Lasso" />
+      </button>
       <button id="text" class="tool-button" title="Text">
         <img src="icons/type.svg" alt="Text" />
       </button>

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -1,5 +1,13 @@
 import { Tool } from "../tools/Tool.js";
 
+export interface SelectionMask {
+  width: number;
+  height: number;
+  data: Uint8ClampedArray;
+  path: Array<{ x: number; y: number }>;
+  bounds: { x: number; y: number; width: number; height: number };
+}
+
 export class Editor {
   canvas: HTMLCanvasElement;
   ctx: CanvasRenderingContext2D;
@@ -12,6 +20,8 @@ export class Editor {
   fontFamily: HTMLSelectElement | null;
   fontSize: HTMLInputElement | null;
   private onChange?: () => void;
+  private selectionMaskValue: SelectionMask | null = null;
+  private selectionListeners = new Set<(mask: SelectionMask | null) => void>();
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -143,6 +153,33 @@ export class Editor {
     return parseInt(this.fontSize?.value ?? "", 10) || 16;
   }
 
+  get selectionMask(): SelectionMask | null {
+    return this.selectionMaskValue;
+  }
+
+  setSelectionMask(mask: SelectionMask | null) {
+    this.selectionMaskValue = mask;
+    this.notifySelectionListeners(mask);
+  }
+
+  clearSelectionMask() {
+    if (this.selectionMaskValue) {
+      this.selectionMaskValue = null;
+      this.notifySelectionListeners(null);
+    }
+  }
+
+  onSelectionChange(listener: (mask: SelectionMask | null) => void) {
+    this.selectionListeners.add(listener);
+    return () => {
+      this.selectionListeners.delete(listener);
+    };
+  }
+
+  private notifySelectionListeners(mask: SelectionMask | null) {
+    this.selectionListeners.forEach((listener) => listener(mask));
+  }
+
   /**
    * Remove all event listeners registered by the editor.
    * Should be called before discarding the instance to prevent leaks.
@@ -153,5 +190,7 @@ export class Editor {
     this.canvas.removeEventListener("pointerdown", this.handlePointerDown);
     this.canvas.removeEventListener("pointermove", this.handlePointerMove);
     this.canvas.removeEventListener("pointerup", this.handlePointerUp);
+    this.selectionListeners.clear();
+    this.selectionMaskValue = null;
   }
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -8,6 +8,7 @@ import { CircleTool } from "./tools/CircleTool.js";
 import { TextTool } from "./tools/TextTool.js";
 import { BucketFillTool } from "./tools/BucketFillTool.js";
 import { EyedropperTool } from "./tools/EyedropperTool.js";
+import { LassoTool, type LassoState } from "./tools/LassoTool.js";
 import type { Tool } from "./tools/Tool.js";
 
 /** Utility to listen to events and auto-remove on destroy. */
@@ -48,12 +49,14 @@ export function initEditor(): EditorHandle {
     text: TextTool,
     bucket: BucketFillTool,
     eyedropper: EyedropperTool,
+    lasso: LassoTool,
   };
 
   const toolButtons: Record<string, HTMLButtonElement> = {};
   const constructorToId = new Map<new () => Tool, string>();
   const editorToolConstructors = new Map<Editor, new () => Tool>();
   let activeToolCtor: new () => Tool = PencilTool;
+  let activeTool: Tool | null = null;
   let activeLayerIndex = 0;
   Object.entries(toolConstructors).forEach(([id, Ctor]) => {
     const btn = document.getElementById(id) as HTMLButtonElement | null;
@@ -99,6 +102,56 @@ export function initEditor(): EditorHandle {
   const colorHistory = document.getElementById(
     "colorHistory",
   ) as HTMLDivElement | null;
+  const selectionControls = document.createElement("div");
+  selectionControls.className = "group selection-controls";
+  selectionControls.style.display = "none";
+  const closePathBtn = document.createElement("button");
+  closePathBtn.type = "button";
+  closePathBtn.id = "lassoClosePath";
+  closePathBtn.textContent = "Close Path";
+  closePathBtn.disabled = true;
+  const commitSelectionBtn = document.createElement("button");
+  commitSelectionBtn.type = "button";
+  commitSelectionBtn.id = "lassoCommit";
+  commitSelectionBtn.textContent = "Commit Selection";
+  commitSelectionBtn.disabled = true;
+  const cancelSelectionBtn = document.createElement("button");
+  cancelSelectionBtn.type = "button";
+  cancelSelectionBtn.id = "lassoCancel";
+  cancelSelectionBtn.textContent = "Cancel Selection";
+  cancelSelectionBtn.disabled = true;
+  selectionControls.append(closePathBtn, commitSelectionBtn, cancelSelectionBtn);
+  toolbar.appendChild(selectionControls);
+
+  const updateSelectionControls = (state?: LassoState) => {
+    if (!state) {
+      closePathBtn.disabled = true;
+      commitSelectionBtn.disabled = true;
+      cancelSelectionBtn.disabled = true;
+      return;
+    }
+    closePathBtn.disabled = !state.canClose;
+    commitSelectionBtn.disabled = !state.canCommit;
+    cancelSelectionBtn.disabled = !(state.hasPath || state.hasSelection);
+  };
+  updateSelectionControls();
+
+  const attachTool = (tool: Tool) => {
+    if (activeTool instanceof LassoTool) {
+      activeTool.onStateChange = undefined;
+    }
+    activeTool = tool;
+    setActiveButton(buttonForTool(tool));
+    if (tool instanceof LassoTool) {
+      selectionControls.style.display = "flex";
+      const handler = (state: LassoState) => updateSelectionControls(state);
+      tool.onStateChange = handler;
+      updateSelectionControls(tool.state);
+    } else {
+      selectionControls.style.display = "none";
+      updateSelectionControls();
+    }
+  };
 
   if (!colorPicker) {
     throw new Error("Missing #colorPicker input");
@@ -231,8 +284,10 @@ export function initEditor(): EditorHandle {
       original(tool);
       const ctor = tool.constructor as new () => Tool;
       editorToolConstructors.set(e, ctor);
-      activeToolCtor = ctor;
-      setActiveButton(buttonForTool(tool));
+      if (e === editor) {
+        activeToolCtor = ctor;
+        attachTool(tool);
+      }
     };
   });
 
@@ -249,7 +304,43 @@ export function initEditor(): EditorHandle {
 
   // map button id to tool constructor
   Object.entries(toolConstructors).forEach(([id, ToolCtor]) =>
-    listen(toolButtons[id], "click", () => editor.setTool(new ToolCtor()), listeners),
+    listen(toolButtons[id], "click", () => {
+      const tool = new ToolCtor();
+      editor.setTool(tool);
+    }, listeners),
+  );
+
+  listen(
+    closePathBtn,
+    "click",
+    () => {
+      if (activeTool instanceof LassoTool) {
+        activeTool.closePath();
+      }
+    },
+    listeners,
+  );
+
+  listen(
+    commitSelectionBtn,
+    "click",
+    () => {
+      if (activeTool instanceof LassoTool) {
+        activeTool.commitSelection();
+      }
+    },
+    listeners,
+  );
+
+  listen(
+    cancelSelectionBtn,
+    "click",
+    () => {
+      if (activeTool instanceof LassoTool) {
+        activeTool.cancelSelection();
+      }
+    },
+    listeners,
   );
 
   listen(

--- a/src/tools/LassoTool.ts
+++ b/src/tools/LassoTool.ts
@@ -1,0 +1,246 @@
+import { Editor, type SelectionMask } from "../core/Editor.js";
+import type { Tool } from "./Tool.js";
+
+export interface LassoState {
+  isDrawing: boolean;
+  hasPath: boolean;
+  canClose: boolean;
+  isClosed: boolean;
+  canCommit: boolean;
+  hasSelection: boolean;
+}
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+export class LassoTool implements Tool {
+  cursor = "crosshair";
+  onStateChange?: (state: LassoState) => void;
+
+  private points: Point[] = [];
+  private drawing = false;
+  private closed = false;
+  private committed = false;
+  private overlay: HTMLCanvasElement | null = null;
+  private overlayCtx: CanvasRenderingContext2D | null = null;
+  private editor: Editor | null = null;
+  private selectionMask: SelectionMask | null = null;
+
+  onPointerDown(e: PointerEvent, editor: Editor) {
+    this.editor = editor;
+    this.ensureOverlay(editor);
+    this.resetPath(this.committed);
+    this.drawing = true;
+    this.closed = false;
+    this.committed = false;
+    this.selectionMask = null;
+    this.points = [this.eventToPoint(e, editor)];
+    this.renderOverlay();
+    this.emitState();
+  }
+
+  onPointerMove(e: PointerEvent, editor: Editor) {
+    if (!this.drawing || this.closed || e.buttons === 0) return;
+    const point = this.eventToPoint(e, editor);
+    const last = this.points[this.points.length - 1];
+    if (!last || Math.hypot(point.x - last.x, point.y - last.y) >= 1) {
+      this.points.push(point);
+      this.renderOverlay();
+      this.emitState();
+    }
+  }
+
+  onPointerUp(_e: PointerEvent, _editor: Editor) {
+    if (!this.drawing) return;
+    this.drawing = false;
+    this.emitState();
+  }
+
+  closePath() {
+    if (this.closed || this.points.length < 3) return;
+    this.closed = true;
+    this.generateMask();
+    this.renderOverlay();
+    this.emitState();
+  }
+
+  commitSelection() {
+    if (!this.closed || !this.selectionMask || !this.editor) return;
+    this.editor.setSelectionMask(this.selectionMask);
+    this.committed = true;
+    this.renderOverlay();
+    this.emitState();
+  }
+
+  cancelSelection() {
+    if (!this.editor) return;
+    this.resetPath(this.committed);
+    this.renderOverlay();
+    this.emitState();
+  }
+
+  destroy() {
+    this.removeOverlay();
+    this.points = [];
+    this.selectionMask = null;
+  }
+
+  get state(): LassoState {
+    return {
+      isDrawing: this.drawing,
+      hasPath: this.points.length > 1,
+      canClose: !this.closed && this.points.length >= 3,
+      isClosed: this.closed,
+      canCommit: this.closed && !!this.selectionMask,
+      hasSelection: this.committed,
+    };
+  }
+
+  private eventToPoint(e: PointerEvent, editor: Editor): Point {
+    const rect = editor.canvas.getBoundingClientRect();
+    const scaleX = editor.canvas.width / rect.width;
+    const scaleY = editor.canvas.height / rect.height;
+    return {
+      x: (e.clientX - rect.left) * scaleX,
+      y: (e.clientY - rect.top) * scaleY,
+    };
+  }
+
+  private ensureOverlay(editor: Editor) {
+    if (this.overlay && this.overlayCtx) {
+      this.syncOverlaySize(editor);
+      return;
+    }
+    const canvas = document.createElement("canvas");
+    canvas.width = editor.canvas.width;
+    canvas.height = editor.canvas.height;
+    canvas.style.pointerEvents = "none";
+    canvas.classList.add("lasso-overlay");
+    editor.canvas.parentElement?.appendChild(canvas);
+    this.overlay = canvas;
+    this.overlayCtx = canvas.getContext("2d");
+    this.syncOverlaySize(editor);
+  }
+
+  private syncOverlaySize(editor: Editor) {
+    if (!this.overlay) return;
+    if (this.overlay.width !== editor.canvas.width) {
+      this.overlay.width = editor.canvas.width;
+    }
+    if (this.overlay.height !== editor.canvas.height) {
+      this.overlay.height = editor.canvas.height;
+    }
+  }
+
+  private renderOverlay() {
+    if (!this.overlayCtx || !this.overlay) return;
+    const ctx = this.overlayCtx;
+    ctx.clearRect(0, 0, this.overlay.width, this.overlay.height);
+    if (this.points.length < 2) return;
+    ctx.save();
+    ctx.lineWidth = 1;
+    ctx.strokeStyle = "rgba(0, 123, 255, 0.8)";
+    ctx.setLineDash([6, 4]);
+    ctx.beginPath();
+    ctx.moveTo(this.points[0].x, this.points[0].y);
+    for (let i = 1; i < this.points.length; i += 1) {
+      const pt = this.points[i];
+      ctx.lineTo(pt.x, pt.y);
+    }
+    if (this.closed) {
+      ctx.closePath();
+    }
+    ctx.stroke();
+    if (this.closed) {
+      ctx.fillStyle = this.committed
+        ? "rgba(0, 123, 255, 0.1)"
+        : "rgba(0, 123, 255, 0.2)";
+      ctx.fill();
+    }
+    ctx.restore();
+  }
+
+  private generateMask() {
+    if (!this.editor || this.points.length < 3) {
+      this.selectionMask = null;
+      return;
+    }
+    const offscreen = document.createElement("canvas");
+    offscreen.width = this.editor.canvas.width;
+    offscreen.height = this.editor.canvas.height;
+    const ctx = offscreen.getContext("2d");
+    if (!ctx) {
+      this.selectionMask = null;
+      return;
+    }
+    ctx.fillStyle = "#fff";
+    ctx.beginPath();
+    ctx.moveTo(this.points[0].x, this.points[0].y);
+    for (let i = 1; i < this.points.length; i += 1) {
+      const pt = this.points[i];
+      ctx.lineTo(pt.x, pt.y);
+    }
+    ctx.closePath();
+    ctx.fill();
+
+    const imageData = ctx.getImageData(0, 0, offscreen.width, offscreen.height);
+    const { data, width, height } = imageData;
+    let minX = width;
+    let minY = height;
+    let maxX = 0;
+    let maxY = 0;
+    let hasMask = false;
+    for (let y = 0; y < height; y += 1) {
+      for (let x = 0; x < width; x += 1) {
+        const alpha = data[(y * width + x) * 4 + 3];
+        if (alpha !== 0) {
+          hasMask = true;
+          if (x < minX) minX = x;
+          if (y < minY) minY = y;
+          if (x > maxX) maxX = x;
+          if (y > maxY) maxY = y;
+        }
+      }
+    }
+    if (!hasMask) {
+      this.selectionMask = null;
+      return;
+    }
+    this.selectionMask = {
+      width,
+      height,
+      data: new Uint8ClampedArray(data),
+      path: this.points.map((pt) => ({ ...pt })),
+      bounds: {
+        x: minX,
+        y: minY,
+        width: maxX - minX + 1,
+        height: maxY - minY + 1,
+      },
+    };
+  }
+
+  private resetPath(clearSelection: boolean) {
+    this.points = [];
+    this.closed = false;
+    this.committed = false;
+    this.selectionMask = null;
+    if (clearSelection && this.editor) {
+      this.editor.clearSelectionMask();
+    }
+  }
+
+  private removeOverlay() {
+    if (this.overlay?.parentElement) {
+      this.overlay.parentElement.removeChild(this.overlay);
+    }
+    this.overlay = null;
+    this.overlayCtx = null;
+  }
+
+  private emitState() {
+    this.onStateChange?.(this.state);
+  }
+}

--- a/style.css
+++ b/style.css
@@ -77,6 +77,22 @@ body {
   filter: brightness(0) invert(1);
 }
 
+.selection-controls {
+  gap: 8px;
+}
+
+.selection-controls button {
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  background: #fff;
+  cursor: pointer;
+}
+
+.selection-controls button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 #canvasContainer {
   flex: 1;
   position: relative;

--- a/tests/bucketIntegration.test.ts
+++ b/tests/bucketIntegration.test.ts
@@ -17,6 +17,7 @@ describe("bucket tool integration", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="lasso"></button>
       <button id="text"></button>
       <button id="bucket">Bucket</button>
       <button id="eyedropper"></button>

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -18,6 +18,7 @@ describe("editor toolbar controls", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="lasso"></button>
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>

--- a/tests/eyedropperTool.test.ts
+++ b/tests/eyedropperTool.test.ts
@@ -102,6 +102,7 @@ describe("EyedropperTool color history", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="lasso"></button>
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -4,7 +4,8 @@ describe("image load and save", () => {
   let canvas: HTMLCanvasElement;
   let ctx: Partial<CanvasRenderingContext2D>;
   let handle: EditorHandle;
-  let anchor: { href: string; download: string; click: jest.Mock };
+  let anchor: HTMLAnchorElement | null;
+  let anchorClickMock: jest.SpyInstance | null;
   let createElementSpy: jest.SpyInstance;
   let fileReaderSpy: jest.SpyInstance;
   let imageSpy: jest.SpyInstance;
@@ -20,6 +21,7 @@ describe("image load and save", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="lasso"></button>
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
@@ -58,10 +60,21 @@ describe("image load and save", () => {
       toJSON: () => {},
     });
 
-    anchor = { href: "", download: "", click: jest.fn() };
+    anchor = null;
+    anchorClickMock = null;
+    const originalCreate = document.createElement;
     createElementSpy = jest
       .spyOn(document, "createElement")
-      .mockReturnValue(anchor as any);
+      .mockImplementation(function (tag: string, options?: ElementCreationOptions) {
+        const element = originalCreate.call(this, tag, options);
+        if (String(tag).toLowerCase() === "a") {
+          anchor = element as HTMLAnchorElement;
+          anchorClickMock = jest
+            .spyOn(anchor, "click")
+            .mockImplementation(() => {});
+        }
+        return element;
+      });
 
     class MockFileReader {
       result: string | ArrayBuffer | null = null;
@@ -90,6 +103,7 @@ describe("image load and save", () => {
 
   afterEach(() => {
     handle.destroy();
+    anchorClickMock?.mockRestore();
     createElementSpy.mockRestore();
     fileReaderSpy.mockRestore();
     imageSpy.mockRestore();
@@ -159,8 +173,10 @@ describe("image load and save", () => {
     const save = document.getElementById("save") as HTMLButtonElement;
     save.click();
     expect(canvas.toDataURL).toHaveBeenCalledWith("image/png");
-    expect(anchor.href).toBe("data:image/png;base64,SAVE");
-    expect(anchor.download).toBe("canvas.png");
-    expect(anchor.click).toHaveBeenCalled();
+    expect(anchor).not.toBeNull();
+    expect(anchor?.href).toBe("data:image/png;base64,SAVE");
+    expect(anchor?.download).toBe("canvas.png");
+    expect(anchorClickMock).not.toBeNull();
+    expect(anchorClickMock).toHaveBeenCalled();
   });
 });

--- a/tests/lassoTool.test.ts
+++ b/tests/lassoTool.test.ts
@@ -1,0 +1,167 @@
+import { Editor } from "../src/core/Editor.js";
+import { LassoTool } from "../src/tools/LassoTool.js";
+
+describe("LassoTool", () => {
+  let canvas: HTMLCanvasElement;
+  let editor: Editor;
+  let tool: LassoTool;
+  const width = 100;
+  const height = 100;
+  let maskData: Uint8ClampedArray;
+  let createElementSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <canvas id="canvas"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
+    `;
+
+    canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    canvas.width = width;
+    canvas.height = height;
+    canvas.getBoundingClientRect = () => ({
+      width,
+      height,
+      top: 0,
+      left: 0,
+      right: width,
+      bottom: height,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+    (canvas as any).setPointerCapture = jest.fn();
+    (canvas as any).releasePointerCapture = jest.fn();
+
+    const baseImage = {
+      data: new Uint8ClampedArray(width * height * 4),
+      width,
+      height,
+    } as ImageData;
+
+    const ctx = {
+      beginPath: jest.fn(),
+      moveTo: jest.fn(),
+      lineTo: jest.fn(),
+      stroke: jest.fn(),
+      closePath: jest.fn(),
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+      getImageData: jest.fn(() => baseImage),
+      putImageData: jest.fn(),
+      clearRect: jest.fn(),
+    } as unknown as CanvasRenderingContext2D;
+
+    canvas.getContext = jest.fn(() => ctx);
+
+    const originalCreateElement = document.createElement.bind(document);
+    maskData = new Uint8ClampedArray(width * height * 4);
+    for (let y = 10; y < 20; y += 1) {
+      for (let x = 10; x < 20; x += 1) {
+        maskData[(y * width + x) * 4 + 3] = 255;
+      }
+    }
+
+    const overlayCtx = {
+      clearRect: jest.fn(),
+      setLineDash: jest.fn(),
+      beginPath: jest.fn(),
+      moveTo: jest.fn(),
+      lineTo: jest.fn(),
+      closePath: jest.fn(),
+      stroke: jest.fn(),
+      fill: jest.fn(),
+      save: jest.fn(),
+      restore: jest.fn(),
+      lineWidth: 1,
+      strokeStyle: "",
+      fillStyle: "",
+    } as unknown as CanvasRenderingContext2D;
+
+    const maskCtx = {
+      fillStyle: "",
+      beginPath: jest.fn(),
+      moveTo: jest.fn(),
+      lineTo: jest.fn(),
+      closePath: jest.fn(),
+      fill: jest.fn(),
+      getImageData: jest.fn(
+        () => ({ data: maskData, width, height } as ImageData),
+      ),
+    } as unknown as CanvasRenderingContext2D;
+
+    let overlayProvided = false;
+    createElementSpy = jest
+      .spyOn(document, "createElement")
+      .mockImplementation((tagName: string) => {
+        if (tagName.toLowerCase() === "canvas") {
+          const el = originalCreateElement(tagName) as HTMLCanvasElement;
+          el.width = width;
+          el.height = height;
+          el.getContext = jest
+            .fn()
+            .mockReturnValue(overlayProvided ? maskCtx : overlayCtx);
+          overlayProvided = true;
+          return el as unknown as HTMLElement;
+        }
+        return originalCreateElement(tagName);
+      });
+
+    editor = new Editor(
+      canvas,
+      document.getElementById("colorPicker") as HTMLInputElement,
+      document.getElementById("lineWidth") as HTMLInputElement,
+      document.getElementById("fillMode") as HTMLInputElement,
+    );
+    tool = new LassoTool();
+  });
+
+  afterEach(() => {
+    createElementSpy.mockRestore();
+    editor.destroy();
+  });
+
+  function drawSimplePolygon() {
+    tool.onPointerDown(
+      { clientX: 10, clientY: 10 } as PointerEvent,
+      editor,
+    );
+    tool.onPointerMove(
+      { clientX: 60, clientY: 10, buttons: 1 } as PointerEvent,
+      editor,
+    );
+    tool.onPointerMove(
+      { clientX: 35, clientY: 40, buttons: 1 } as PointerEvent,
+      editor,
+    );
+    tool.onPointerUp({ clientX: 35, clientY: 40 } as PointerEvent, editor);
+  }
+
+  it("commits a selection mask when closed and committed", () => {
+    drawSimplePolygon();
+    tool.closePath();
+    tool.commitSelection();
+
+    expect(editor.selectionMask).not.toBeNull();
+    expect(editor.selectionMask?.bounds).toEqual({
+      x: 10,
+      y: 10,
+      width: 10,
+      height: 10,
+    });
+    expect(tool.state.hasSelection).toBe(true);
+  });
+
+  it("clears selection on cancel", () => {
+    drawSimplePolygon();
+    tool.closePath();
+    tool.commitSelection();
+    expect(editor.selectionMask).not.toBeNull();
+
+    tool.cancelSelection();
+    expect(editor.selectionMask).toBeNull();
+    expect(tool.state.hasSelection).toBe(false);
+  });
+});

--- a/tests/layers.test.ts
+++ b/tests/layers.test.ts
@@ -21,6 +21,7 @@ describe("layer-specific undo/redo", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="lasso"></button>
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>

--- a/tests/opacity.test.ts
+++ b/tests/opacity.test.ts
@@ -18,6 +18,7 @@ describe("layer opacity", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="lasso"></button>
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -12,6 +12,7 @@ describe("save button", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="lasso"></button>
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
@@ -35,18 +36,32 @@ describe("save button", () => {
       toJSON: () => {},
     });
 
-    const click = jest.fn();
-    const anchor = { href: "", download: "", click } as any;
-
-    jest.spyOn(document, "createElement").mockReturnValue(anchor);
+    let createdAnchor: HTMLAnchorElement | null = null;
+    let clickMock: jest.SpyInstance | null = null;
+    const originalCreate = document.createElement;
+    const createSpy = jest
+      .spyOn(document, "createElement")
+      .mockImplementation(function (tag: string, options?: ElementCreationOptions) {
+        const element = originalCreate.call(this, tag, options);
+        if (String(tag).toLowerCase() === "a") {
+          createdAnchor = element as HTMLAnchorElement;
+          clickMock = jest
+            .spyOn(createdAnchor, "click")
+            .mockImplementation(() => {});
+        }
+        return element;
+      });
 
     const handle = initEditor();
 
     (document.getElementById("save") as HTMLButtonElement).click();
     expect(canvas.toDataURL).toHaveBeenCalledWith("image/png");
-    expect(click).toHaveBeenCalled();
+    expect(clickMock).not.toBeNull();
+    expect(clickMock).toHaveBeenCalled();
 
     handle.destroy();
+    clickMock?.mockRestore();
+    createSpy.mockRestore();
   });
 
   it("supports selecting jpeg format", () => {
@@ -60,6 +75,7 @@ describe("save button", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="lasso"></button>
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>
@@ -83,17 +99,32 @@ describe("save button", () => {
       toJSON: () => {},
     });
 
-    const click = jest.fn();
-    const anchor = { href: "", download: "", click } as any;
-    jest.spyOn(document, "createElement").mockReturnValue(anchor);
+    let createdAnchor: HTMLAnchorElement | null = null;
+    let clickMock: jest.SpyInstance | null = null;
+    const originalCreate = document.createElement;
+    const createSpy = jest
+      .spyOn(document, "createElement")
+      .mockImplementation(function (tag: string, options?: ElementCreationOptions) {
+        const element = originalCreate.call(this, tag, options);
+        if (String(tag).toLowerCase() === "a") {
+          createdAnchor = element as HTMLAnchorElement;
+          clickMock = jest
+            .spyOn(createdAnchor, "click")
+            .mockImplementation(() => {});
+        }
+        return element;
+      });
 
     const handle = initEditor();
 
     (document.getElementById("save") as HTMLButtonElement).click();
     expect(canvas.toDataURL).toHaveBeenCalledWith("image/jpeg", 0.9);
-    expect(anchor.download).toBe("canvas.jpg");
-    expect(click).toHaveBeenCalled();
+    expect(createdAnchor?.download).toBe("canvas.jpg");
+    expect(clickMock).not.toBeNull();
+    expect(clickMock).toHaveBeenCalled();
 
     handle.destroy();
+    clickMock?.mockRestore();
+    createSpy.mockRestore();
   });
 });

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -26,6 +26,7 @@ describe("keyboard shortcuts", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="lasso"></button>
       <button id="text"></button>
       <button id="bucket"></button>
       <button id="eyedropper"></button>

--- a/tests/toolbar.test.ts
+++ b/tests/toolbar.test.ts
@@ -6,6 +6,7 @@ import { LineTool } from "../src/tools/LineTool.js";
 import { CircleTool } from "../src/tools/CircleTool.js";
 import { TextTool } from "../src/tools/TextTool.js";
 import { EyedropperTool } from "../src/tools/EyedropperTool.js";
+import { LassoTool } from "../src/tools/LassoTool.js";
 
 describe("toolbar controls", () => {
   let handle: EditorHandle;
@@ -25,6 +26,7 @@ describe("toolbar controls", () => {
       <button id="rectangle"></button>
       <button id="line"></button>
       <button id="circle"></button>
+      <button id="lasso"></button>
       <button id="text"></button>
       <button id="eyedropper"></button>
       <button id="bucket"></button>
@@ -94,11 +96,14 @@ describe("toolbar controls", () => {
       (document.getElementById("circle") as HTMLButtonElement).click();
       expect(spy.mock.calls[4][0]).toBeInstanceOf(CircleTool);
 
+      (document.getElementById("lasso") as HTMLButtonElement).click();
+      expect(spy.mock.calls[5][0]).toBeInstanceOf(LassoTool);
+
       (document.getElementById("text") as HTMLButtonElement).click();
-      expect(spy.mock.calls[5][0]).toBeInstanceOf(TextTool);
+      expect(spy.mock.calls[6][0]).toBeInstanceOf(TextTool);
 
       (document.getElementById("eyedropper") as HTMLButtonElement).click();
-      expect(spy.mock.calls[6][0]).toBeInstanceOf(EyedropperTool);
+      expect(spy.mock.calls[7][0]).toBeInstanceOf(EyedropperTool);
     });
 
     it("routes tool changes to the selected layer", () => {


### PR DESCRIPTION
## Summary
- add a lasso selection tool that records pointer paths, renders an overlay, and produces selection masks on commit
- teach the editor to persist selection masks and surface toolbar controls for closing, committing, and cancelling a lasso path
- style the new controls, add a lasso icon, and expand tests to cover the new tool alongside updated editor fixtures

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60d169b588328be46a886cea028d4