### PR TITLE
Implement weighted smoothing for pencil strokes

### DIFF
--- a/src/tools/PencilTool.ts
+++ b/src/tools/PencilTool.ts
@@ -1,23 +1,127 @@
 import { Editor } from "../core/Editor.js";
 import { DrawingTool } from "./DrawingTool.js";
 
+type Point = {
+  x: number;
+  y: number;
+};
+
 export class PencilTool extends DrawingTool {
+  private static readonly SMOOTHING_WEIGHTS = [0.5, 0.3, 0.15, 0.05];
+
+  private recentPoints: Point[] = [];
+  private bufferedPoints: Point[] = [];
+  private lastOutputPoint: Point | null = null;
+  private isDrawing = false;
+  private frameHandle: number | null = null;
+
   onPointerDown(e: PointerEvent, editor: Editor) {
+    this.isDrawing = true;
+    this.recentPoints = [];
+    this.bufferedPoints = [];
+    this.lastOutputPoint = null;
+    this.cancelScheduledFlush();
+
     this.applyStroke(editor.ctx, editor);
+    const startPoint = this.toPoint(e);
+    this.recentPoints.push(startPoint);
+    this.lastOutputPoint = startPoint;
+
     const ctx = editor.ctx;
     ctx.beginPath();
-    ctx.moveTo(e.offsetX, e.offsetY);
-  }
-
-  onPointerMove(e: PointerEvent, editor: Editor) {
-    if (e.buttons !== 1) return;
-    this.applyStroke(editor.ctx, editor);
-    const ctx = editor.ctx;
-    ctx.lineTo(e.offsetX, e.offsetY);
+    ctx.moveTo(startPoint.x, startPoint.y);
+    ctx.lineTo(startPoint.x, startPoint.y);
     ctx.stroke();
   }
 
+  onPointerMove(e: PointerEvent, editor: Editor) {
+    if (!this.isDrawing || e.buttons !== 1) return;
+    this.bufferedPoints.push(this.toPoint(e));
+    this.scheduleFlush(editor);
+  }
+
   onPointerUp(_e: PointerEvent, editor: Editor) {
+    if (!this.isDrawing) return;
+    this.isDrawing = false;
+    this.cancelScheduledFlush();
+    this.flushBufferedPoints(editor);
     editor.ctx.closePath();
+    this.recentPoints = [];
+    this.bufferedPoints = [];
+    this.lastOutputPoint = null;
+  }
+
+  private toPoint(e: PointerEvent): Point {
+    return { x: e.offsetX, y: e.offsetY };
+  }
+
+  private scheduleFlush(editor: Editor) {
+    if (this.frameHandle !== null) return;
+    this.frameHandle = window.requestAnimationFrame(() => {
+      this.frameHandle = null;
+      this.flushBufferedPoints(editor);
+    });
+  }
+
+  private cancelScheduledFlush() {
+    if (this.frameHandle !== null) {
+      window.cancelAnimationFrame(this.frameHandle);
+      this.frameHandle = null;
+    }
+  }
+
+  private flushBufferedPoints(editor: Editor) {
+    if (!this.bufferedPoints.length || !this.lastOutputPoint) {
+      this.bufferedPoints = [];
+      return;
+    }
+
+    const ctx = editor.ctx;
+    this.applyStroke(ctx, editor);
+
+    let lastPoint: Point = this.lastOutputPoint;
+    for (const point of this.bufferedPoints) {
+      this.recentPoints.push(point);
+      if (this.recentPoints.length > PencilTool.SMOOTHING_WEIGHTS.length) {
+        this.recentPoints.shift();
+      }
+
+      const smoothed = this.computeSmoothedPoint();
+      ctx.beginPath();
+      ctx.moveTo(lastPoint.x, lastPoint.y);
+      ctx.lineTo(smoothed.x, smoothed.y);
+      ctx.stroke();
+      lastPoint = smoothed;
+    }
+
+    this.lastOutputPoint = lastPoint;
+    this.bufferedPoints = [];
+  }
+
+  private computeSmoothedPoint(): Point {
+    const points = this.recentPoints;
+    const weights = PencilTool.SMOOTHING_WEIGHTS;
+    const count = points.length;
+    let weightedX = 0;
+    let weightedY = 0;
+    let totalWeight = 0;
+
+    for (let i = 0; i < count; i++) {
+      const point = points[count - 1 - i];
+      const weight = weights[i] ?? 0;
+      weightedX += point.x * weight;
+      weightedY += point.y * weight;
+      totalWeight += weight;
+    }
+
+    if (totalWeight === 0) {
+      const lastPoint = points[points.length - 1];
+      return { x: lastPoint.x, y: lastPoint.y };
+    }
+
+    return {
+      x: weightedX / totalWeight,
+      y: weightedY / totalWeight,
+    };
   }
 }

--- a/tests/pencilTool.test.ts
+++ b/tests/pencilTool.test.ts
@@ -1,0 +1,127 @@
+import { Editor } from "../src/core/Editor.js";
+import { PencilTool } from "../src/tools/PencilTool.js";
+
+describe("PencilTool smoothing", () => {
+  let editor: Editor;
+  let ctx: Partial<CanvasRenderingContext2D> & {
+    lineTo: jest.Mock;
+    moveTo: jest.Mock;
+    beginPath: jest.Mock;
+    stroke: jest.Mock;
+    closePath: jest.Mock;
+  };
+  let rafSpy: jest.SpyInstance<number, [FrameRequestCallback]>;
+  let cancelSpy: jest.SpyInstance<void, [number]>;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <canvas id="canvas"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
+    `;
+    const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    const rect = {
+      width: 100,
+      height: 100,
+      top: 0,
+      left: 0,
+      right: 100,
+      bottom: 100,
+      x: 0,
+      y: 0,
+      toJSON() {
+        return {};
+      },
+    } as DOMRect;
+    canvas.getBoundingClientRect = () => rect;
+    (canvas as any).setPointerCapture = jest.fn();
+    (canvas as any).releasePointerCapture = jest.fn();
+    const imageData = {
+      data: new Uint8ClampedArray(),
+      width: 100,
+      height: 100,
+    } as ImageData;
+    ctx = {
+      getImageData: jest.fn().mockReturnValue(imageData),
+      putImageData: jest.fn(),
+      clearRect: jest.fn(),
+      beginPath: jest.fn(),
+      moveTo: jest.fn(),
+      lineTo: jest.fn(),
+      stroke: jest.fn(),
+      closePath: jest.fn(),
+      setTransform: jest.fn(),
+      scale: jest.fn(),
+      lineWidth: 1,
+      strokeStyle: "#000000",
+      fillStyle: "#000000",
+    };
+    canvas.getContext = jest
+      .fn()
+      .mockReturnValue(ctx as CanvasRenderingContext2D);
+
+    rafSpy = jest
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+      });
+    cancelSpy = jest
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation(() => undefined);
+
+    editor = new Editor(
+      canvas,
+      document.getElementById("colorPicker") as HTMLInputElement,
+      document.getElementById("lineWidth") as HTMLInputElement,
+      document.getElementById("fillMode") as HTMLInputElement,
+    );
+  });
+
+  afterEach(() => {
+    rafSpy.mockRestore();
+    cancelSpy.mockRestore();
+  });
+
+  it("applies weighted moving average smoothing", () => {
+    const tool = new PencilTool();
+    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+    tool.onPointerMove({ offsetX: 10, offsetY: 0, buttons: 1 } as PointerEvent, editor);
+    tool.onPointerMove({ offsetX: 20, offsetY: 0, buttons: 1 } as PointerEvent, editor);
+    tool.onPointerMove({ offsetX: 30, offsetY: 0, buttons: 1 } as PointerEvent, editor);
+    tool.onPointerUp({ offsetX: 30, offsetY: 0 } as PointerEvent, editor);
+
+    const calls = (ctx.lineTo as jest.Mock).mock.calls;
+    expect(calls.length).toBe(4);
+    const smoothedCalls = calls.slice(1);
+    expect(smoothedCalls[0][0]).toBeCloseTo(6.25, 2);
+    expect(smoothedCalls[1][0]).toBeCloseTo(13.68, 2);
+    expect(smoothedCalls[2][0]).toBeCloseTo(22.5, 2);
+    smoothedCalls.forEach(([, y]: number[]) => expect(y).toBeCloseTo(0, 5));
+  });
+
+  it("buffers pointer events until the next animation frame flush", () => {
+    const callbacks: jest.Mock[] = [];
+    rafSpy.mockImplementation((cb: FrameRequestCallback) => {
+      const wrapper = jest.fn(cb);
+      callbacks.push(wrapper);
+      return callbacks.length;
+    });
+
+    const tool = new PencilTool();
+    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+    tool.onPointerMove({ offsetX: 10, offsetY: 0, buttons: 1 } as PointerEvent, editor);
+    tool.onPointerMove({ offsetX: 20, offsetY: 0, buttons: 1 } as PointerEvent, editor);
+
+    // Only the initial dot should be rendered before the frame callback runs.
+    expect((ctx.lineTo as jest.Mock).mock.calls.length).toBe(1);
+
+    tool.onPointerUp({ offsetX: 20, offsetY: 0 } as PointerEvent, editor);
+    expect(cancelSpy).toHaveBeenCalled();
+    expect((ctx.lineTo as jest.Mock).mock.calls.length).toBe(3);
+
+    // The scheduled callbacks should not have been invoked once cancelled.
+    callbacks.forEach((cb) => expect(cb).not.toHaveBeenCalled());
+  });
+});


### PR DESCRIPTION
## Summary
- implement weighted moving average smoothing and buffered pointer handling in the pencil tool
- process pointer events on animation frames to render catch-up stroke segments
- add tests covering smoothing and buffering behavior on synthetic stroke data

## Testing
- npm test -- pencilTool

------
https://chatgpt.com/codex/tasks/task_e_68d60d13df448328876f1997e35e7dbf