### PR TITLE
Add configurable tolerance and connectivity for bucket fill tool

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -7,6 +7,7 @@ import { LineTool } from "./tools/LineTool.js";
 import { CircleTool } from "./tools/CircleTool.js";
 import { TextTool } from "./tools/TextTool.js";
 import { BucketFillTool } from "./tools/BucketFillTool.js";
+import type { BucketFillOptions } from "./tools/BucketFillTool.js";
 import { EyedropperTool } from "./tools/EyedropperTool.js";
 import type { Tool } from "./tools/Tool.js";
 
@@ -99,6 +100,75 @@ export function initEditor(): EditorHandle {
   const colorHistory = document.getElementById(
     "colorHistory",
   ) as HTMLDivElement | null;
+  const bucketSettingsKey = "bucketFillSettings";
+
+  const loadBucketSettings = (): Partial<BucketFillOptions> | undefined => {
+    if (typeof window === "undefined") return undefined;
+    try {
+      return JSON.parse(
+        window.sessionStorage?.getItem(bucketSettingsKey) ?? "null",
+      ) ?? undefined;
+    } catch {
+      return undefined;
+    }
+  };
+
+  const persistBucketSettings = (settings: BucketFillOptions) => {
+    try {
+      window.sessionStorage?.setItem(
+        bucketSettingsKey,
+        JSON.stringify(settings),
+      );
+    } catch {
+      /* ignore storage errors */
+    }
+  };
+
+  const storedBucketSettings = loadBucketSettings();
+  const bucketSettings = storedBucketSettings
+    ? BucketFillTool.setDefaults(storedBucketSettings)
+    : BucketFillTool.getDefaults();
+
+  const bucketControlsGroup = document.createElement("div");
+  bucketControlsGroup.className = "group bucket-fill-controls";
+
+  const toleranceRow = document.createElement("div");
+  toleranceRow.className = "bucket-tolerance-row";
+
+  const toleranceLabel = document.createElement("label");
+  toleranceLabel.htmlFor = "bucketTolerance";
+  toleranceLabel.textContent = "Fill tolerance";
+
+  const toleranceSlider = document.createElement("input");
+  toleranceSlider.type = "range";
+  toleranceSlider.id = "bucketTolerance";
+  toleranceSlider.min = "0";
+  toleranceSlider.max = "255";
+  toleranceSlider.step = "1";
+  toleranceSlider.value = String(bucketSettings.tolerance);
+
+  const toleranceValue = document.createElement("span");
+  toleranceValue.className = "bucket-tolerance-value";
+  toleranceValue.textContent = String(bucketSettings.tolerance);
+
+  toleranceRow.appendChild(toleranceLabel);
+  toleranceRow.appendChild(toleranceSlider);
+  toleranceRow.appendChild(toleranceValue);
+
+  const connectivityLabel = document.createElement("label");
+  connectivityLabel.className = "bucket-connectivity-toggle";
+
+  const connectivityToggle = document.createElement("input");
+  connectivityToggle.type = "checkbox";
+  connectivityToggle.id = "bucketConnectivity";
+  connectivityToggle.checked = bucketSettings.connectivity === 8;
+
+  connectivityLabel.appendChild(connectivityToggle);
+  connectivityLabel.appendChild(document.createTextNode("8-way fill"));
+
+  bucketControlsGroup.appendChild(toleranceRow);
+  bucketControlsGroup.appendChild(connectivityLabel);
+  toolbar.appendChild(bucketControlsGroup);
 
   if (!colorPicker) {
     throw new Error("Missing #colorPicker input");
@@ -155,6 +225,27 @@ export function initEditor(): EditorHandle {
   const undoBtn = document.getElementById("undo") as HTMLButtonElement | null;
   const redoBtn = document.getElementById("redo") as HTMLButtonElement | null;
   const listeners: Array<() => void> = [];
+
+  const updateBucketTolerance = () => {
+    const updated = BucketFillTool.setDefaults({
+      tolerance: Number(toleranceSlider.value),
+    });
+    toleranceSlider.value = String(updated.tolerance);
+    toleranceValue.textContent = String(updated.tolerance);
+    persistBucketSettings(updated);
+  };
+
+  const updateBucketConnectivity = () => {
+    const updated = BucketFillTool.setDefaults({
+      connectivity: connectivityToggle.checked ? 8 : 4,
+    });
+    connectivityToggle.checked = updated.connectivity === 8;
+    persistBucketSettings(updated);
+  };
+
+  listen(toleranceSlider, "input", updateBucketTolerance, listeners);
+
+  listen(connectivityToggle, "change", updateBucketConnectivity, listeners);
 
   const recentColors: string[] = [];
   const maxRecentColors = 10;

--- a/src/tools/BucketFillTool.ts
+++ b/src/tools/BucketFillTool.ts
@@ -1,12 +1,72 @@
 import { Editor } from "../core/Editor.js";
 import { Tool } from "./Tool.js";
 
+export type BucketFillConnectivity = 4 | 8;
+
+export interface BucketFillOptions {
+  tolerance: number;
+  connectivity: BucketFillConnectivity;
+}
+
 /**
  * Tool that fills a contiguous region of pixels with the current fill color.
  * Uses an iterative flood fill with typed-array backed queue to reduce memory churn.
  */
 export class BucketFillTool implements Tool {
   private static readonly MAX_FILL_PIXELS = 1_000_000;
+  private static defaults: BucketFillOptions = {
+    tolerance: 0,
+    connectivity: 4,
+  };
+
+  private readonly override?: BucketFillOptions;
+
+  constructor(options?: Partial<BucketFillOptions>) {
+    if (options) {
+      this.override = BucketFillTool.normalizeOptions(
+        options,
+        BucketFillTool.defaults,
+      );
+    }
+  }
+
+  static getDefaults(): BucketFillOptions {
+    return { ...BucketFillTool.defaults };
+  }
+
+  static setDefaults(options: Partial<BucketFillOptions>): BucketFillOptions {
+    BucketFillTool.defaults = BucketFillTool.normalizeOptions(
+      options,
+      BucketFillTool.defaults,
+    );
+    return BucketFillTool.getDefaults();
+  }
+
+  private static normalizeOptions(
+    options: Partial<BucketFillOptions>,
+    base: BucketFillOptions,
+  ): BucketFillOptions {
+    const tolerance =
+      options.tolerance !== undefined
+        ? BucketFillTool.clampTolerance(options.tolerance)
+        : base.tolerance;
+    const connectivity =
+      options.connectivity !== undefined
+        ? options.connectivity === 8
+          ? 8
+          : 4
+        : base.connectivity;
+    return { tolerance, connectivity };
+  }
+
+  private static clampTolerance(value: number): number {
+    if (!Number.isFinite(value)) return 0;
+    return Math.max(0, Math.min(255, Math.round(value)));
+  }
+
+  private get options(): BucketFillOptions {
+    return this.override ?? BucketFillTool.defaults;
+  }
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
@@ -39,13 +99,20 @@ export class BucketFillTool implements Tool {
     let tail = 0;
     let processed = 0;
 
+    const { tolerance, connectivity } = this.options;
+    const useEightConnectivity = connectivity === 8;
+
     queue[tail++] = start;
     visited[start] = 1;
 
     while (head < tail) {
       const idx = queue[head++];
       const offset = idx * 4;
-      if (data[offset] !== tr || data[offset + 1] !== tg || data[offset + 2] !== tb) {
+      if (
+        Math.abs(data[offset] - tr) > tolerance ||
+        Math.abs(data[offset + 1] - tg) > tolerance ||
+        Math.abs(data[offset + 2] - tb) > tolerance
+      ) {
         continue;
       }
 
@@ -62,33 +129,25 @@ export class BucketFillTool implements Tool {
       const x = idx % width;
       const y = (idx / width) | 0;
 
-      if (x > 0) {
-        const n = idx - 1;
+      const enqueue = (nx: number, ny: number) => {
+        if (nx < 0 || ny < 0 || nx >= width || ny >= height) return;
+        const n = ny * width + nx;
         if (!visited[n]) {
           queue[tail++] = n;
           visited[n] = 1;
         }
-      }
-      if (x < width - 1) {
-        const n = idx + 1;
-        if (!visited[n]) {
-          queue[tail++] = n;
-          visited[n] = 1;
-        }
-      }
-      if (y > 0) {
-        const n = idx - width;
-        if (!visited[n]) {
-          queue[tail++] = n;
-          visited[n] = 1;
-        }
-      }
-      if (y < height - 1) {
-        const n = idx + width;
-        if (!visited[n]) {
-          queue[tail++] = n;
-          visited[n] = 1;
-        }
+      };
+
+      enqueue(x - 1, y);
+      enqueue(x + 1, y);
+      enqueue(x, y - 1);
+      enqueue(x, y + 1);
+
+      if (useEightConnectivity) {
+        enqueue(x - 1, y - 1);
+        enqueue(x + 1, y - 1);
+        enqueue(x - 1, y + 1);
+        enqueue(x + 1, y + 1);
       }
     }
     ctx.putImageData(image, 0, 0);

--- a/tests/bucketFillTool.test.ts
+++ b/tests/bucketFillTool.test.ts
@@ -48,6 +48,10 @@ describe("BucketFillTool", () => {
     );
   });
 
+  afterEach(() => {
+    BucketFillTool.setDefaults({ tolerance: 0, connectivity: 4 });
+  });
+
   it("fills enclosed areas with the selected color", () => {
     const tool = new BucketFillTool();
     tool.onPointerDown({ offsetX: 2, offsetY: 2 } as PointerEvent, editor);
@@ -88,5 +92,80 @@ describe("BucketFillTool", () => {
     expect(image.data[last + 1]).toBe(0);
     expect(image.data[last + 2]).toBe(255);
     expect(ctx.putImageData).toHaveBeenCalledWith(image, 0, 0);
+  });
+
+  it("fills neighboring pixels that are within the configured tolerance", () => {
+    const width = 3;
+    const height = 3;
+    const data = new Uint8ClampedArray(width * height * 4);
+    for (let i = 0; i < width * height; i++) {
+      const offset = i * 4;
+      data[offset] = 255;
+      data[offset + 1] = 255;
+      data[offset + 2] = 255;
+      data[offset + 3] = 255;
+    }
+    // Starting pixel slightly darker than neighbors
+    data[0] = 245;
+    data[1] = 245;
+    data[2] = 245;
+    const image = { data, width, height } as ImageData;
+    (ctx.getImageData as jest.Mock).mockReturnValueOnce(image);
+
+    const tool = new BucketFillTool({ tolerance: 10 });
+    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+
+    const last = (width * height - 1) * 4;
+    expect(image.data[last]).toBe(0);
+    expect(image.data[last + 1]).toBe(0);
+    expect(image.data[last + 2]).toBe(255);
+  });
+
+  it("expands diagonally when using 8-way connectivity", () => {
+    const createImage = () => {
+      const width = 3;
+      const height = 3;
+      const data = new Uint8ClampedArray(width * height * 4);
+      for (let i = 0; i < width * height; i++) {
+        const offset = i * 4;
+        data[offset] = 0;
+        data[offset + 1] = 0;
+        data[offset + 2] = 0;
+        data[offset + 3] = 255;
+      }
+      // Start and diagonal pixel share a color
+      const start = 0;
+      data[start] = 255;
+      data[start + 1] = 255;
+      data[start + 2] = 255;
+
+      const diagonal = (1 * width + 1) * 4;
+      data[diagonal] = 255;
+      data[diagonal + 1] = 255;
+      data[diagonal + 2] = 255;
+
+      return { data, width, height } as ImageData;
+    };
+
+    const image4 = createImage();
+    (ctx.getImageData as jest.Mock).mockReturnValueOnce(image4);
+
+    const fourWayTool = new BucketFillTool({ connectivity: 4 });
+    fourWayTool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+
+    const diagonal = (1 * image4.width + 1) * 4;
+    expect(image4.data[diagonal]).toBe(255);
+    expect(image4.data[diagonal + 1]).toBe(255);
+    expect(image4.data[diagonal + 2]).toBe(255);
+
+    const image8 = createImage();
+    (ctx.getImageData as jest.Mock).mockReturnValueOnce(image8);
+
+    const eightWayTool = new BucketFillTool({ connectivity: 8 });
+    eightWayTool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+
+    expect(image8.data[diagonal]).toBe(0);
+    expect(image8.data[diagonal + 1]).toBe(0);
+    expect(image8.data[diagonal + 2]).toBe(255);
   });
 });

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -59,9 +59,15 @@ describe("image load and save", () => {
     });
 
     anchor = { href: "", download: "", click: jest.fn() };
+    const realCreateElement = document.createElement.bind(document);
     createElementSpy = jest
       .spyOn(document, "createElement")
-      .mockReturnValue(anchor as any);
+      .mockImplementation(((tagName: string, options?: ElementCreationOptions) => {
+        if (tagName.toLowerCase() === "a") {
+          return anchor as unknown as HTMLElement;
+        }
+        return realCreateElement(tagName as any, options);
+      }) as typeof document.createElement);
 
     class MockFileReader {
       result: string | ArrayBuffer | null = null;

--- a/tests/save.test.ts
+++ b/tests/save.test.ts
@@ -38,7 +38,15 @@ describe("save button", () => {
     const click = jest.fn();
     const anchor = { href: "", download: "", click } as any;
 
-    jest.spyOn(document, "createElement").mockReturnValue(anchor);
+    const realCreateElement = document.createElement.bind(document);
+    const createElementSpy = jest
+      .spyOn(document, "createElement")
+      .mockImplementation(((tagName: string, options?: ElementCreationOptions) => {
+        if (tagName.toLowerCase() === "a") {
+          return anchor as unknown as HTMLElement;
+        }
+        return realCreateElement(tagName as any, options);
+      }) as typeof document.createElement);
 
     const handle = initEditor();
 
@@ -47,6 +55,7 @@ describe("save button", () => {
     expect(click).toHaveBeenCalled();
 
     handle.destroy();
+    createElementSpy.mockRestore();
   });
 
   it("supports selecting jpeg format", () => {
@@ -85,7 +94,15 @@ describe("save button", () => {
 
     const click = jest.fn();
     const anchor = { href: "", download: "", click } as any;
-    jest.spyOn(document, "createElement").mockReturnValue(anchor);
+    const realCreateElement = document.createElement.bind(document);
+    const createElementSpy = jest
+      .spyOn(document, "createElement")
+      .mockImplementation(((tagName: string, options?: ElementCreationOptions) => {
+        if (tagName.toLowerCase() === "a") {
+          return anchor as unknown as HTMLElement;
+        }
+        return realCreateElement(tagName as any, options);
+      }) as typeof document.createElement);
 
     const handle = initEditor();
 
@@ -95,5 +112,6 @@ describe("save button", () => {
     expect(click).toHaveBeenCalled();
 
     handle.destroy();
+    createElementSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- extend the bucket fill tool to support configurable tolerance and 4- or 8-way connectivity with shared defaults
- add toolbar controls that persist the bucket settings for the session and update the active tool
- expand unit tests to cover tolerance/connectivity behaviour and adjust DOM mocks for the new controls

## Testing
- npm test -- --runInBand
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d60d14ef28832886c920e26c91b66c