### PR TITLE
Add rulers with persistent grid overlay toggle

### DIFF
--- a/dist/core/Editor.js
+++ b/dist/core/Editor.js
@@ -1,8 +1,11 @@
 export class Editor {
-    constructor(canvas, colorPicker, lineWidth, fillMode, onChange, fontFamily, fontSize) {
+    constructor(canvas, colorPicker, lineWidth, fillMode, onChange, fontFamily, fontSize, options = {}) {
         this.undoStack = [];
         this.redoStack = [];
         this.currentTool = null;
+        this.baseGridSpacing = 50;
+        this.minGridSpacingPx = 25;
+        this.majorLineFrequency = 4;
         this.handlePointerDown = (e) => {
             // Capture the pointer once before recording canvas state
             this.canvas.setPointerCapture(e.pointerId);
@@ -20,6 +23,7 @@ export class Editor {
             const data = this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height);
             this.adjustForPixelRatio();
             this.ctx.putImageData(data, 0, 0);
+            this.updateOverlays();
         };
         this.canvas = canvas;
         const ctx = canvas.getContext("2d");
@@ -32,7 +36,14 @@ export class Editor {
         this.onChange = onChange;
         this.fontFamily = fontFamily ?? null;
         this.fontSize = fontSize ?? null;
+        this.gridOverlay = options.gridOverlay ?? null;
+        this.gridCtx = this.gridOverlay ? this.gridOverlay.getContext("2d") : null;
+        this.horizontalRuler = options.horizontalRuler ?? null;
+        this.verticalRuler = options.verticalRuler ?? null;
+        this.gridVisible = options.initialGridVisible ?? true;
+        this.zoom = options.initialZoom ?? 1;
         this.adjustForPixelRatio();
+        this.setGridVisible(this.gridVisible);
         window.addEventListener("resize", this.handleResize);
         this.canvas.addEventListener("pointerdown", this.handlePointerDown);
         this.canvas.addEventListener("pointermove", this.handlePointerMove);
@@ -44,13 +55,14 @@ export class Editor {
         this.canvas.style.cursor = tool.cursor || "crosshair";
     }
     adjustForPixelRatio() {
-        const dpr = window.devicePixelRatio || 1;
+        const dpr = this.devicePixelRatio;
         const rect = this.canvas.getBoundingClientRect();
         this.canvas.width = rect.width * dpr;
         this.canvas.height = rect.height * dpr;
         this.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
         // Reset any existing transforms
         this.ctx.scale(1, 1);
+        this.updateOverlays();
     }
     saveState() {
         this.undoStack.push(this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height));
@@ -97,6 +109,232 @@ export class Editor {
     }
     get fontSizeValue() {
         return parseInt(this.fontSize?.value ?? "", 10) || 16;
+    }
+    setGridVisible(visible) {
+        this.gridVisible = visible;
+        if (this.gridOverlay) {
+            this.gridOverlay.style.visibility = visible ? "visible" : "hidden";
+        }
+        this.renderGrid();
+    }
+    toggleGrid() {
+        const next = !this.gridVisible;
+        this.setGridVisible(next);
+        return next;
+    }
+    isGridVisible() {
+        return this.gridVisible;
+    }
+    setZoom(zoom) {
+        if (!Number.isFinite(zoom) || zoom <= 0)
+            return;
+        this.zoom = zoom;
+        this.updateOverlays();
+    }
+    get zoomLevel() {
+        return this.zoom;
+    }
+    get devicePixelRatio() {
+        return window.devicePixelRatio || 1;
+    }
+    updateOverlays() {
+        this.renderGrid();
+        this.renderRulers();
+    }
+    renderGrid() {
+        if (!this.gridOverlay || !this.gridCtx)
+            return;
+        const rect = this.canvas.getBoundingClientRect();
+        const dpr = this.devicePixelRatio;
+        const width = Math.max(0, rect.width);
+        const height = Math.max(0, rect.height);
+        this.gridOverlay.width = Math.max(1, Math.round(width * dpr));
+        this.gridOverlay.height = Math.max(1, Math.round(height * dpr));
+        const ctx = this.gridCtx;
+        ctx.setTransform(1, 0, 0, 1, 0, 0);
+        ctx.clearRect(0, 0, this.gridOverlay.width, this.gridOverlay.height);
+        if (!this.gridVisible) {
+            return;
+        }
+        ctx.scale(dpr, dpr);
+        ctx.lineWidth = 1 / dpr;
+        const { spacing, majorFrequency } = this.getGridMetrics();
+        if (!isFinite(spacing) || spacing <= 0) {
+            return;
+        }
+        const limitX = width;
+        const limitY = height;
+        const maxColumns = Math.ceil(limitX / spacing) + 1;
+        const maxRows = Math.ceil(limitY / spacing) + 1;
+        ctx.strokeStyle = "rgba(0, 0, 0, 0.08)";
+        ctx.beginPath();
+        for (let i = 0; i <= maxColumns; i++) {
+            if (i % majorFrequency === 0)
+                continue;
+            const x = i * spacing;
+            if (x > limitX + 1)
+                break;
+            ctx.moveTo(x, 0);
+            ctx.lineTo(x, limitY);
+        }
+        for (let i = 0; i <= maxRows; i++) {
+            if (i % majorFrequency === 0)
+                continue;
+            const y = i * spacing;
+            if (y > limitY + 1)
+                break;
+            ctx.moveTo(0, y);
+            ctx.lineTo(limitX, y);
+        }
+        ctx.stroke();
+        ctx.strokeStyle = "rgba(0, 0, 0, 0.18)";
+        ctx.beginPath();
+        for (let i = 0; i <= maxColumns; i++) {
+            if (i % majorFrequency !== 0)
+                continue;
+            const x = i * spacing;
+            if (x > limitX + 1)
+                break;
+            ctx.moveTo(x, 0);
+            ctx.lineTo(x, limitY);
+        }
+        for (let i = 0; i <= maxRows; i++) {
+            if (i % majorFrequency !== 0)
+                continue;
+            const y = i * spacing;
+            if (y > limitY + 1)
+                break;
+            ctx.moveTo(0, y);
+            ctx.lineTo(limitX, y);
+        }
+        ctx.stroke();
+    }
+    renderRulers() {
+        const hasHorizontal = Boolean(this.horizontalRuler);
+        const hasVertical = Boolean(this.verticalRuler);
+        if (!hasHorizontal && !hasVertical)
+            return;
+        const canvasRect = this.canvas.getBoundingClientRect();
+        const dpr = this.devicePixelRatio;
+        if (this.horizontalRuler) {
+            const rect = this.horizontalRuler.getBoundingClientRect();
+            if (rect.width > 0 && rect.height > 0) {
+                this.horizontalRuler.width = Math.max(1, Math.round(rect.width * dpr));
+                this.horizontalRuler.height = Math.max(1, Math.round(rect.height * dpr));
+                const ctx = this.horizontalRuler.getContext("2d");
+                if (ctx) {
+                    ctx.setTransform(1, 0, 0, 1, 0, 0);
+                    ctx.clearRect(0, 0, this.horizontalRuler.width, this.horizontalRuler.height);
+                    ctx.scale(dpr, dpr);
+                    this.drawRuler(ctx, canvasRect.width, rect.height, "horizontal");
+                }
+            }
+        }
+        if (this.verticalRuler) {
+            const rect = this.verticalRuler.getBoundingClientRect();
+            if (rect.width > 0 && rect.height > 0) {
+                this.verticalRuler.width = Math.max(1, Math.round(rect.width * dpr));
+                this.verticalRuler.height = Math.max(1, Math.round(rect.height * dpr));
+                const ctx = this.verticalRuler.getContext("2d");
+                if (ctx) {
+                    ctx.setTransform(1, 0, 0, 1, 0, 0);
+                    ctx.clearRect(0, 0, this.verticalRuler.width, this.verticalRuler.height);
+                    ctx.scale(dpr, dpr);
+                    this.drawRuler(ctx, canvasRect.height, rect.width, "vertical");
+                }
+            }
+        }
+    }
+    drawRuler(ctx, length, thickness, orientation) {
+        const dpr = this.devicePixelRatio;
+        ctx.save();
+        ctx.lineWidth = 1 / dpr;
+        const width = orientation === "horizontal" ? length : thickness;
+        const height = orientation === "horizontal" ? thickness : length;
+        ctx.fillStyle = "#f8f8f8";
+        ctx.fillRect(0, 0, width, height);
+        ctx.strokeStyle = "#d0d0d0";
+        ctx.beginPath();
+        if (orientation === "horizontal") {
+            ctx.moveTo(0, thickness - 0.5);
+            ctx.lineTo(length, thickness - 0.5);
+        }
+        else {
+            ctx.moveTo(thickness - 0.5, 0);
+            ctx.lineTo(thickness - 0.5, length);
+        }
+        ctx.stroke();
+        const { spacing, majorFrequency, unit } = this.getGridMetrics();
+        if (!isFinite(spacing) || spacing <= 0) {
+            ctx.restore();
+            return;
+        }
+        const tickLong = thickness * 0.65;
+        const tickShort = thickness * 0.4;
+        const maxTicks = Math.ceil(length / spacing) + 1;
+        ctx.strokeStyle = "#999";
+        ctx.beginPath();
+        for (let i = 0; i <= maxTicks; i++) {
+            const pos = i * spacing;
+            if (pos > length + 1)
+                break;
+            const isMajor = i % majorFrequency === 0;
+            const tick = isMajor ? tickLong : tickShort;
+            if (orientation === "horizontal") {
+                ctx.moveTo(pos, thickness);
+                ctx.lineTo(pos, thickness - tick);
+            }
+            else {
+                ctx.moveTo(thickness, pos);
+                ctx.lineTo(thickness - tick, pos);
+            }
+        }
+        ctx.stroke();
+        ctx.fillStyle = "#555";
+        ctx.font = "10px sans-serif";
+        const labelOffset = thickness - tickLong - 4;
+        for (let i = 0; i <= maxTicks; i++) {
+            if (i % majorFrequency !== 0)
+                continue;
+            const pos = i * spacing;
+            if (pos > length + 1)
+                break;
+            const value = Math.round(i * unit);
+            const label = String(value);
+            if (orientation === "horizontal") {
+                ctx.textAlign = "center";
+                ctx.textBaseline = "top";
+                ctx.fillText(label, pos, labelOffset);
+            }
+            else {
+                ctx.save();
+                ctx.translate(labelOffset, pos);
+                ctx.rotate(-Math.PI / 2);
+                ctx.textAlign = "center";
+                ctx.textBaseline = "middle";
+                ctx.fillText(label, 0, 0);
+                ctx.restore();
+            }
+        }
+        ctx.restore();
+    }
+    getGridMetrics() {
+        let spacing = this.baseGridSpacing * this.zoom;
+        let unit = this.baseGridSpacing;
+        if (!isFinite(spacing) || spacing <= 0) {
+            spacing = this.baseGridSpacing;
+            unit = this.baseGridSpacing;
+        }
+        while (spacing < this.minGridSpacingPx) {
+            spacing *= 2;
+            unit *= 2;
+        }
+        while (spacing > this.minGridSpacingPx * 4) {
+            spacing /= 2;
+            unit /= 2;
+        }
+        const majorFrequency = Math.max(1, this.majorLineFrequency);
+        return { spacing, unit, majorFrequency };
     }
     /**
      * Remove all event listeners registered by the editor.

--- a/dist/core/Shortcuts.js
+++ b/dist/core/Shortcuts.js
@@ -11,8 +11,9 @@ import { EyedropperTool } from "../tools/EyedropperTool.js";
  * Maps specific key presses to tool changes or editor actions.
  */
 export class Shortcuts {
-    constructor(editor) {
+    constructor(editor, options) {
         this.editor = editor;
+        this.onGridToggle = options?.onGridToggle;
         this.handler = (e) => this.onKeyDown(e);
         document.addEventListener("keydown", this.handler);
     }
@@ -34,6 +35,11 @@ export class Shortcuts {
             }
             else if (key === "y" && e.ctrlKey && !e.metaKey) {
                 this.editor.redo();
+                e.preventDefault();
+            }
+            else if (key === "'" || key === ";") {
+                const visible = this.editor.toggleGrid();
+                this.onGridToggle?.(visible);
                 e.preventDefault();
             }
             return;
@@ -71,7 +77,15 @@ export class Shortcuts {
                 e.preventDefault();
                 this.editor.setTool(new EyedropperTool());
                 break;
+            case "g":
+                e.preventDefault();
+                this.handleGridToggle();
+                break;
         }
+    }
+    handleGridToggle() {
+        const visible = this.editor.toggleGrid();
+        this.onGridToggle?.(visible);
     }
     /** Remove keyboard listeners. */
     destroy() {

--- a/dist/editor.js
+++ b/dist/editor.js
@@ -21,7 +21,8 @@ function listen(el, type, handler, list) {
  * {@link EditorHandle} that allows tests or callers to tear down the editor.
  */
 export function initEditor() {
-    const canvases = Array.from(document.querySelectorAll("canvas"));
+    const canvases = Array.from(document.querySelectorAll("canvas")).filter((canvas) => !canvas.classList.contains("grid-overlay") &&
+        !canvas.classList.contains("ruler"));
     const toolConstructors = {
         pencil: PencilTool,
         eraser: EraserTool,
@@ -73,6 +74,10 @@ export function initEditor() {
     const fontSize = document.getElementById("fontSize");
     const layerSelect = document.getElementById("layerSelect");
     const toolbar = document.getElementById("toolbar") || document.body;
+    const showGridToggle = document.getElementById("showGrid");
+    const horizontalRuler = document.getElementById("horizontalRuler");
+    const verticalRuler = document.getElementById("verticalRuler");
+    const gridOverlay = document.getElementById("gridOverlay");
     const saveBtn = document.getElementById("save");
     const formatSelect = document.getElementById("formatSelect");
     const colorHistory = document.getElementById("colorHistory");
@@ -123,6 +128,39 @@ export function initEditor() {
     const undoBtn = document.getElementById("undo");
     const redoBtn = document.getElementById("redo");
     const listeners = [];
+    const editors = [];
+    const GRID_STORAGE_KEY = "static-photoshop-clone:gridVisible";
+    const readGridPreference = () => {
+        try {
+            const stored = window.localStorage.getItem(GRID_STORAGE_KEY);
+            if (stored === null)
+                return true;
+            return stored === "true";
+        }
+        catch {
+            return true;
+        }
+    };
+    const persistGridPreference = (visible) => {
+        try {
+            window.localStorage.setItem(GRID_STORAGE_KEY, visible ? "true" : "false");
+        }
+        catch {
+            /* ignore storage errors */
+        }
+    };
+    let gridVisible = readGridPreference();
+    if (showGridToggle) {
+        showGridToggle.checked = gridVisible;
+    }
+    const applyGridVisibility = (visible, { persist = true } = {}) => {
+        gridVisible = visible;
+        editors.forEach((e) => e.setGridVisible(visible));
+        if (persist)
+            persistGridPreference(visible);
+        if (showGridToggle)
+            showGridToggle.checked = visible;
+    };
     const recentColors = [];
     const maxRecentColors = 10;
     const renderColorHistory = () => {
@@ -154,6 +192,11 @@ export function initEditor() {
     listen(colorPicker, "input", () => {
         recordColor(colorPicker.value);
     }, listeners);
+    listen(showGridToggle, "change", () => {
+        if (!showGridToggle)
+            return;
+        applyGridVisibility(showGridToggle.checked);
+    }, listeners);
     let editor; // set after editors created
     const updateHistoryButtons = () => {
         if (undoBtn)
@@ -161,12 +204,16 @@ export function initEditor() {
         if (redoBtn)
             redoBtn.disabled = !editor?.canRedo;
     };
-    const editors = [];
-    canvases.forEach((c) => {
+    canvases.forEach((c, index) => {
         try {
             const e = new Editor(c, colorPicker, lineWidth, fillMode, () => {
                 updateHistoryButtons();
-            }, fontFamily ?? undefined, fontSize ?? undefined);
+            }, fontFamily ?? undefined, fontSize ?? undefined, {
+                gridOverlay: index === 0 ? gridOverlay ?? undefined : undefined,
+                horizontalRuler: index === 0 ? horizontalRuler ?? undefined : undefined,
+                verticalRuler: index === 0 ? verticalRuler ?? undefined : undefined,
+                initialGridVisible: gridVisible,
+            });
             editors.push(e);
         }
         catch {
@@ -192,8 +239,11 @@ export function initEditor() {
     editor.setTool(new PencilTool());
     editorToolConstructors.set(editor, PencilTool);
     updateLayerInteractivity();
+    applyGridVisibility(gridVisible, { persist: false });
     // keyboard shortcuts
-    const shortcuts = new Shortcuts(editor);
+    const shortcuts = new Shortcuts(editor, {
+        onGridToggle: (visible) => applyGridVisibility(visible),
+    });
     // map button id to tool constructor
     Object.entries(toolConstructors).forEach(([id, ToolCtor]) => listen(toolButtons[id], "click", () => editor.setTool(new ToolCtor()), listeners));
     listen(undoBtn, "click", () => {

--- a/index.html
+++ b/index.html
@@ -21,6 +21,10 @@
         <input type="checkbox" id="fillMode" />
         Fill
       </label>
+      <label class="toggle">
+        <input type="checkbox" id="showGrid" />
+        Show Grid
+      </label>
       <button id="pencil" class="tool-button" title="Pencil">
         <img src="icons/pencil.svg" alt="Pencil" />
       </button>
@@ -66,9 +70,37 @@
       </button>
 
     </div>
-    <div id="canvasContainer">
-      <canvas id="canvas" width="800" height="600"></canvas>
-      <canvas id="layer2" width="800" height="600"></canvas>
+    <div id="workspace">
+      <div id="rulerCorner" aria-hidden="true"></div>
+      <canvas
+        id="horizontalRuler"
+        class="ruler"
+        aria-hidden="true"
+      ></canvas>
+      <canvas
+        id="verticalRuler"
+        class="ruler"
+        aria-hidden="true"
+      ></canvas>
+      <div id="canvasContainer">
+        <canvas
+          id="canvas"
+          class="drawing-layer"
+          width="800"
+          height="600"
+        ></canvas>
+        <canvas
+          id="layer2"
+          class="drawing-layer"
+          width="800"
+          height="600"
+        ></canvas>
+        <canvas
+          id="gridOverlay"
+          class="grid-overlay"
+          aria-hidden="true"
+        ></canvas>
+      </div>
     </div>
     <script type="module" src="dist/index.js"></script>
   </body>

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -1,5 +1,13 @@
 import { Tool } from "../tools/Tool.js";
 
+interface EditorOptions {
+  gridOverlay?: HTMLCanvasElement;
+  horizontalRuler?: HTMLCanvasElement;
+  verticalRuler?: HTMLCanvasElement;
+  initialGridVisible?: boolean;
+  initialZoom?: number;
+}
+
 export class Editor {
   canvas: HTMLCanvasElement;
   ctx: CanvasRenderingContext2D;
@@ -12,6 +20,15 @@ export class Editor {
   fontFamily: HTMLSelectElement | null;
   fontSize: HTMLInputElement | null;
   private onChange?: () => void;
+  private gridOverlay: HTMLCanvasElement | null;
+  private gridCtx: CanvasRenderingContext2D | null;
+  private horizontalRuler: HTMLCanvasElement | null;
+  private verticalRuler: HTMLCanvasElement | null;
+  private gridVisible: boolean;
+  private zoom: number;
+  private readonly baseGridSpacing = 50;
+  private readonly minGridSpacingPx = 25;
+  private readonly majorLineFrequency = 4;
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -21,6 +38,7 @@ export class Editor {
     onChange?: () => void,
     fontFamily?: HTMLSelectElement | null,
     fontSize?: HTMLInputElement | null,
+    options: EditorOptions = {},
   ) {
     this.canvas = canvas;
     const ctx = canvas.getContext("2d");
@@ -32,7 +50,14 @@ export class Editor {
     this.onChange = onChange;
     this.fontFamily = fontFamily ?? null;
     this.fontSize = fontSize ?? null;
+    this.gridOverlay = options.gridOverlay ?? null;
+    this.gridCtx = this.gridOverlay ? this.gridOverlay.getContext("2d") : null;
+    this.horizontalRuler = options.horizontalRuler ?? null;
+    this.verticalRuler = options.verticalRuler ?? null;
+    this.gridVisible = options.initialGridVisible ?? true;
+    this.zoom = options.initialZoom ?? 1;
     this.adjustForPixelRatio();
+    this.setGridVisible(this.gridVisible);
     window.addEventListener("resize", this.handleResize);
 
     this.canvas.addEventListener("pointerdown", this.handlePointerDown);
@@ -63,13 +88,14 @@ export class Editor {
   };
 
   private adjustForPixelRatio() {
-    const dpr = window.devicePixelRatio || 1;
+    const dpr = this.devicePixelRatio;
     const rect = this.canvas.getBoundingClientRect();
     this.canvas.width = rect.width * dpr;
     this.canvas.height = rect.height * dpr;
     this.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     // Reset any existing transforms
     this.ctx.scale(1, 1);
+    this.updateOverlays();
   }
 
   private handleResize = () => {
@@ -81,6 +107,7 @@ export class Editor {
     );
     this.adjustForPixelRatio();
     this.ctx.putImageData(data, 0, 0);
+    this.updateOverlays();
   };
 
   saveState() {
@@ -141,6 +168,261 @@ export class Editor {
 
   get fontSizeValue() {
     return parseInt(this.fontSize?.value ?? "", 10) || 16;
+  }
+
+  setGridVisible(visible: boolean) {
+    this.gridVisible = visible;
+    if (this.gridOverlay) {
+      this.gridOverlay.style.visibility = visible ? "visible" : "hidden";
+    }
+    this.renderGrid();
+  }
+
+  toggleGrid(): boolean {
+    const next = !this.gridVisible;
+    this.setGridVisible(next);
+    return next;
+  }
+
+  isGridVisible() {
+    return this.gridVisible;
+  }
+
+  setZoom(zoom: number) {
+    if (!Number.isFinite(zoom) || zoom <= 0) return;
+    this.zoom = zoom;
+    this.updateOverlays();
+  }
+
+  get zoomLevel() {
+    return this.zoom;
+  }
+
+  private get devicePixelRatio() {
+    return window.devicePixelRatio || 1;
+  }
+
+  private updateOverlays() {
+    this.renderGrid();
+    this.renderRulers();
+  }
+
+  private renderGrid() {
+    if (!this.gridOverlay || !this.gridCtx) return;
+    const rect = this.canvas.getBoundingClientRect();
+    const dpr = this.devicePixelRatio;
+    const width = Math.max(0, rect.width);
+    const height = Math.max(0, rect.height);
+    this.gridOverlay.width = Math.max(1, Math.round(width * dpr));
+    this.gridOverlay.height = Math.max(1, Math.round(height * dpr));
+
+    const ctx = this.gridCtx;
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, this.gridOverlay.width, this.gridOverlay.height);
+
+    if (!this.gridVisible) {
+      return;
+    }
+
+    ctx.scale(dpr, dpr);
+    ctx.lineWidth = 1 / dpr;
+
+    const { spacing, majorFrequency } = this.getGridMetrics();
+    if (!isFinite(spacing) || spacing <= 0) {
+      return;
+    }
+
+    const limitX = width;
+    const limitY = height;
+    const maxColumns = Math.ceil(limitX / spacing) + 1;
+    const maxRows = Math.ceil(limitY / spacing) + 1;
+
+    ctx.strokeStyle = "rgba(0, 0, 0, 0.08)";
+    ctx.beginPath();
+    for (let i = 0; i <= maxColumns; i++) {
+      if (i % majorFrequency === 0) continue;
+      const x = i * spacing;
+      if (x > limitX + 1) break;
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, limitY);
+    }
+    for (let i = 0; i <= maxRows; i++) {
+      if (i % majorFrequency === 0) continue;
+      const y = i * spacing;
+      if (y > limitY + 1) break;
+      ctx.moveTo(0, y);
+      ctx.lineTo(limitX, y);
+    }
+    ctx.stroke();
+
+    ctx.strokeStyle = "rgba(0, 0, 0, 0.18)";
+    ctx.beginPath();
+    for (let i = 0; i <= maxColumns; i++) {
+      if (i % majorFrequency !== 0) continue;
+      const x = i * spacing;
+      if (x > limitX + 1) break;
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, limitY);
+    }
+    for (let i = 0; i <= maxRows; i++) {
+      if (i % majorFrequency !== 0) continue;
+      const y = i * spacing;
+      if (y > limitY + 1) break;
+      ctx.moveTo(0, y);
+      ctx.lineTo(limitX, y);
+    }
+    ctx.stroke();
+  }
+
+  private renderRulers() {
+    const hasHorizontal = Boolean(this.horizontalRuler);
+    const hasVertical = Boolean(this.verticalRuler);
+    if (!hasHorizontal && !hasVertical) return;
+
+    const canvasRect = this.canvas.getBoundingClientRect();
+    const dpr = this.devicePixelRatio;
+
+    if (this.horizontalRuler) {
+      const rect = this.horizontalRuler.getBoundingClientRect();
+      if (rect.width > 0 && rect.height > 0) {
+        this.horizontalRuler.width = Math.max(
+          1,
+          Math.round(rect.width * dpr),
+        );
+        this.horizontalRuler.height = Math.max(
+          1,
+          Math.round(rect.height * dpr),
+        );
+        const ctx = this.horizontalRuler.getContext("2d");
+        if (ctx) {
+          ctx.setTransform(1, 0, 0, 1, 0, 0);
+          ctx.clearRect(0, 0, this.horizontalRuler.width, this.horizontalRuler.height);
+          ctx.scale(dpr, dpr);
+          this.drawRuler(ctx, canvasRect.width, rect.height, "horizontal");
+        }
+      }
+    }
+
+    if (this.verticalRuler) {
+      const rect = this.verticalRuler.getBoundingClientRect();
+      if (rect.width > 0 && rect.height > 0) {
+        this.verticalRuler.width = Math.max(
+          1,
+          Math.round(rect.width * dpr),
+        );
+        this.verticalRuler.height = Math.max(
+          1,
+          Math.round(rect.height * dpr),
+        );
+        const ctx = this.verticalRuler.getContext("2d");
+        if (ctx) {
+          ctx.setTransform(1, 0, 0, 1, 0, 0);
+          ctx.clearRect(0, 0, this.verticalRuler.width, this.verticalRuler.height);
+          ctx.scale(dpr, dpr);
+          this.drawRuler(ctx, canvasRect.height, rect.width, "vertical");
+        }
+      }
+    }
+  }
+
+  private drawRuler(
+    ctx: CanvasRenderingContext2D,
+    length: number,
+    thickness: number,
+    orientation: "horizontal" | "vertical",
+  ) {
+    const dpr = this.devicePixelRatio;
+    ctx.save();
+    ctx.lineWidth = 1 / dpr;
+    const width = orientation === "horizontal" ? length : thickness;
+    const height = orientation === "horizontal" ? thickness : length;
+    ctx.fillStyle = "#f8f8f8";
+    ctx.fillRect(0, 0, width, height);
+    ctx.strokeStyle = "#d0d0d0";
+    ctx.beginPath();
+    if (orientation === "horizontal") {
+      ctx.moveTo(0, thickness - 0.5);
+      ctx.lineTo(length, thickness - 0.5);
+    } else {
+      ctx.moveTo(thickness - 0.5, 0);
+      ctx.lineTo(thickness - 0.5, length);
+    }
+    ctx.stroke();
+
+    const { spacing, majorFrequency, unit } = this.getGridMetrics();
+    if (!isFinite(spacing) || spacing <= 0) {
+      ctx.restore();
+      return;
+    }
+
+    const tickLong = thickness * 0.65;
+    const tickShort = thickness * 0.4;
+    const maxTicks = Math.ceil(length / spacing) + 1;
+
+    ctx.strokeStyle = "#999";
+    ctx.beginPath();
+    for (let i = 0; i <= maxTicks; i++) {
+      const pos = i * spacing;
+      if (pos > length + 1) break;
+      const isMajor = i % majorFrequency === 0;
+      const tick = isMajor ? tickLong : tickShort;
+      if (orientation === "horizontal") {
+        ctx.moveTo(pos, thickness);
+        ctx.lineTo(pos, thickness - tick);
+      } else {
+        ctx.moveTo(thickness, pos);
+        ctx.lineTo(thickness - tick, pos);
+      }
+    }
+    ctx.stroke();
+
+    ctx.fillStyle = "#555";
+    ctx.font = "10px sans-serif";
+    const labelOffset = thickness - tickLong - 4;
+    for (let i = 0; i <= maxTicks; i++) {
+      if (i % majorFrequency !== 0) continue;
+      const pos = i * spacing;
+      if (pos > length + 1) break;
+      const value = Math.round(i * unit);
+      const label = String(value);
+      if (orientation === "horizontal") {
+        ctx.textAlign = "center";
+        ctx.textBaseline = "top";
+        ctx.fillText(label, pos, labelOffset);
+      } else {
+        ctx.save();
+        ctx.translate(labelOffset, pos);
+        ctx.rotate(-Math.PI / 2);
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.fillText(label, 0, 0);
+        ctx.restore();
+      }
+    }
+
+    ctx.restore();
+  }
+
+  private getGridMetrics() {
+    let spacing = this.baseGridSpacing * this.zoom;
+    let unit = this.baseGridSpacing;
+    if (!isFinite(spacing) || spacing <= 0) {
+      spacing = this.baseGridSpacing;
+      unit = this.baseGridSpacing;
+    }
+
+    while (spacing < this.minGridSpacingPx) {
+      spacing *= 2;
+      unit *= 2;
+    }
+    while (spacing > this.minGridSpacingPx * 4) {
+      spacing /= 2;
+      unit /= 2;
+    }
+
+    const majorFrequency = Math.max(1, this.majorLineFrequency);
+
+    return { spacing, unit, majorFrequency };
   }
 
   /**

--- a/src/core/Shortcuts.ts
+++ b/src/core/Shortcuts.ts
@@ -16,9 +16,11 @@ import { EyedropperTool } from "../tools/EyedropperTool.js";
 export class Shortcuts {
   private readonly handler: (e: KeyboardEvent) => void;
   private editor: Editor;
+  private readonly onGridToggle?: (visible: boolean) => void;
 
-  constructor(editor: Editor) {
+  constructor(editor: Editor, options?: { onGridToggle?: (visible: boolean) => void }) {
     this.editor = editor;
+    this.onGridToggle = options?.onGridToggle;
     this.handler = (e: KeyboardEvent) => this.onKeyDown(e);
     document.addEventListener("keydown", this.handler);
   }
@@ -41,6 +43,10 @@ export class Shortcuts {
         e.preventDefault();
       } else if (key === "y" && e.ctrlKey && !e.metaKey) {
         this.editor.redo();
+        e.preventDefault();
+      } else if (key === "'" || key === ";") {
+        const visible = this.editor.toggleGrid();
+        this.onGridToggle?.(visible);
         e.preventDefault();
       }
       return;
@@ -79,7 +85,16 @@ export class Shortcuts {
         e.preventDefault();
         this.editor.setTool(new EyedropperTool());
         break;
+      case "g":
+        e.preventDefault();
+        this.handleGridToggle();
+        break;
     }
+  }
+
+  private handleGridToggle() {
+    const visible = this.editor.toggleGrid();
+    this.onGridToggle?.(visible);
   }
 
   /** Remove keyboard listeners. */

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -37,6 +37,10 @@ export interface EditorHandle {
 export function initEditor(): EditorHandle {
   const canvases = Array.from(
     document.querySelectorAll<HTMLCanvasElement>("canvas"),
+  ).filter(
+    (canvas) =>
+      !canvas.classList.contains("grid-overlay") &&
+      !canvas.classList.contains("ruler"),
   );
 
   const toolConstructors: Record<string, new () => Tool> = {
@@ -93,6 +97,17 @@ export function initEditor(): EditorHandle {
   const fontSize = document.getElementById("fontSize") as HTMLInputElement | null;
   const layerSelect = document.getElementById("layerSelect") as HTMLSelectElement | null;
   const toolbar = document.getElementById("toolbar") || document.body;
+  const showGridToggle =
+    document.getElementById("showGrid") as HTMLInputElement | null;
+  const horizontalRuler = document.getElementById(
+    "horizontalRuler",
+  ) as HTMLCanvasElement | null;
+  const verticalRuler = document.getElementById(
+    "verticalRuler",
+  ) as HTMLCanvasElement | null;
+  const gridOverlay = document.getElementById(
+    "gridOverlay",
+  ) as HTMLCanvasElement | null;
   const saveBtn = document.getElementById("save") as HTMLButtonElement | null;
   const formatSelect =
     document.getElementById("formatSelect") as HTMLSelectElement | null;
@@ -155,6 +170,40 @@ export function initEditor(): EditorHandle {
   const undoBtn = document.getElementById("undo") as HTMLButtonElement | null;
   const redoBtn = document.getElementById("redo") as HTMLButtonElement | null;
   const listeners: Array<() => void> = [];
+  const editors: Editor[] = [];
+  const GRID_STORAGE_KEY = "static-photoshop-clone:gridVisible";
+  const readGridPreference = () => {
+    try {
+      const stored = window.localStorage.getItem(GRID_STORAGE_KEY);
+      if (stored === null) return true;
+      return stored === "true";
+    } catch {
+      return true;
+    }
+  };
+  const persistGridPreference = (visible: boolean) => {
+    try {
+      window.localStorage.setItem(
+        GRID_STORAGE_KEY,
+        visible ? "true" : "false",
+      );
+    } catch {
+      /* ignore storage errors */
+    }
+  };
+  let gridVisible = readGridPreference();
+  if (showGridToggle) {
+    showGridToggle.checked = gridVisible;
+  }
+  const applyGridVisibility = (
+    visible: boolean,
+    { persist = true }: { persist?: boolean } = {},
+  ) => {
+    gridVisible = visible;
+    editors.forEach((e) => e.setGridVisible(visible));
+    if (persist) persistGridPreference(visible);
+    if (showGridToggle) showGridToggle.checked = visible;
+  };
 
   const recentColors: string[] = [];
   const maxRecentColors = 10;
@@ -192,6 +241,16 @@ export function initEditor(): EditorHandle {
     listeners,
   );
 
+  listen(
+    showGridToggle,
+    "change",
+    () => {
+      if (!showGridToggle) return;
+      applyGridVisibility(showGridToggle.checked);
+    },
+    listeners,
+  );
+
   let editor: Editor; // set after editors created
 
   const updateHistoryButtons = () => {
@@ -199,8 +258,7 @@ export function initEditor(): EditorHandle {
     if (redoBtn) redoBtn.disabled = !editor?.canRedo;
   };
 
-  const editors: Editor[] = [];
-  canvases.forEach((c) => {
+  canvases.forEach((c, index) => {
     try {
       const e = new Editor(
         c,
@@ -212,6 +270,14 @@ export function initEditor(): EditorHandle {
         },
         fontFamily ?? undefined,
         fontSize ?? undefined,
+        {
+          gridOverlay: index === 0 ? gridOverlay ?? undefined : undefined,
+          horizontalRuler:
+            index === 0 ? horizontalRuler ?? undefined : undefined,
+          verticalRuler:
+            index === 0 ? verticalRuler ?? undefined : undefined,
+          initialGridVisible: gridVisible,
+        },
       );
       editors.push(e);
     } catch {
@@ -244,8 +310,12 @@ export function initEditor(): EditorHandle {
   editorToolConstructors.set(editor, PencilTool);
   updateLayerInteractivity();
 
+  applyGridVisibility(gridVisible, { persist: false });
+
   // keyboard shortcuts
-  const shortcuts = new Shortcuts(editor);
+  const shortcuts = new Shortcuts(editor, {
+    onGridToggle: (visible) => applyGridVisibility(visible),
+  });
 
   // map button id to tool constructor
   Object.entries(toolConstructors).forEach(([id, ToolCtor]) =>

--- a/style.css
+++ b/style.css
@@ -78,7 +78,6 @@ body {
 }
 
 #canvasContainer {
-  flex: 1;
   position: relative;
   background-image: linear-gradient(45deg, #ccc 25%, transparent 25%),
     linear-gradient(-45deg, #ccc 25%, transparent 25%),
@@ -97,6 +96,55 @@ body {
   width: 100%;
   height: 100%;
   box-sizing: border-box;
+}
+
+.grid-overlay {
+  pointer-events: none;
+}
+
+#toolbar .toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#workspace {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 40px 1fr;
+  grid-template-rows: 40px 1fr;
+  min-height: 0;
+}
+
+#rulerCorner {
+  grid-column: 1 / 2;
+  grid-row: 1 / 2;
+  background: #f0f0f0;
+  border-right: 1px solid #d0d0d0;
+  border-bottom: 1px solid #d0d0d0;
+}
+
+#horizontalRuler {
+  grid-column: 2 / 3;
+  grid-row: 1 / 2;
+}
+
+#verticalRuler {
+  grid-column: 1 / 2;
+  grid-row: 2 / 3;
+}
+
+#horizontalRuler,
+#verticalRuler {
+  width: 100%;
+  height: 100%;
+  background: #f8f8f8;
+}
+
+#canvasContainer {
+  grid-column: 2 / 3;
+  grid-row: 2 / 3;
+  overflow: hidden;
 }
 
 


### PR DESCRIPTION
## Summary
- add toolbar grid visibility toggle and workspace layout with dedicated ruler and overlay canvases
- render DPI-aware rulers and grid overlays inside the editor while persisting the chosen visibility state
- extend keyboard shortcuts with grid toggling support and remember the preference across sessions

## Testing
- npm test --silent
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d60d12d56c8328a32041f91a0b57d4