### PR TITLE
Add hand tool with temporary spacebar shortcut

### DIFF
--- a/dist/core/Editor.js
+++ b/dist/core/Editor.js
@@ -16,6 +16,9 @@ export class Editor {
             this.currentTool?.onPointerUp(e, this);
             this.canvas.releasePointerCapture(e.pointerId);
         };
+        this.handlePointerCancel = (e) => {
+            this.currentTool?.onPointerUp(e, this);
+        };
         this.handleResize = () => {
             const data = this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height);
             this.adjustForPixelRatio();
@@ -26,6 +29,8 @@ export class Editor {
         if (!ctx)
             throw new Error("Unable to get 2D context");
         this.ctx = ctx;
+        this.scrollContainer =
+            canvas.parentElement instanceof HTMLElement ? canvas.parentElement : null;
         this.colorPicker = colorPicker;
         this.lineWidth = lineWidth;
         this.fillMode = fillMode;
@@ -37,11 +42,24 @@ export class Editor {
         this.canvas.addEventListener("pointerdown", this.handlePointerDown);
         this.canvas.addEventListener("pointermove", this.handlePointerMove);
         this.canvas.addEventListener("pointerup", this.handlePointerUp);
+        this.canvas.addEventListener("pointercancel", this.handlePointerCancel);
+        this.canvas.addEventListener("lostpointercapture", this.handlePointerCancel);
     }
     setTool(tool) {
         this.currentTool?.destroy?.();
         this.currentTool = tool;
-        this.canvas.style.cursor = tool.cursor || "crosshair";
+        this.setCursor(tool.cursor);
+    }
+    setCursor(cursor) {
+        if (cursor) {
+            this.canvas.style.cursor = cursor;
+        }
+        else {
+            this.canvas.style.cursor = this.currentTool?.cursor || "crosshair";
+        }
+    }
+    get activeTool() {
+        return this.currentTool;
     }
     adjustForPixelRatio() {
         const dpr = window.devicePixelRatio || 1;
@@ -108,5 +126,7 @@ export class Editor {
         this.canvas.removeEventListener("pointerdown", this.handlePointerDown);
         this.canvas.removeEventListener("pointermove", this.handlePointerMove);
         this.canvas.removeEventListener("pointerup", this.handlePointerUp);
+        this.canvas.removeEventListener("pointercancel", this.handlePointerCancel);
+        this.canvas.removeEventListener("lostpointercapture", this.handlePointerCancel);
     }
 }

--- a/dist/core/Shortcuts.js
+++ b/dist/core/Shortcuts.js
@@ -6,21 +6,39 @@ import { TextTool } from "../tools/TextTool.js";
 import { EraserTool } from "../tools/EraserTool.js";
 import { BucketFillTool } from "../tools/BucketFillTool.js";
 import { EyedropperTool } from "../tools/EyedropperTool.js";
+import { HandTool } from "../tools/HandTool.js";
 /**
  * Keyboard shortcuts handler for the editor.
  * Maps specific key presses to tool changes or editor actions.
  */
 export class Shortcuts {
     constructor(editor) {
+        this.spacePressed = false;
+        this.previousToolCtor = null;
         this.editor = editor;
         this.handler = (e) => this.onKeyDown(e);
+        this.keyupHandler = (e) => this.onKeyUp(e);
         document.addEventListener("keydown", this.handler);
+        document.addEventListener("keyup", this.keyupHandler);
     }
     /** Swap the editor that receives subsequent shortcut actions. */
     switchEditor(newEditor) {
         this.editor = newEditor;
+        const active = this.editor.activeTool;
+        if (this.spacePressed) {
+            if (!(active instanceof HandTool)) {
+                this.previousToolCtor = this.getToolCtor(active) ?? this.previousToolCtor;
+            }
+            this.editor.setTool(new HandTool());
+        }
+        else {
+            this.previousToolCtor = active instanceof HandTool ? null : this.getToolCtor(active);
+        }
     }
     onKeyDown(e) {
+        if (this.handleSpaceKeyDown(e)) {
+            return;
+        }
         if (e.ctrlKey || e.metaKey) {
             const key = e.key.toLowerCase();
             if (key === "z") {
@@ -73,8 +91,43 @@ export class Shortcuts {
                 break;
         }
     }
+    onKeyUp(e) {
+        if (!this.spacePressed)
+            return;
+        if (e.key !== " " && e.key !== "Spacebar")
+            return;
+        e.preventDefault();
+        this.spacePressed = false;
+        if (this.previousToolCtor) {
+            this.editor.setTool(new this.previousToolCtor());
+        }
+        this.previousToolCtor = null;
+    }
+    handleSpaceKeyDown(e) {
+        if (e.key !== " " && e.key !== "Spacebar") {
+            return false;
+        }
+        if (e.repeat) {
+            e.preventDefault();
+            return true;
+        }
+        e.preventDefault();
+        if (!this.spacePressed) {
+            const active = this.editor.activeTool;
+            if (!(active instanceof HandTool)) {
+                this.previousToolCtor = this.getToolCtor(active);
+            }
+            this.editor.setTool(new HandTool());
+            this.spacePressed = true;
+        }
+        return true;
+    }
+    getToolCtor(tool) {
+        return tool ? tool.constructor : null;
+    }
     /** Remove keyboard listeners. */
     destroy() {
         document.removeEventListener("keydown", this.handler);
+        document.removeEventListener("keyup", this.keyupHandler);
     }
 }

--- a/dist/editor.js
+++ b/dist/editor.js
@@ -275,12 +275,13 @@ export function initEditor() {
         if (index < 0 || index >= editors.length)
             return;
         activeLayerIndex = index;
-        editor = editors[index];
+        const nextEditor = editors[index];
+        const ToolCtor = editorToolConstructors.get(nextEditor) ?? activeToolCtor;
+        nextEditor.setTool(new ToolCtor());
+        editor = nextEditor;
         handle.editor = editor;
         shortcuts.switchEditor(editor);
         updateLayerInteractivity();
-        const ToolCtor = editorToolConstructors.get(editor) ?? activeToolCtor;
-        editor.setTool(new ToolCtor());
         updateHistoryButtons();
         if (layerSelect)
             layerSelect.value = String(index);

--- a/dist/tools/HandTool.js
+++ b/dist/tools/HandTool.js
@@ -1,0 +1,44 @@
+export class HandTool {
+    constructor() {
+        this.cursor = "grab";
+        this.dragging = false;
+        this.startX = 0;
+        this.startY = 0;
+        this.startScrollLeft = 0;
+        this.startScrollTop = 0;
+        this.pointerId = null;
+    }
+    onPointerDown(e, editor) {
+        const container = editor.scrollContainer;
+        if (!container)
+            return;
+        this.dragging = true;
+        this.pointerId = e.pointerId;
+        this.startX = e.clientX;
+        this.startY = e.clientY;
+        this.startScrollLeft = container.scrollLeft;
+        this.startScrollTop = container.scrollTop;
+        editor.setCursor("grabbing");
+        e.preventDefault();
+    }
+    onPointerMove(e, editor) {
+        if (!this.dragging || (this.pointerId !== null && e.pointerId !== this.pointerId)) {
+            return;
+        }
+        const container = editor.scrollContainer;
+        if (!container)
+            return;
+        const dx = e.clientX - this.startX;
+        const dy = e.clientY - this.startY;
+        container.scrollLeft = this.startScrollLeft - dx;
+        container.scrollTop = this.startScrollTop - dy;
+        e.preventDefault();
+    }
+    onPointerUp(_e, editor) {
+        if (!this.dragging)
+            return;
+        this.dragging = false;
+        this.pointerId = null;
+        editor.setCursor();
+    }
+}

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -6,6 +6,7 @@ export class Editor {
   private undoStack: ImageData[] = [];
   private redoStack: ImageData[] = [];
   private currentTool: Tool | null = null;
+  readonly scrollContainer: HTMLElement | null;
   colorPicker: HTMLInputElement;
   lineWidth: HTMLInputElement;
   fillMode: HTMLInputElement;
@@ -26,6 +27,8 @@ export class Editor {
     const ctx = canvas.getContext("2d");
     if (!ctx) throw new Error("Unable to get 2D context");
     this.ctx = ctx;
+    this.scrollContainer =
+      canvas.parentElement instanceof HTMLElement ? canvas.parentElement : null;
     this.colorPicker = colorPicker;
     this.lineWidth = lineWidth;
     this.fillMode = fillMode;
@@ -38,12 +41,17 @@ export class Editor {
     this.canvas.addEventListener("pointerdown", this.handlePointerDown);
     this.canvas.addEventListener("pointermove", this.handlePointerMove);
     this.canvas.addEventListener("pointerup", this.handlePointerUp);
+    this.canvas.addEventListener("pointercancel", this.handlePointerCancel);
+    this.canvas.addEventListener(
+      "lostpointercapture",
+      this.handlePointerCancel,
+    );
   }
 
   setTool(tool: Tool) {
     this.currentTool?.destroy?.();
     this.currentTool = tool;
-    this.canvas.style.cursor = tool.cursor || "crosshair";
+    this.setCursor(tool.cursor);
   }
 
   private handlePointerDown = (e: PointerEvent) => {
@@ -61,6 +69,22 @@ export class Editor {
     this.currentTool?.onPointerUp(e, this);
     this.canvas.releasePointerCapture(e.pointerId);
   };
+
+  private handlePointerCancel = (e: PointerEvent) => {
+    this.currentTool?.onPointerUp(e, this);
+  };
+
+  setCursor(cursor?: string) {
+    if (cursor) {
+      this.canvas.style.cursor = cursor;
+    } else {
+      this.canvas.style.cursor = this.currentTool?.cursor || "crosshair";
+    }
+  }
+
+  get activeTool(): Tool | null {
+    return this.currentTool;
+  }
 
   private adjustForPixelRatio() {
     const dpr = window.devicePixelRatio || 1;
@@ -153,5 +177,10 @@ export class Editor {
     this.canvas.removeEventListener("pointerdown", this.handlePointerDown);
     this.canvas.removeEventListener("pointermove", this.handlePointerMove);
     this.canvas.removeEventListener("pointerup", this.handlePointerUp);
+    this.canvas.removeEventListener("pointercancel", this.handlePointerCancel);
+    this.canvas.removeEventListener(
+      "lostpointercapture",
+      this.handlePointerCancel,
+    );
   }
 }

--- a/src/core/Shortcuts.ts
+++ b/src/core/Shortcuts.ts
@@ -7,6 +7,8 @@ import { TextTool } from "../tools/TextTool.js";
 import { EraserTool } from "../tools/EraserTool.js";
 import { BucketFillTool } from "../tools/BucketFillTool.js";
 import { EyedropperTool } from "../tools/EyedropperTool.js";
+import { HandTool } from "../tools/HandTool.js";
+import type { Tool } from "../tools/Tool.js";
 
 
 /**
@@ -15,21 +17,37 @@ import { EyedropperTool } from "../tools/EyedropperTool.js";
  */
 export class Shortcuts {
   private readonly handler: (e: KeyboardEvent) => void;
+  private readonly keyupHandler: (e: KeyboardEvent) => void;
   private editor: Editor;
+  private spacePressed = false;
+  private previousToolCtor: (new () => Tool) | null = null;
 
   constructor(editor: Editor) {
     this.editor = editor;
     this.handler = (e: KeyboardEvent) => this.onKeyDown(e);
+    this.keyupHandler = (e: KeyboardEvent) => this.onKeyUp(e);
     document.addEventListener("keydown", this.handler);
+    document.addEventListener("keyup", this.keyupHandler);
   }
 
   /** Swap the editor that receives subsequent shortcut actions. */
   switchEditor(newEditor: Editor) {
     this.editor = newEditor;
+    const active = this.editor.activeTool;
+    if (this.spacePressed) {
+      if (!(active instanceof HandTool)) {
+        this.previousToolCtor = this.getToolCtor(active) ?? this.previousToolCtor;
+      }
+      this.editor.setTool(new HandTool());
+    } else {
+      this.previousToolCtor = active instanceof HandTool ? null : this.getToolCtor(active);
+    }
   }
 
   private onKeyDown(e: KeyboardEvent) {
-
+    if (this.handleSpaceKeyDown(e)) {
+      return;
+    }
     if (e.ctrlKey || e.metaKey) {
       const key = e.key.toLowerCase();
       if (key === "z") {
@@ -82,8 +100,44 @@ export class Shortcuts {
     }
   }
 
+  private onKeyUp(e: KeyboardEvent) {
+    if (!this.spacePressed) return;
+    if (e.key !== " " && e.key !== "Spacebar") return;
+    e.preventDefault();
+    this.spacePressed = false;
+    if (this.previousToolCtor) {
+      this.editor.setTool(new this.previousToolCtor());
+    }
+    this.previousToolCtor = null;
+  }
+
+  private handleSpaceKeyDown(e: KeyboardEvent) {
+    if (e.key !== " " && e.key !== "Spacebar") {
+      return false;
+    }
+    if (e.repeat) {
+      e.preventDefault();
+      return true;
+    }
+    e.preventDefault();
+    if (!this.spacePressed) {
+      const active = this.editor.activeTool;
+      if (!(active instanceof HandTool)) {
+        this.previousToolCtor = this.getToolCtor(active);
+      }
+      this.editor.setTool(new HandTool());
+      this.spacePressed = true;
+    }
+    return true;
+  }
+
+  private getToolCtor(tool: Tool | null): (new () => Tool) | null {
+    return tool ? (tool.constructor as new () => Tool) : null;
+  }
+
   /** Remove keyboard listeners. */
   destroy() {
     document.removeEventListener("keydown", this.handler);
+    document.removeEventListener("keyup", this.keyupHandler);
   }
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -372,12 +372,13 @@ export function initEditor(): EditorHandle {
   function activateLayer(index: number) {
     if (index < 0 || index >= editors.length) return;
     activeLayerIndex = index;
-    editor = editors[index];
+    const nextEditor = editors[index];
+    const ToolCtor = editorToolConstructors.get(nextEditor) ?? activeToolCtor;
+    nextEditor.setTool(new ToolCtor());
+    editor = nextEditor;
     handle.editor = editor;
     shortcuts.switchEditor(editor);
     updateLayerInteractivity();
-    const ToolCtor = editorToolConstructors.get(editor) ?? activeToolCtor;
-    editor.setTool(new ToolCtor());
     updateHistoryButtons();
     if (layerSelect) layerSelect.value = String(index);
   }

--- a/src/tools/HandTool.ts
+++ b/src/tools/HandTool.ts
@@ -1,0 +1,45 @@
+import { Editor } from "../core/Editor.js";
+import { Tool } from "./Tool.js";
+
+export class HandTool implements Tool {
+  cursor = "grab";
+  private dragging = false;
+  private startX = 0;
+  private startY = 0;
+  private startScrollLeft = 0;
+  private startScrollTop = 0;
+  private pointerId: number | null = null;
+
+  onPointerDown(e: PointerEvent, editor: Editor) {
+    const container = editor.scrollContainer;
+    if (!container) return;
+    this.dragging = true;
+    this.pointerId = e.pointerId;
+    this.startX = e.clientX;
+    this.startY = e.clientY;
+    this.startScrollLeft = container.scrollLeft;
+    this.startScrollTop = container.scrollTop;
+    editor.setCursor("grabbing");
+    e.preventDefault();
+  }
+
+  onPointerMove(e: PointerEvent, editor: Editor) {
+    if (!this.dragging || (this.pointerId !== null && e.pointerId !== this.pointerId)) {
+      return;
+    }
+    const container = editor.scrollContainer;
+    if (!container) return;
+    const dx = e.clientX - this.startX;
+    const dy = e.clientY - this.startY;
+    container.scrollLeft = this.startScrollLeft - dx;
+    container.scrollTop = this.startScrollTop - dy;
+    e.preventDefault();
+  }
+
+  onPointerUp(_e: PointerEvent, editor: Editor) {
+    if (!this.dragging) return;
+    this.dragging = false;
+    this.pointerId = null;
+    editor.setCursor();
+  }
+}

--- a/style.css
+++ b/style.css
@@ -80,6 +80,7 @@ body {
 #canvasContainer {
   flex: 1;
   position: relative;
+  overflow: auto;
   background-image: linear-gradient(45deg, #ccc 25%, transparent 25%),
     linear-gradient(-45deg, #ccc 25%, transparent 25%),
     linear-gradient(45deg, transparent 75%, #ccc 75%),

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -9,6 +9,7 @@ import { TextTool } from "../src/tools/TextTool.js";
 import { BucketFillTool } from "../src/tools/BucketFillTool.js";
 import { Shortcuts } from "../src/core/Shortcuts.js";
 import { Editor } from "../src/core/Editor.js";
+import { HandTool } from "../src/tools/HandTool.js";
 
 describe("keyboard shortcuts", () => {
   let handle: EditorHandle;
@@ -17,7 +18,7 @@ describe("keyboard shortcuts", () => {
 
   beforeEach(() => {
     document.body.innerHTML = `
-      <canvas id="canvas"></canvas>
+      <div id="canvasContainer"><canvas id="canvas"></canvas></div>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
@@ -82,6 +83,19 @@ describe("keyboard shortcuts", () => {
       expect(prevent).toHaveBeenCalled();
       expect(event.defaultPrevented).toBe(true);
     });
+  });
+
+  it("temporarily activates the hand tool while spacebar is held", () => {
+    const spy = jest.spyOn(handle.editor, "setTool");
+    const keydown = new KeyboardEvent("keydown", { key: " ", cancelable: true });
+    document.dispatchEvent(keydown);
+    expect(spy.mock.calls.at(-1)?.[0]).toBeInstanceOf(HandTool);
+    expect(keydown.defaultPrevented).toBe(true);
+
+    const keyup = new KeyboardEvent("keyup", { key: " ", cancelable: true });
+    document.dispatchEvent(keyup);
+    expect(spy.mock.calls.at(-1)?.[0]).toBeInstanceOf(PencilTool);
+    expect(keyup.defaultPrevented).toBe(true);
   });
 
   it("performs undo and redo with shortcuts", () => {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -3,6 +3,7 @@ import { PencilTool } from "../src/tools/PencilTool.js";
 import { LineTool } from "../src/tools/LineTool.js";
 import { CircleTool } from "../src/tools/CircleTool.js";
 import { TextTool } from "../src/tools/TextTool.js";
+import { HandTool } from "../src/tools/HandTool.js";
 
 describe("additional tools", () => {
   let canvas: HTMLCanvasElement;
@@ -11,7 +12,7 @@ describe("additional tools", () => {
 
   beforeEach(() => {
     document.body.innerHTML = `
-      <canvas id="canvas"></canvas>
+      <div id="canvasContainer"><canvas id="canvas"></canvas></div>
       <input id="colorPicker" value="#000000" />
       <input id="lineWidth" value="2" />
       <input id="fillMode" type="checkbox" />
@@ -105,5 +106,44 @@ describe("additional tools", () => {
     textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     expect(ctx.fillText).not.toHaveBeenCalled();
     expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("hand tool pans the scroll container on drag", () => {
+    const tool = new HandTool();
+    const container = editor.scrollContainer as HTMLElement;
+    Object.defineProperty(container, "scrollLeft", { value: 25, writable: true });
+    Object.defineProperty(container, "scrollTop", { value: 40, writable: true });
+
+    const setCursorSpy = jest.spyOn(editor, "setCursor");
+    const downPrevent = jest.fn();
+    tool.onPointerDown(
+      {
+        clientX: 10,
+        clientY: 20,
+        pointerId: 1,
+        preventDefault: downPrevent,
+      } as unknown as PointerEvent,
+      editor,
+    );
+    expect(downPrevent).toHaveBeenCalled();
+    expect(setCursorSpy).toHaveBeenCalledWith("grabbing");
+    setCursorSpy.mockClear();
+
+    const movePrevent = jest.fn();
+    tool.onPointerMove(
+      {
+        clientX: 15,
+        clientY: 30,
+        pointerId: 1,
+        preventDefault: movePrevent,
+      } as unknown as PointerEvent,
+      editor,
+    );
+    expect(movePrevent).toHaveBeenCalled();
+    expect(container.scrollLeft).toBe(20);
+    expect(container.scrollTop).toBe(30);
+
+    tool.onPointerUp({ pointerId: 1 } as PointerEvent, editor);
+    expect(setCursorSpy).toHaveBeenCalledWith();
   });
 });


### PR DESCRIPTION
## Summary
- add a dedicated HandTool that pans the canvas container and updates cursor feedback
- extend the editor and shortcuts to support temporary spacebar activation of the hand tool and smooth layer switching
- adjust styling and tests to cover the new hand tool behavior

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d60d0ea1488328a4648d75eb56198d