### PR TITLE
Refactor layer management into dedicated manager

### DIFF
--- a/src/core/LayerManager.ts
+++ b/src/core/LayerManager.ts
@@ -1,0 +1,195 @@
+import type { Editor } from "./Editor.js";
+
+interface LayerEntry {
+  canvas: HTMLCanvasElement;
+  editor: Editor;
+  name: string;
+  visible: boolean;
+}
+
+export interface LayerManagerOptions {
+  layers: Array<{ canvas: HTMLCanvasElement; editor: Editor; name?: string }>;
+  layerSelect?: HTMLSelectElement | null;
+  toolbar?: HTMLElement | null;
+  onActivate?: (editor: Editor, index: number) => void;
+}
+
+/**
+ * Manages editor layers including activation state, ordering, and visibility.
+ */
+export class LayerManager {
+  private readonly layers: LayerEntry[];
+  private activeIndex = 0;
+  private readonly layerSelect?: HTMLSelectElement | null;
+  private readonly toolbar?: HTMLElement | null;
+  private readonly onActivate?: (editor: Editor, index: number) => void;
+  private readonly cleanup: Array<() => void> = [];
+
+  constructor({ layers, layerSelect, toolbar, onActivate }: LayerManagerOptions) {
+    if (layers.length === 0) {
+      throw new Error("LayerManager requires at least one layer");
+    }
+
+    this.layers = layers.map((layer, index) => ({
+      canvas: layer.canvas,
+      editor: layer.editor,
+      name: layer.name ?? (layer.canvas.id || `Layer ${index + 1}`),
+      visible: true,
+    }));
+    this.layerSelect = layerSelect ?? undefined;
+    this.toolbar = toolbar ?? undefined;
+    this.onActivate = onActivate;
+
+    this.populateLayerSelect();
+    this.createOpacityControls();
+    this.updateLayerVisibility();
+    this.updateLayerInteractivity();
+    this.selectActiveLayerOption();
+  }
+
+  get activeLayer(): LayerEntry {
+    return this.layers[this.activeIndex];
+  }
+
+  get activeEditor(): Editor {
+    return this.activeLayer.editor;
+  }
+
+  get count(): number {
+    return this.layers.length;
+  }
+
+  getActiveIndex(): number {
+    return this.activeIndex;
+  }
+
+  getLayers(): readonly LayerEntry[] {
+    return this.layers;
+  }
+
+  activateLayer(index: number): void {
+    if (index < 0 || index >= this.layers.length || index === this.activeIndex) {
+      return;
+    }
+
+    this.activeIndex = index;
+    this.updateLayerInteractivity();
+    this.selectActiveLayerOption();
+    this.notifyActivation();
+  }
+
+  setLayerVisibility(index: number, visible: boolean): void {
+    const layer = this.layers[index];
+    if (!layer) return;
+    if (layer.visible === visible) return;
+
+    layer.visible = visible;
+    this.updateLayerVisibility();
+    this.updateLayerInteractivity();
+
+    if (!visible && this.activeIndex === index) {
+      const nextVisible = this.layers.findIndex((entry) => entry.visible);
+      if (nextVisible !== -1) {
+        this.activeIndex = nextVisible;
+        this.selectActiveLayerOption();
+        this.notifyActivation();
+      }
+    }
+  }
+
+  destroy(): void {
+    while (this.cleanup.length) {
+      const dispose = this.cleanup.pop();
+      dispose?.();
+    }
+  }
+
+  private populateLayerSelect(): void {
+    if (!this.layerSelect) return;
+
+    this.layerSelect.innerHTML = "";
+    this.layers.forEach((layer, index) => {
+      const option = document.createElement("option");
+      option.value = String(index);
+      option.textContent = layer.name;
+      this.layerSelect!.appendChild(option);
+    });
+
+    const handler = (event: Event) => {
+      const target = event.target as HTMLSelectElement;
+      const idx = parseInt(target.value, 10);
+      if (!Number.isNaN(idx)) {
+        this.activateLayer(idx);
+      }
+    };
+
+    this.layerSelect.addEventListener("change", handler);
+    this.cleanup.push(() => this.layerSelect?.removeEventListener("change", handler));
+  }
+
+  private createOpacityControls(): void {
+    if (!this.toolbar) return;
+
+    this.layers.forEach((layer, index) => {
+      if (index === 0) return;
+
+      const canvasId = layer.canvas.id || `layer${index + 1}`;
+      let input = document.getElementById(`${canvasId}Opacity`) as
+        | HTMLInputElement
+        | null;
+
+      if (!input) {
+        const group = document.createElement("div");
+        group.className = "group";
+
+        const label = document.createElement("label");
+        label.htmlFor = `${canvasId}Opacity`;
+        label.textContent = `${layer.name} Opacity`;
+
+        input = document.createElement("input");
+        input.id = `${canvasId}Opacity`;
+        input.type = "number";
+        input.min = "0";
+        input.max = "100";
+        input.value = "100";
+
+        group.appendChild(label);
+        group.appendChild(input);
+        this.toolbar!.appendChild(group);
+      }
+
+      const handler = () => {
+        const value = parseFloat(input.value);
+        layer.canvas.style.opacity = Number.isNaN(value)
+          ? "1"
+          : String(Math.max(0, Math.min(100, value)) / 100);
+      };
+      input.addEventListener("input", handler);
+      this.cleanup.push(() => input.removeEventListener("input", handler));
+    });
+  }
+
+  private updateLayerInteractivity(): void {
+    this.layers.forEach((layer, index) => {
+      const isActive = index === this.activeIndex && layer.visible;
+      layer.canvas.style.pointerEvents = isActive ? "auto" : "none";
+    });
+  }
+
+  private updateLayerVisibility(): void {
+    this.layers.forEach((layer) => {
+      layer.canvas.style.display = layer.visible ? "" : "none";
+    });
+  }
+
+  private selectActiveLayerOption(): void {
+    if (!this.layerSelect) return;
+    this.layerSelect.value = String(this.activeIndex);
+  }
+
+  private notifyActivation(): void {
+    if (this.onActivate) {
+      this.onActivate(this.layers[this.activeIndex].editor, this.activeIndex);
+    }
+  }
+}

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,4 +1,5 @@
 import { Editor } from "./core/Editor.js";
+import { LayerManager } from "./core/LayerManager.js";
 import { Shortcuts } from "./core/Shortcuts.js";
 import { PencilTool } from "./tools/PencilTool.js";
 import { EraserTool } from "./tools/EraserTool.js";
@@ -54,7 +55,6 @@ export function initEditor(): EditorHandle {
   const constructorToId = new Map<new () => Tool, string>();
   const editorToolConstructors = new Map<Editor, new () => Tool>();
   let activeToolCtor: new () => Tool = PencilTool;
-  let activeLayerIndex = 0;
   Object.entries(toolConstructors).forEach(([id, Ctor]) => {
     const btn = document.getElementById(id) as HTMLButtonElement | null;
     if (!btn) {
@@ -77,12 +77,6 @@ export function initEditor(): EditorHandle {
       }
     }
     return null;
-  };
-
-  const updateLayerInteractivity = () => {
-    canvases.forEach((canvas, index) => {
-      canvas.style.pointerEvents = index === activeLayerIndex ? "auto" : "none";
-    });
   };
 
   const colorPicker =
@@ -115,42 +109,6 @@ export function initEditor(): EditorHandle {
   if (!formatSelect) {
     throw new Error("Missing #formatSelect select");
   }
-
-  if (layerSelect) {
-    layerSelect.innerHTML = "";
-  }
-
-  canvases.forEach((c, i) => {
-    const canvasId = c.id || `layer${i + 1}`;
-    const name = c.id || `Layer ${i + 1}`;
-
-    if (layerSelect) {
-      const opt = document.createElement("option");
-      opt.value = String(i);
-      opt.textContent = name;
-      layerSelect.appendChild(opt);
-    }
-
-    if (!document.getElementById(`${canvasId}Opacity`) && i > 0) {
-      const group = document.createElement("div");
-      group.className = "group";
-
-      const label = document.createElement("label");
-      label.htmlFor = `${canvasId}Opacity`;
-      label.textContent = `${name} Opacity`;
-
-      const input = document.createElement("input");
-      input.id = `${canvasId}Opacity`;
-      input.type = "number";
-      input.min = "0";
-      input.max = "100";
-      input.value = "100";
-
-      group.appendChild(label);
-      group.appendChild(input);
-      toolbar.appendChild(group);
-    }
-  });
 
   const undoBtn = document.getElementById("undo") as HTMLButtonElement | null;
   const redoBtn = document.getElementById("redo") as HTMLButtonElement | null;
@@ -199,7 +157,7 @@ export function initEditor(): EditorHandle {
     if (redoBtn) redoBtn.disabled = !editor?.canRedo;
   };
 
-  const editors: Editor[] = [];
+  const layerEntries: Array<{ canvas: HTMLCanvasElement; editor: Editor }> = [];
   canvases.forEach((c) => {
     try {
       const e = new Editor(
@@ -213,11 +171,13 @@ export function initEditor(): EditorHandle {
         fontFamily ?? undefined,
         fontSize ?? undefined,
       );
-      editors.push(e);
+      layerEntries.push({ canvas: c, editor: e });
     } catch {
       /* skip canvases without 2D context */
     }
   });
+
+  const editors = layerEntries.map((entry) => entry.editor);
 
   if (editors.length === 0) {
     throw new Error(
@@ -242,10 +202,24 @@ export function initEditor(): EditorHandle {
   // default tool
   editor.setTool(new PencilTool());
   editorToolConstructors.set(editor, PencilTool);
-  updateLayerInteractivity();
 
   // keyboard shortcuts
   const shortcuts = new Shortcuts(editor);
+
+  let handle: EditorHandle | null = null;
+  const layerManager = new LayerManager({
+    layers: layerEntries,
+    layerSelect,
+    toolbar,
+    onActivate: (nextEditor) => {
+      editor = nextEditor;
+      if (handle) handle.editor = editor;
+      shortcuts.switchEditor(editor);
+      const ToolCtor = editorToolConstructors.get(editor) ?? activeToolCtor;
+      editor.setTool(new ToolCtor());
+      updateHistoryButtons();
+    },
+  });
 
   // map button id to tool constructor
   Object.entries(toolConstructors).forEach(([id, ToolCtor]) =>
@@ -341,58 +315,21 @@ export function initEditor(): EditorHandle {
     listeners,
   );
 
-  document
-    .querySelectorAll<HTMLInputElement>('input[id$="Opacity"]')
-    .forEach((input) => {
-      const targetId = input.id.replace(/Opacity$/, "");
-      const layer = document.getElementById(targetId) as HTMLCanvasElement | null;
-      if (!layer) return;
-      listen(
-        input,
-        "input",
-        () => {
-          const value = parseFloat(input.value);
-          layer.style.opacity = isNaN(value) ? "1" : String(value / 100);
-        },
-        listeners,
-      );
-    });
-
-  // layer selection
-  listen(
-    layerSelect,
-    "change",
-    () => {
-      const idx = parseInt(layerSelect!.value, 10);
-      activateLayer(idx);
-    },
-    listeners,
-  );
-
-  function activateLayer(index: number) {
-    if (index < 0 || index >= editors.length) return;
-    activeLayerIndex = index;
-    editor = editors[index];
-    handle.editor = editor;
-    shortcuts.switchEditor(editor);
-    updateLayerInteractivity();
-    const ToolCtor = editorToolConstructors.get(editor) ?? activeToolCtor;
-    editor.setTool(new ToolCtor());
-    updateHistoryButtons();
-    if (layerSelect) layerSelect.value = String(index);
-  }
-
-  const handle: EditorHandle = {
+  const handleObject: EditorHandle = {
     editor,
     editors,
-    activateLayer,
+    activateLayer(index: number) {
+      layerManager.activateLayer(index);
+    },
     destroy() {
       listeners.forEach((fn) => fn());
       shortcuts.destroy();
       editors.forEach((e) => e.destroy());
+      layerManager.destroy();
     },
   };
+  handle = handleObject;
   recordColor(colorPicker.value);
   updateHistoryButtons();
-  return handle;
+  return handleObject;
 }

--- a/tests/layers.test.ts
+++ b/tests/layers.test.ts
@@ -1,128 +1,74 @@
-import { initEditor, EditorHandle } from "../src/editor.js";
+import { LayerManager } from "../src/core/LayerManager.js";
+import type { Editor } from "../src/core/Editor.js";
 
-describe("layer-specific undo/redo", () => {
-  let handle: EditorHandle;
-  let canvas1: HTMLCanvasElement;
-  let canvas2: HTMLCanvasElement;
-  let ctx1: Partial<CanvasRenderingContext2D>;
-  let ctx2: Partial<CanvasRenderingContext2D>;
-  let undoBtn: HTMLButtonElement;
-  let redoBtn: HTMLButtonElement;
+describe("LayerManager", () => {
+  let canvases: HTMLCanvasElement[];
+  let toolbar: HTMLDivElement;
+  let layerSelect: HTMLSelectElement;
+  let onActivate: jest.Mock;
+  let manager: LayerManager;
 
   beforeEach(() => {
     document.body.innerHTML = `
+      <div id="toolbar"></div>
+      <select id="layerSelect"></select>
       <canvas id="c1"></canvas>
       <canvas id="c2"></canvas>
-      <input id="colorPicker" value="#000000" />
-      <input id="lineWidth" value="2" />
-      <input id="fillMode" type="checkbox" />
-      <button id="pencil"></button>
-      <button id="eraser"></button>
-      <button id="rectangle"></button>
-      <button id="line"></button>
-      <button id="circle"></button>
-      <button id="text"></button>
-      <button id="bucket"></button>
-      <button id="eyedropper"></button>
-      <select id="formatSelect"><option value="png">PNG</option></select>
-      <button id="save"></button>
-      <button id="undo"></button>
-      <button id="redo"></button>
     `;
 
-    canvas1 = document.getElementById("c1") as HTMLCanvasElement;
-    canvas2 = document.getElementById("c2") as HTMLCanvasElement;
+    canvases = Array.from(document.querySelectorAll("canvas"));
+    toolbar = document.getElementById("toolbar") as HTMLDivElement;
+    layerSelect = document.getElementById("layerSelect") as HTMLSelectElement;
+    onActivate = jest.fn();
 
-    const rect = {
-      width: 100,
-      height: 100,
-      top: 0,
-      left: 0,
-      bottom: 100,
-      right: 100,
-      x: 0,
-      y: 0,
-      toJSON: () => {},
-    };
-
-    ctx1 = {
-      clearRect: jest.fn(),
-      putImageData: jest.fn(),
-      getImageData: jest
-        .fn()
-        .mockReturnValue({
-          data: new Uint8ClampedArray(),
-          width: 1,
-          height: 1,
-        } as ImageData),
-      setTransform: jest.fn(),
-      scale: jest.fn(),
-    };
-    ctx2 = {
-      clearRect: jest.fn(),
-      putImageData: jest.fn(),
-      getImageData: jest
-        .fn()
-        .mockReturnValue({
-          data: new Uint8ClampedArray(),
-          width: 1,
-          height: 1,
-        } as ImageData),
-      setTransform: jest.fn(),
-      scale: jest.fn(),
-    };
-
-    canvas1.getContext = jest.fn().mockReturnValue(ctx1 as any);
-    canvas2.getContext = jest.fn().mockReturnValue(ctx2 as any);
-    canvas1.getBoundingClientRect = canvas2.getBoundingClientRect = () => rect;
-
-    handle = initEditor();
-    undoBtn = document.getElementById("undo") as HTMLButtonElement;
-    redoBtn = document.getElementById("redo") as HTMLButtonElement;
+    const stubEditors = canvases.map(() => ({}) as Editor);
+    manager = new LayerManager({
+      layers: canvases.map((canvas, index) => ({
+        canvas,
+        editor: stubEditors[index],
+      })),
+      layerSelect,
+      toolbar,
+      onActivate,
+    });
   });
 
-  afterEach(() => handle.destroy());
+  afterEach(() => manager.destroy());
 
-  it("targets the active layer and toggles button states", () => {
-    // initially disabled
-    expect(undoBtn.disabled).toBe(true);
-    expect(redoBtn.disabled).toBe(true);
-
-    // add state to first layer
-    handle.editor.saveState();
-    expect(undoBtn.disabled).toBe(false);
-
-    // switch to second layer – no history yet
-    handle.activateLayer(1);
-    expect(undoBtn.disabled).toBe(true);
-
-    // add state to second layer and undo
-    handle.editor.saveState();
-    expect(undoBtn.disabled).toBe(false);
-    undoBtn.click();
-    expect(ctx2.putImageData).toHaveBeenCalled();
-    expect(ctx1.putImageData).not.toHaveBeenCalled();
-    expect(undoBtn.disabled).toBe(true);
-    expect(redoBtn.disabled).toBe(false);
-
-    // switch back to first layer – its undo stack still has entries
-    handle.activateLayer(0);
-    expect(undoBtn.disabled).toBe(false);
-    expect(redoBtn.disabled).toBe(true);
-  });
-
-  it("enables pointer events only on the active layer", () => {
-    const canvases = Array.from(
-      document.querySelectorAll<HTMLCanvasElement>("canvas"),
-    );
-
+  it("activates layers and updates pointer events", () => {
+    expect(manager.getActiveIndex()).toBe(0);
     expect(canvases[0].style.pointerEvents).toBe("auto");
     expect(canvases[1].style.pointerEvents).toBe("none");
 
-    handle.activateLayer(1);
+    manager.activateLayer(1);
 
+    expect(manager.getActiveIndex()).toBe(1);
     expect(canvases[0].style.pointerEvents).toBe("none");
     expect(canvases[1].style.pointerEvents).toBe("auto");
+    expect(layerSelect.value).toBe("1");
+    expect(onActivate).toHaveBeenCalledTimes(1);
+    expect(onActivate).toHaveBeenCalledWith(expect.any(Object), 1);
+  });
+
+  it("creates opacity controls and updates canvas opacity", () => {
+    const opacityInput = document.getElementById("c2Opacity") as HTMLInputElement;
+    expect(opacityInput).toBeTruthy();
+
+    opacityInput.value = "50";
+    opacityInput.dispatchEvent(new Event("input"));
+
+    expect(canvases[1].style.opacity).toBe("0.5");
+  });
+
+  it("hides layers and falls back to the next visible layer", () => {
+    manager.activateLayer(1);
+    expect(onActivate).toHaveBeenLastCalledWith(expect.any(Object), 1);
+
+    manager.setLayerVisibility(1, false);
+
+    expect(canvases[1].style.display).toBe("none");
+    expect(manager.getActiveIndex()).toBe(0);
+    expect(onActivate).toHaveBeenLastCalledWith(expect.any(Object), 0);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a LayerManager core module to encapsulate layer activation, visibility, and opacity controls
- refactor the editor bootstrap to delegate layer DOM wiring to the manager
- add focused LayerManager unit tests covering activation, opacity updates, and visibility changes

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d60d0c72088328b968b43e63a2ec1e