### PR TITLE
Add viewport zoom controls and normalize tool coordinates

### DIFF
--- a/dist/core/Editor.js
+++ b/dist/core/Editor.js
@@ -3,23 +3,137 @@ export class Editor {
         this.undoStack = [];
         this.redoStack = [];
         this.currentTool = null;
+        this.activeToolPointers = new Set();
+        this.capturedPointers = new Set();
+        this.pixelRatio = window.devicePixelRatio || 1;
+        this.zoom = 1;
+        this.minZoom = 0.25;
+        this.maxZoom = 8;
+        this.panX = 0;
+        this.panY = 0;
+        this.viewListeners = new Set();
+        this.cursorOverride = null;
+        this.baseCursor = "crosshair";
+        this.spacePressed = false;
+        this.panPointerId = null;
+        this.lastPanPoint = null;
+        this.touchPointers = new Map();
+        this.initialPinchDistance = null;
+        this.initialPinchZoom = 1;
+        this.pinchCenter = null;
+        this.isPinching = false;
         this.handlePointerDown = (e) => {
+            if (e.pointerType === "touch") {
+                this.touchPointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+                if (this.touchPointers.size === 2) {
+                    this.beginPinch();
+                }
+            }
+            if (this.isPinching) {
+                return;
+            }
+            if (this.shouldStartPan(e)) {
+                this.startPan(e);
+                return;
+            }
             // Capture the pointer once before recording canvas state
-            this.canvas.setPointerCapture(e.pointerId);
+            this.setPointerCaptureSafe(e.pointerId);
             this.saveState();
+            this.activeToolPointers.add(e.pointerId);
             this.currentTool?.onPointerDown(e, this);
         };
         this.handlePointerMove = (e) => {
+            if (this.panPointerId === e.pointerId && this.lastPanPoint) {
+                this.continuePan(e);
+                return;
+            }
+            if (e.pointerType === "touch" && this.touchPointers.has(e.pointerId)) {
+                this.touchPointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+                if (this.isPinching) {
+                    e.preventDefault();
+                    this.updatePinch();
+                    return;
+                }
+            }
+            if (!this.activeToolPointers.has(e.pointerId))
+                return;
             this.currentTool?.onPointerMove(e, this);
         };
         this.handlePointerUp = (e) => {
+            if (this.panPointerId === e.pointerId) {
+                this.endPan();
+                return;
+            }
+            const hadToolPointer = this.activeToolPointers.has(e.pointerId);
+            if (e.pointerType === "touch") {
+                this.touchPointers.delete(e.pointerId);
+                if (this.isPinching) {
+                    if (hadToolPointer) {
+                        this.activeToolPointers.delete(e.pointerId);
+                        if (this.hasPointerCaptureSafe(e.pointerId)) {
+                            this.releasePointerCaptureSafe(e.pointerId);
+                        }
+                    }
+                    if (this.touchPointers.size < 2) {
+                        this.finishPinch();
+                    }
+                    return;
+                }
+            }
+            if (!hadToolPointer)
+                return;
             this.currentTool?.onPointerUp(e, this);
-            this.canvas.releasePointerCapture(e.pointerId);
+            this.activeToolPointers.delete(e.pointerId);
+            if (this.hasPointerCaptureSafe(e.pointerId)) {
+                this.releasePointerCaptureSafe(e.pointerId);
+            }
         };
         this.handleResize = () => {
             const data = this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height);
             this.adjustForPixelRatio();
             this.ctx.putImageData(data, 0, 0);
+        };
+        this.handleWheel = (e) => {
+            if (!(e.ctrlKey || e.metaKey)) {
+                return;
+            }
+            e.preventDefault();
+            const rect = this.canvas.getBoundingClientRect();
+            const point = {
+                x: e.clientX - rect.left,
+                y: e.clientY - rect.top,
+            };
+            const delta = e.deltaY;
+            const scale = Math.exp(-delta / 500);
+            this.zoomTo(this.zoom * scale, point);
+        };
+        this.handleKeyDown = (e) => {
+            if (e.defaultPrevented)
+                return;
+            const target = e.target;
+            if (target instanceof HTMLElement && this.shouldIgnoreKeyTarget(target)) {
+                return;
+            }
+            if (e.code === "Space") {
+                if (!this.spacePressed) {
+                    e.preventDefault();
+                    this.spacePressed = true;
+                    if (!this.cursorOverride) {
+                        this.setCursorOverride("grab");
+                    }
+                }
+            }
+        };
+        this.handleKeyUp = (e) => {
+            if (e.code === "Space") {
+                this.spacePressed = false;
+                if (!this.panPointerId && !this.isPinching) {
+                    this.setCursorOverride(null);
+                }
+            }
+        };
+        this.preventContextMenu = (e) => {
+            e.preventDefault();
         };
         this.canvas = canvas;
         const ctx = canvas.getContext("2d");
@@ -32,25 +146,257 @@ export class Editor {
         this.onChange = onChange;
         this.fontFamily = fontFamily ?? null;
         this.fontSize = fontSize ?? null;
+        this.canvas.style.touchAction = "none";
         this.adjustForPixelRatio();
         window.addEventListener("resize", this.handleResize);
+        window.addEventListener("keydown", this.handleKeyDown, { capture: true });
+        window.addEventListener("keyup", this.handleKeyUp, { capture: true });
+        this.canvas.addEventListener("wheel", this.handleWheel, { passive: false });
         this.canvas.addEventListener("pointerdown", this.handlePointerDown);
         this.canvas.addEventListener("pointermove", this.handlePointerMove);
         this.canvas.addEventListener("pointerup", this.handlePointerUp);
+        this.canvas.addEventListener("pointercancel", this.handlePointerUp);
+        this.canvas.addEventListener("pointerleave", this.handlePointerUp);
+        this.canvas.addEventListener("contextmenu", this.preventContextMenu);
+        this.emitViewChange();
     }
     setTool(tool) {
         this.currentTool?.destroy?.();
         this.currentTool = tool;
-        this.canvas.style.cursor = tool.cursor || "crosshair";
+        this.baseCursor = tool.cursor || "crosshair";
+        this.updateCursor();
+    }
+    setPointerCaptureSafe(pointerId) {
+        if (typeof this.canvas.setPointerCapture === "function") {
+            try {
+                this.canvas.setPointerCapture(pointerId);
+            }
+            catch {
+                /* ignore unsupported pointer capture */
+            }
+        }
+        this.capturedPointers.add(pointerId);
+    }
+    releasePointerCaptureSafe(pointerId) {
+        if (typeof this.canvas.releasePointerCapture === "function") {
+            try {
+                this.canvas.releasePointerCapture(pointerId);
+            }
+            catch {
+                /* ignore unsupported pointer capture */
+            }
+        }
+        this.capturedPointers.delete(pointerId);
+    }
+    hasPointerCaptureSafe(pointerId) {
+        return (typeof this.canvas.hasPointerCapture === "function" &&
+            this.canvas.hasPointerCapture(pointerId)) || this.capturedPointers.has(pointerId);
     }
     adjustForPixelRatio() {
         const dpr = window.devicePixelRatio || 1;
         const rect = this.canvas.getBoundingClientRect();
+        this.pixelRatio = dpr;
         this.canvas.width = rect.width * dpr;
         this.canvas.height = rect.height * dpr;
-        this.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-        // Reset any existing transforms
-        this.ctx.scale(1, 1);
+        this.updateTransform();
+    }
+    shouldIgnoreKeyTarget(target) {
+        return (target.closest("input, textarea, select, [contenteditable]") !== null ||
+            target.tagName === "BUTTON");
+    }
+    shouldStartPan(e) {
+        if (e.pointerType === "touch") {
+            return false;
+        }
+        return e.button === 1 || (e.button === 0 && this.spacePressed);
+    }
+    startPan(e) {
+        this.panPointerId = e.pointerId;
+        this.lastPanPoint = { x: e.clientX, y: e.clientY };
+        this.setPointerCaptureSafe(e.pointerId);
+        this.setCursorOverride("grabbing");
+    }
+    continuePan(e) {
+        if (!this.lastPanPoint)
+            return;
+        const dx = e.clientX - this.lastPanPoint.x;
+        const dy = e.clientY - this.lastPanPoint.y;
+        this.panX += dx;
+        this.panY += dy;
+        this.lastPanPoint = { x: e.clientX, y: e.clientY };
+        this.updateTransform();
+    }
+    endPan() {
+        if (this.panPointerId !== null && this.hasPointerCaptureSafe(this.panPointerId)) {
+            this.releasePointerCaptureSafe(this.panPointerId);
+        }
+        this.panPointerId = null;
+        this.lastPanPoint = null;
+        if (this.spacePressed) {
+            this.setCursorOverride("grab");
+        }
+        else {
+            this.setCursorOverride(null);
+        }
+    }
+    beginPinch() {
+        const pointers = Array.from(this.touchPointers.values());
+        if (pointers.length < 2)
+            return;
+        this.isPinching = true;
+        this.initialPinchZoom = this.zoom;
+        this.initialPinchDistance = this.distanceBetween(pointers[0], pointers[1]);
+        const rect = this.canvas.getBoundingClientRect();
+        this.pinchCenter = {
+            x: (pointers[0].x + pointers[1].x) / 2 - rect.left,
+            y: (pointers[0].y + pointers[1].y) / 2 - rect.top,
+        };
+        this.activeToolPointers.forEach((pointerId) => {
+            if (this.hasPointerCaptureSafe(pointerId)) {
+                this.releasePointerCaptureSafe(pointerId);
+            }
+        });
+        this.activeToolPointers.clear();
+        this.setCursorOverride("grabbing");
+    }
+    updatePinch() {
+        const pointers = Array.from(this.touchPointers.values());
+        if (pointers.length < 2 || !this.initialPinchDistance) {
+            return;
+        }
+        const rect = this.canvas.getBoundingClientRect();
+        const center = {
+            x: (pointers[0].x + pointers[1].x) / 2 - rect.left,
+            y: (pointers[0].y + pointers[1].y) / 2 - rect.top,
+        };
+        if (this.pinchCenter) {
+            this.panX += center.x - this.pinchCenter.x;
+            this.panY += center.y - this.pinchCenter.y;
+        }
+        this.pinchCenter = center;
+        const distance = this.distanceBetween(pointers[0], pointers[1]);
+        const scale = distance / this.initialPinchDistance;
+        this.zoomTo(this.initialPinchZoom * scale, center);
+    }
+    finishPinch() {
+        this.isPinching = false;
+        this.initialPinchDistance = null;
+        this.initialPinchZoom = this.zoom;
+        this.pinchCenter = null;
+        if (this.spacePressed) {
+            this.setCursorOverride("grab");
+        }
+        else {
+            this.setCursorOverride(null);
+        }
+    }
+    distanceBetween(a, b) {
+        return Math.hypot(a.x - b.x, a.y - b.y);
+    }
+    updateCursor() {
+        this.canvas.style.cursor = this.cursorOverride ?? this.baseCursor;
+    }
+    setCursorOverride(cursor) {
+        this.cursorOverride = cursor;
+        this.updateCursor();
+    }
+    zoomTo(zoom, center) {
+        const clamped = Math.min(this.maxZoom, Math.max(this.minZoom, zoom));
+        if (center) {
+            const worldX = (center.x - this.panX) / this.zoom;
+            const worldY = (center.y - this.panY) / this.zoom;
+            this.zoom = clamped;
+            this.panX = center.x - worldX * this.zoom;
+            this.panY = center.y - worldY * this.zoom;
+        }
+        else {
+            this.zoom = clamped;
+        }
+        this.updateTransform();
+    }
+    updateTransform(options = {}) {
+        this.ctx.setTransform(this.pixelRatio * this.zoom, 0, 0, this.pixelRatio * this.zoom, this.panX * this.pixelRatio, this.panY * this.pixelRatio);
+        if (!options.suppress) {
+            this.emitViewChange();
+        }
+    }
+    emitViewChange() {
+        const state = this.getViewState();
+        this.viewListeners.forEach((listener) => listener(state));
+    }
+    clampZoom(value) {
+        return Math.min(this.maxZoom, Math.max(this.minZoom, value));
+    }
+    getViewState() {
+        return { zoom: this.zoom, panX: this.panX, panY: this.panY };
+    }
+    onViewChange(listener) {
+        this.viewListeners.add(listener);
+        listener(this.getViewState());
+        return () => {
+            this.viewListeners.delete(listener);
+        };
+    }
+    setViewState(state) {
+        this.zoom = this.clampZoom(state.zoom);
+        this.panX = state.panX;
+        this.panY = state.panY;
+        this.updateTransform();
+    }
+    syncViewState(state) {
+        this.zoom = this.clampZoom(state.zoom);
+        this.panX = state.panX;
+        this.panY = state.panY;
+        this.updateTransform({ suppress: true });
+    }
+    zoomIn(center) {
+        this.zoomTo(this.zoom * 1.25, center);
+    }
+    zoomOut(center) {
+        this.zoomTo(this.zoom / 1.25, center);
+    }
+    resetView() {
+        this.zoom = 1;
+        this.panX = 0;
+        this.panY = 0;
+        this.updateTransform();
+    }
+    get zoomFactor() {
+        return this.zoom;
+    }
+    get pixelRatioValue() {
+        return this.pixelRatio;
+    }
+    get lineWidthOnCanvas() {
+        return this.lineWidthValue / this.zoom;
+    }
+    getCanvasPoint(e) {
+        const rect = this.canvas.getBoundingClientRect();
+        const fallback = e;
+        const hasOffsetX = typeof fallback.offsetX === "number" && !Number.isNaN(fallback.offsetX);
+        const hasOffsetY = typeof fallback.offsetY === "number" && !Number.isNaN(fallback.offsetY);
+        const hasClientX = typeof e.clientX === "number" && !Number.isNaN(e.clientX);
+        const hasClientY = typeof e.clientY === "number" && !Number.isNaN(e.clientY);
+        const cssX = hasOffsetX
+            ? fallback.offsetX
+            : hasClientX
+                ? e.clientX - rect.left
+                : 0;
+        const cssY = hasOffsetY
+            ? fallback.offsetY
+            : hasClientY
+                ? e.clientY - rect.top
+                : 0;
+        return {
+            x: (cssX - this.panX) / this.zoom,
+            y: (cssY - this.panY) / this.zoom,
+        };
+    }
+    canvasToScreen(x, y) {
+        return {
+            x: x * this.zoom + this.panX,
+            y: y * this.zoom + this.panY,
+        };
     }
     saveState() {
         this.undoStack.push(this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height));
@@ -105,8 +451,15 @@ export class Editor {
     destroy() {
         this.currentTool?.destroy?.();
         window.removeEventListener("resize", this.handleResize);
+        window.removeEventListener("keydown", this.handleKeyDown, true);
+        window.removeEventListener("keyup", this.handleKeyUp, true);
         this.canvas.removeEventListener("pointerdown", this.handlePointerDown);
         this.canvas.removeEventListener("pointermove", this.handlePointerMove);
         this.canvas.removeEventListener("pointerup", this.handlePointerUp);
+        this.canvas.removeEventListener("pointercancel", this.handlePointerUp);
+        this.canvas.removeEventListener("pointerleave", this.handlePointerUp);
+        this.canvas.removeEventListener("wheel", this.handleWheel);
+        this.canvas.removeEventListener("contextmenu", this.preventContextMenu);
+        this.viewListeners.clear();
     }
 }

--- a/dist/editor.js
+++ b/dist/editor.js
@@ -22,6 +22,11 @@ function listen(el, type, handler, list) {
  */
 export function initEditor() {
     const canvases = Array.from(document.querySelectorAll("canvas"));
+    const listeners = [];
+    const createHTMLElement = (tag) => {
+        const el = document.createElement(tag);
+        return el instanceof HTMLElement ? el : null;
+    };
     const toolConstructors = {
         pencil: PencilTool,
         eraser: EraserTool,
@@ -91,6 +96,44 @@ export function initEditor() {
     if (!formatSelect) {
         throw new Error("Missing #formatSelect select");
     }
+    const zoomControls = createHTMLElement("div");
+    const zoomOutBtn = createHTMLElement("button");
+    const zoomDisplay = createHTMLElement("span");
+    const zoomInBtn = createHTMLElement("button");
+    const zoomResetBtn = createHTMLElement("button");
+    if (zoomControls) {
+        zoomControls.className = "group zoom-controls";
+    }
+    if (zoomOutBtn) {
+        zoomOutBtn.type = "button";
+        zoomOutBtn.className = "tool-button";
+        zoomOutBtn.textContent = "-";
+        zoomOutBtn.title = "Zoom out (Ctrl+-)";
+        zoomOutBtn.setAttribute("aria-label", "Zoom out");
+    }
+    if (zoomDisplay) {
+        zoomDisplay.className = "zoom-display";
+        zoomDisplay.textContent = "100%";
+        zoomDisplay.setAttribute("aria-live", "polite");
+    }
+    if (zoomInBtn) {
+        zoomInBtn.type = "button";
+        zoomInBtn.className = "tool-button";
+        zoomInBtn.textContent = "+";
+        zoomInBtn.title = "Zoom in (Ctrl+=)";
+        zoomInBtn.setAttribute("aria-label", "Zoom in");
+    }
+    if (zoomResetBtn) {
+        zoomResetBtn.type = "button";
+        zoomResetBtn.className = "tool-button";
+        zoomResetBtn.textContent = "Reset";
+        zoomResetBtn.title = "Reset zoom (Ctrl+0)";
+        zoomResetBtn.setAttribute("aria-label", "Reset zoom");
+    }
+    if (zoomControls && zoomOutBtn && zoomDisplay && zoomInBtn && zoomResetBtn) {
+        zoomControls.append(zoomOutBtn, zoomDisplay, zoomInBtn, zoomResetBtn);
+        toolbar.appendChild(zoomControls);
+    }
     if (layerSelect) {
         layerSelect.innerHTML = "";
     }
@@ -122,7 +165,6 @@ export function initEditor() {
     });
     const undoBtn = document.getElementById("undo");
     const redoBtn = document.getElementById("redo");
-    const listeners = [];
     const recentColors = [];
     const maxRecentColors = 10;
     const renderColorHistory = () => {
@@ -155,6 +197,11 @@ export function initEditor() {
         recordColor(colorPicker.value);
     }, listeners);
     let editor; // set after editors created
+    const updateZoomDisplay = (zoom) => {
+        if (zoomDisplay) {
+            zoomDisplay.textContent = `${Math.round(zoom * 100)}%`;
+        }
+    };
     const updateHistoryButtons = () => {
         if (undoBtn)
             undoBtn.disabled = !editor?.canUndo;
@@ -162,12 +209,22 @@ export function initEditor() {
             redoBtn.disabled = !editor?.canRedo;
     };
     const editors = [];
+    const syncView = (source, state) => {
+        editors.forEach((target) => {
+            if (target !== source) {
+                target.syncViewState(state);
+            }
+        });
+        updateZoomDisplay(state.zoom);
+    };
     canvases.forEach((c) => {
         try {
             const e = new Editor(c, colorPicker, lineWidth, fillMode, () => {
                 updateHistoryButtons();
             }, fontFamily ?? undefined, fontSize ?? undefined);
             editors.push(e);
+            const unsubscribe = e.onViewChange((state) => syncView(e, state));
+            listeners.push(unsubscribe);
         }
         catch {
             /* skip canvases without 2D context */
@@ -188,12 +245,50 @@ export function initEditor() {
     });
     // active editor defaults to the first successfully created editor
     editor = editors[0];
+    updateZoomDisplay(editor.zoomFactor);
     // default tool
     editor.setTool(new PencilTool());
     editorToolConstructors.set(editor, PencilTool);
     updateLayerInteractivity();
     // keyboard shortcuts
     const shortcuts = new Shortcuts(editor);
+    const getCanvasCenter = () => {
+        const rect = editor.canvas.getBoundingClientRect();
+        return { x: rect.width / 2, y: rect.height / 2 };
+    };
+    listen(zoomOutBtn, "click", () => {
+        editor.zoomOut(getCanvasCenter());
+    }, listeners);
+    listen(zoomInBtn, "click", () => {
+        editor.zoomIn(getCanvasCenter());
+    }, listeners);
+    listen(zoomResetBtn, "click", () => {
+        editor.resetView();
+    }, listeners);
+    const handleZoomShortcut = (ev) => {
+        if (!(ev.ctrlKey || ev.metaKey))
+            return;
+        const target = ev.target;
+        if (target instanceof HTMLElement &&
+            target.closest("input, textarea, select, [contenteditable]")) {
+            return;
+        }
+        const key = ev.key;
+        if (key === "=" || key === "+") {
+            ev.preventDefault();
+            editor.zoomIn(getCanvasCenter());
+        }
+        else if (key === "-") {
+            ev.preventDefault();
+            editor.zoomOut(getCanvasCenter());
+        }
+        else if (key === "0") {
+            ev.preventDefault();
+            editor.resetView();
+        }
+    };
+    document.addEventListener("keydown", handleZoomShortcut);
+    listeners.push(() => document.removeEventListener("keydown", handleZoomShortcut));
     // map button id to tool constructor
     Object.entries(toolConstructors).forEach(([id, ToolCtor]) => listen(toolButtons[id], "click", () => editor.setTool(new ToolCtor()), listeners));
     listen(undoBtn, "click", () => {
@@ -282,6 +377,7 @@ export function initEditor() {
         const ToolCtor = editorToolConstructors.get(editor) ?? activeToolCtor;
         editor.setTool(new ToolCtor());
         updateHistoryButtons();
+        updateZoomDisplay(editor.zoomFactor);
         if (layerSelect)
             layerSelect.value = String(index);
     }

--- a/dist/tools/BucketFillTool.js
+++ b/dist/tools/BucketFillTool.js
@@ -12,9 +12,10 @@ export class BucketFillTool {
             console.warn("Bucket fill aborted: area too large");
             return;
         }
-        const dpr = window.devicePixelRatio || 1;
-        const sx = Math.max(0, Math.min(width - 1, Math.floor(e.offsetX * dpr)));
-        const sy = Math.max(0, Math.min(height - 1, Math.floor(e.offsetY * dpr)));
+        const { x, y } = editor.getCanvasPoint(e);
+        const dpr = editor.pixelRatioValue;
+        const sx = Math.max(0, Math.min(width - 1, Math.floor(x * dpr)));
+        const sy = Math.max(0, Math.min(height - 1, Math.floor(y * dpr)));
         const start = sy * width + sx;
         const targetOffset = start * 4;
         const tr = data[targetOffset];

--- a/dist/tools/CircleTool.js
+++ b/dist/tools/CircleTool.js
@@ -7,8 +7,9 @@ export class CircleTool extends DrawingTool {
         this.imageData = null;
     }
     onPointerDown(e, editor) {
-        this.startX = e.offsetX;
-        this.startY = e.offsetY;
+        const { x, y } = editor.getCanvasPoint(e);
+        this.startX = x;
+        this.startY = y;
         const ctx = editor.ctx;
         this.applyStroke(ctx, editor);
         if (typeof ctx.getImageData === "function") {
@@ -24,8 +25,9 @@ export class CircleTool extends DrawingTool {
         const ctx = editor.ctx;
         ctx.putImageData(this.imageData, 0, 0);
         this.applyStroke(ctx, editor);
-        const dx = e.offsetX - this.startX;
-        const dy = e.offsetY - this.startY;
+        const { x, y } = editor.getCanvasPoint(e);
+        const dx = x - this.startX;
+        const dy = y - this.startY;
         let radiusX = Math.abs(dx);
         let radiusY = Math.abs(dy);
         if (e.shiftKey) {
@@ -47,8 +49,9 @@ export class CircleTool extends DrawingTool {
             ctx.putImageData(this.imageData, 0, 0);
         }
         this.applyStroke(ctx, editor);
-        const dx = e.offsetX - this.startX;
-        const dy = e.offsetY - this.startY;
+        const { x, y } = editor.getCanvasPoint(e);
+        const dx = x - this.startX;
+        const dy = y - this.startY;
         let radiusX = Math.abs(dx);
         let radiusY = Math.abs(dy);
         if (e.shiftKey) {

--- a/dist/tools/DrawingTool.js
+++ b/dist/tools/DrawingTool.js
@@ -9,7 +9,7 @@ export class DrawingTool {
      * drawing operations.
      */
     applyStroke(ctx, editor) {
-        ctx.lineWidth = editor.lineWidthValue;
+        ctx.lineWidth = editor.lineWidthOnCanvas;
         ctx.strokeStyle = editor.strokeStyle;
         ctx.fillStyle = editor.fillStyle;
     }

--- a/dist/tools/EraserTool.js
+++ b/dist/tools/EraserTool.js
@@ -4,18 +4,22 @@ export class EraserTool extends DrawingTool {
         const ctx = editor.ctx;
         ctx.globalCompositeOperation = "destination-out";
         this.applyStroke(ctx, editor);
+        const { x, y } = editor.getCanvasPoint(e);
+        const size = editor.lineWidthOnCanvas;
         ctx.beginPath();
-        ctx.moveTo(e.offsetX, e.offsetY);
-        ctx.clearRect(e.offsetX - editor.lineWidthValue / 2, e.offsetY - editor.lineWidthValue / 2, editor.lineWidthValue, editor.lineWidthValue);
+        ctx.moveTo(x, y);
+        ctx.clearRect(x - size / 2, y - size / 2, size, size);
     }
     onPointerMove(e, editor) {
         if (e.buttons !== 1)
             return;
         const ctx = editor.ctx;
         this.applyStroke(ctx, editor);
-        ctx.lineTo(e.offsetX, e.offsetY);
+        const { x, y } = editor.getCanvasPoint(e);
+        const size = editor.lineWidthOnCanvas;
+        ctx.lineTo(x, y);
         ctx.stroke();
-        ctx.clearRect(e.offsetX - editor.lineWidthValue / 2, e.offsetY - editor.lineWidthValue / 2, editor.lineWidthValue, editor.lineWidthValue);
+        ctx.clearRect(x - size / 2, y - size / 2, size, size);
     }
     onPointerUp(_e, editor) {
         const ctx = editor.ctx;

--- a/dist/tools/EyedropperTool.js
+++ b/dist/tools/EyedropperTool.js
@@ -8,9 +8,10 @@ export class EyedropperTool {
     }
     onPointerDown(e, editor) {
         const { width, height } = editor.canvas;
-        const dpr = window.devicePixelRatio || 1;
-        const x = Math.max(0, Math.min(width - 1, Math.floor(e.offsetX * dpr)));
-        const y = Math.max(0, Math.min(height - 1, Math.floor(e.offsetY * dpr)));
+        const dpr = editor.pixelRatioValue;
+        const { x: worldX, y: worldY } = editor.getCanvasPoint(e);
+        const x = Math.max(0, Math.min(width - 1, Math.floor(worldX * dpr)));
+        const y = Math.max(0, Math.min(height - 1, Math.floor(worldY * dpr)));
         const { data } = editor.ctx.getImageData(x, y, 1, 1);
         const [r, g, b] = data;
         const toHex = (v) => v.toString(16).padStart(2, "0");

--- a/dist/tools/LineTool.js
+++ b/dist/tools/LineTool.js
@@ -8,8 +8,9 @@ export class LineTool extends DrawingTool {
     }
     onPointerDown(e, editor) {
         const ctx = editor.ctx;
-        this.startX = e.offsetX;
-        this.startY = e.offsetY;
+        const { x, y } = editor.getCanvasPoint(e);
+        this.startX = x;
+        this.startY = y;
         this.applyStroke(ctx, editor);
         this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
     }
@@ -21,8 +22,7 @@ export class LineTool extends DrawingTool {
         this.applyStroke(ctx, editor);
         ctx.beginPath();
         ctx.moveTo(this.startX, this.startY);
-        let x = e.offsetX;
-        let y = e.offsetY;
+        let { x, y } = editor.getCanvasPoint(e);
         if (e.shiftKey) {
             const dx = x - this.startX;
             const dy = y - this.startY;
@@ -44,8 +44,7 @@ export class LineTool extends DrawingTool {
         this.applyStroke(ctx, editor);
         ctx.beginPath();
         ctx.moveTo(this.startX, this.startY);
-        let x = e.offsetX;
-        let y = e.offsetY;
+        let { x, y } = editor.getCanvasPoint(e);
         if (e.shiftKey) {
             const dx = x - this.startX;
             const dy = y - this.startY;

--- a/dist/tools/PencilTool.js
+++ b/dist/tools/PencilTool.js
@@ -3,15 +3,17 @@ export class PencilTool extends DrawingTool {
     onPointerDown(e, editor) {
         this.applyStroke(editor.ctx, editor);
         const ctx = editor.ctx;
+        const { x, y } = editor.getCanvasPoint(e);
         ctx.beginPath();
-        ctx.moveTo(e.offsetX, e.offsetY);
+        ctx.moveTo(x, y);
     }
     onPointerMove(e, editor) {
         if (e.buttons !== 1)
             return;
         this.applyStroke(editor.ctx, editor);
         const ctx = editor.ctx;
-        ctx.lineTo(e.offsetX, e.offsetY);
+        const { x, y } = editor.getCanvasPoint(e);
+        ctx.lineTo(x, y);
         ctx.stroke();
     }
     onPointerUp(_e, editor) {

--- a/dist/tools/RectangleTool.js
+++ b/dist/tools/RectangleTool.js
@@ -7,8 +7,9 @@ export class RectangleTool extends DrawingTool {
         this.imageData = null;
     }
     onPointerDown(e, editor) {
-        this.startX = e.offsetX;
-        this.startY = e.offsetY;
+        const { x, y } = editor.getCanvasPoint(e);
+        this.startX = x;
+        this.startY = y;
         this.applyStroke(editor.ctx, editor);
         const ctx = editor.ctx;
         this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
@@ -19,8 +20,7 @@ export class RectangleTool extends DrawingTool {
         const ctx = editor.ctx;
         ctx.putImageData(this.imageData, 0, 0);
         this.applyStroke(editor.ctx, editor);
-        const x = e.offsetX;
-        const y = e.offsetY;
+        const { x, y } = editor.getCanvasPoint(e);
         let width = x - this.startX;
         let height = y - this.startY;
         if (e.shiftKey) {
@@ -39,8 +39,7 @@ export class RectangleTool extends DrawingTool {
             ctx.putImageData(this.imageData, 0, 0);
         }
         this.applyStroke(editor.ctx, editor);
-        const x = e.offsetX;
-        const y = e.offsetY;
+        const { x, y } = editor.getCanvasPoint(e);
         let width = x - this.startX;
         let height = y - this.startY;
         if (e.shiftKey) {

--- a/dist/tools/TextTool.js
+++ b/dist/tools/TextTool.js
@@ -3,16 +3,21 @@ export class TextTool {
         this.textarea = null;
         this.blurListener = null;
         this.keydownListener = null;
+        this.viewUnsubscribe = null;
+        this.anchor = null;
     }
     onPointerDown(e, editor) {
         this.cleanup();
         const textarea = document.createElement("textarea");
         textarea.style.position = "absolute";
         const parent = editor.canvas.parentElement || document.body;
-        textarea.style.left = `${e.offsetX}px`;
-        textarea.style.top = `${e.offsetY}px`;
+        const point = editor.getCanvasPoint(e);
+        this.anchor = point;
+        const screen = editor.canvasToScreen(point.x, point.y);
+        textarea.style.left = `${screen.x}px`;
+        textarea.style.top = `${screen.y}px`;
         textarea.style.color = editor.strokeStyle;
-        textarea.style.fontSize = `${editor.fontSizeValue}px`;
+        textarea.style.fontSize = `${editor.fontSizeValue * editor.zoomFactor}px`;
         textarea.style.fontFamily = editor.fontFamilyValue;
         textarea.style.background = "transparent";
         textarea.style.border = "none";
@@ -21,11 +26,13 @@ export class TextTool {
         textarea.focus();
         const commit = () => {
             const text = textarea.value;
+            const anchor = this.anchor;
             this.cleanup();
-            if (text) {
+            if (text && anchor) {
                 editor.ctx.fillStyle = editor.strokeStyle;
-                editor.ctx.font = `${editor.fontSizeValue}px ${editor.fontFamilyValue}`;
-                editor.ctx.fillText(text, e.offsetX, e.offsetY);
+                const fontSize = editor.fontSizeValue / editor.zoomFactor;
+                editor.ctx.font = `${fontSize}px ${editor.fontFamilyValue}`;
+                editor.ctx.fillText(text, anchor.x, anchor.y);
             }
         };
         const cancel = () => {
@@ -45,6 +52,14 @@ export class TextTool {
         };
         textarea.addEventListener("keydown", this.keydownListener);
         this.textarea = textarea;
+        this.viewUnsubscribe = editor.onViewChange((state) => {
+            if (!this.textarea || !this.anchor)
+                return;
+            const screenPos = editor.canvasToScreen(this.anchor.x, this.anchor.y);
+            this.textarea.style.left = `${screenPos.x}px`;
+            this.textarea.style.top = `${screenPos.y}px`;
+            this.textarea.style.fontSize = `${editor.fontSizeValue * state.zoom}px`;
+        });
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     onPointerMove(_e, _editor) {
@@ -68,9 +83,14 @@ export class TextTool {
         if (this.keydownListener) {
             this.textarea.removeEventListener("keydown", this.keydownListener);
         }
+        if (this.viewUnsubscribe) {
+            this.viewUnsubscribe();
+            this.viewUnsubscribe = null;
+        }
         this.textarea.remove();
         this.textarea = null;
         this.blurListener = null;
         this.keydownListener = null;
+        this.anchor = null;
     }
 }

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -6,12 +6,31 @@ export class Editor {
   private undoStack: ImageData[] = [];
   private redoStack: ImageData[] = [];
   private currentTool: Tool | null = null;
+  private readonly activeToolPointers = new Set<number>();
+  private readonly capturedPointers = new Set<number>();
   colorPicker: HTMLInputElement;
   lineWidth: HTMLInputElement;
   fillMode: HTMLInputElement;
   fontFamily: HTMLSelectElement | null;
   fontSize: HTMLInputElement | null;
   private onChange?: () => void;
+  private pixelRatio = window.devicePixelRatio || 1;
+  private zoom = 1;
+  private readonly minZoom = 0.25;
+  private readonly maxZoom = 8;
+  private panX = 0;
+  private panY = 0;
+  private readonly viewListeners = new Set<(state: ViewState) => void>();
+  private cursorOverride: string | null = null;
+  private baseCursor = "crosshair";
+  private spacePressed = false;
+  private panPointerId: number | null = null;
+  private lastPanPoint: { x: number; y: number } | null = null;
+  private readonly touchPointers = new Map<number, { x: number; y: number }>();
+  private initialPinchDistance: number | null = null;
+  private initialPinchZoom = 1;
+  private pinchCenter: { x: number; y: number } | null = null;
+  private isPinching = false;
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -32,44 +51,140 @@ export class Editor {
     this.onChange = onChange;
     this.fontFamily = fontFamily ?? null;
     this.fontSize = fontSize ?? null;
+    this.canvas.style.touchAction = "none";
     this.adjustForPixelRatio();
     window.addEventListener("resize", this.handleResize);
+    window.addEventListener("keydown", this.handleKeyDown, { capture: true });
+    window.addEventListener("keyup", this.handleKeyUp, { capture: true });
+
+    this.canvas.addEventListener("wheel", this.handleWheel, { passive: false });
 
     this.canvas.addEventListener("pointerdown", this.handlePointerDown);
     this.canvas.addEventListener("pointermove", this.handlePointerMove);
     this.canvas.addEventListener("pointerup", this.handlePointerUp);
+    this.canvas.addEventListener("pointercancel", this.handlePointerUp);
+    this.canvas.addEventListener("pointerleave", this.handlePointerUp);
+    this.canvas.addEventListener("contextmenu", this.preventContextMenu);
+    this.emitViewChange();
   }
 
   setTool(tool: Tool) {
     this.currentTool?.destroy?.();
     this.currentTool = tool;
-    this.canvas.style.cursor = tool.cursor || "crosshair";
+    this.baseCursor = tool.cursor || "crosshair";
+    this.updateCursor();
+  }
+
+  private setPointerCaptureSafe(pointerId: number) {
+    if (typeof this.canvas.setPointerCapture === "function") {
+      try {
+        this.canvas.setPointerCapture(pointerId);
+      } catch {
+        /* ignore unsupported pointer capture */
+      }
+    }
+    this.capturedPointers.add(pointerId);
+  }
+
+  private releasePointerCaptureSafe(pointerId: number) {
+    if (typeof this.canvas.releasePointerCapture === "function") {
+      try {
+        this.canvas.releasePointerCapture(pointerId);
+      } catch {
+        /* ignore unsupported pointer capture */
+      }
+    }
+    this.capturedPointers.delete(pointerId);
+  }
+
+  private hasPointerCaptureSafe(pointerId: number) {
+    return (
+      typeof this.canvas.hasPointerCapture === "function" &&
+      this.canvas.hasPointerCapture(pointerId)
+    ) || this.capturedPointers.has(pointerId);
   }
 
   private handlePointerDown = (e: PointerEvent) => {
+    if (e.pointerType === "touch") {
+      this.touchPointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      if (this.touchPointers.size === 2) {
+        this.beginPinch();
+      }
+    }
+
+    if (this.isPinching) {
+      return;
+    }
+
+    if (this.shouldStartPan(e)) {
+      this.startPan(e);
+      return;
+    }
+
     // Capture the pointer once before recording canvas state
-    this.canvas.setPointerCapture(e.pointerId);
+    this.setPointerCaptureSafe(e.pointerId);
     this.saveState();
+    this.activeToolPointers.add(e.pointerId);
     this.currentTool?.onPointerDown(e, this);
   };
 
   private handlePointerMove = (e: PointerEvent) => {
+    if (this.panPointerId === e.pointerId && this.lastPanPoint) {
+      this.continuePan(e);
+      return;
+    }
+
+    if (e.pointerType === "touch" && this.touchPointers.has(e.pointerId)) {
+      this.touchPointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      if (this.isPinching) {
+        e.preventDefault();
+        this.updatePinch();
+        return;
+      }
+    }
+
+    if (!this.activeToolPointers.has(e.pointerId)) return;
     this.currentTool?.onPointerMove(e, this);
   };
 
   private handlePointerUp = (e: PointerEvent) => {
+    if (this.panPointerId === e.pointerId) {
+      this.endPan();
+      return;
+    }
+
+    const hadToolPointer = this.activeToolPointers.has(e.pointerId);
+    if (e.pointerType === "touch") {
+      this.touchPointers.delete(e.pointerId);
+      if (this.isPinching) {
+        if (hadToolPointer) {
+          this.activeToolPointers.delete(e.pointerId);
+          if (this.hasPointerCaptureSafe(e.pointerId)) {
+            this.releasePointerCaptureSafe(e.pointerId);
+          }
+        }
+        if (this.touchPointers.size < 2) {
+          this.finishPinch();
+        }
+        return;
+      }
+    }
+
+    if (!hadToolPointer) return;
     this.currentTool?.onPointerUp(e, this);
-    this.canvas.releasePointerCapture(e.pointerId);
+    this.activeToolPointers.delete(e.pointerId);
+    if (this.hasPointerCaptureSafe(e.pointerId)) {
+      this.releasePointerCaptureSafe(e.pointerId);
+    }
   };
 
   private adjustForPixelRatio() {
     const dpr = window.devicePixelRatio || 1;
     const rect = this.canvas.getBoundingClientRect();
+    this.pixelRatio = dpr;
     this.canvas.width = rect.width * dpr;
     this.canvas.height = rect.height * dpr;
-    this.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-    // Reset any existing transforms
-    this.ctx.scale(1, 1);
+    this.updateTransform();
   }
 
   private handleResize = () => {
@@ -82,6 +197,282 @@ export class Editor {
     this.adjustForPixelRatio();
     this.ctx.putImageData(data, 0, 0);
   };
+
+  private handleWheel = (e: WheelEvent) => {
+    if (!(e.ctrlKey || e.metaKey)) {
+      return;
+    }
+    e.preventDefault();
+    const rect = this.canvas.getBoundingClientRect();
+    const point = {
+      x: e.clientX - rect.left,
+      y: e.clientY - rect.top,
+    };
+    const delta = e.deltaY;
+    const scale = Math.exp(-delta / 500);
+    this.zoomTo(this.zoom * scale, point);
+  };
+
+  private handleKeyDown = (e: KeyboardEvent) => {
+    if (e.defaultPrevented) return;
+    const target = e.target;
+    if (target instanceof HTMLElement && this.shouldIgnoreKeyTarget(target)) {
+      return;
+    }
+    if (e.code === "Space") {
+      if (!this.spacePressed) {
+        e.preventDefault();
+        this.spacePressed = true;
+        if (!this.cursorOverride) {
+          this.setCursorOverride("grab");
+        }
+      }
+    }
+  };
+
+  private handleKeyUp = (e: KeyboardEvent) => {
+    if (e.code === "Space") {
+      this.spacePressed = false;
+      if (!this.panPointerId && !this.isPinching) {
+        this.setCursorOverride(null);
+      }
+    }
+  };
+
+  private preventContextMenu = (e: Event) => {
+    e.preventDefault();
+  };
+
+  private shouldIgnoreKeyTarget(target: HTMLElement) {
+    return (
+      target.closest("input, textarea, select, [contenteditable]") !== null ||
+      target.tagName === "BUTTON"
+    );
+  }
+
+  private shouldStartPan(e: PointerEvent) {
+    if (e.pointerType === "touch") {
+      return false;
+    }
+    return e.button === 1 || (e.button === 0 && this.spacePressed);
+  }
+
+  private startPan(e: PointerEvent) {
+    this.panPointerId = e.pointerId;
+    this.lastPanPoint = { x: e.clientX, y: e.clientY };
+    this.setPointerCaptureSafe(e.pointerId);
+    this.setCursorOverride("grabbing");
+  }
+
+  private continuePan(e: PointerEvent) {
+    if (!this.lastPanPoint) return;
+    const dx = e.clientX - this.lastPanPoint.x;
+    const dy = e.clientY - this.lastPanPoint.y;
+    this.panX += dx;
+    this.panY += dy;
+    this.lastPanPoint = { x: e.clientX, y: e.clientY };
+    this.updateTransform();
+  }
+
+  private endPan() {
+    if (this.panPointerId !== null && this.hasPointerCaptureSafe(this.panPointerId)) {
+      this.releasePointerCaptureSafe(this.panPointerId);
+    }
+    this.panPointerId = null;
+    this.lastPanPoint = null;
+    if (this.spacePressed) {
+      this.setCursorOverride("grab");
+    } else {
+      this.setCursorOverride(null);
+    }
+  }
+
+  private beginPinch() {
+    const pointers = Array.from(this.touchPointers.values());
+    if (pointers.length < 2) return;
+    this.isPinching = true;
+    this.initialPinchZoom = this.zoom;
+    this.initialPinchDistance = this.distanceBetween(pointers[0], pointers[1]);
+    const rect = this.canvas.getBoundingClientRect();
+    this.pinchCenter = {
+      x: (pointers[0].x + pointers[1].x) / 2 - rect.left,
+      y: (pointers[0].y + pointers[1].y) / 2 - rect.top,
+    };
+    this.activeToolPointers.forEach((pointerId) => {
+      if (this.hasPointerCaptureSafe(pointerId)) {
+        this.releasePointerCaptureSafe(pointerId);
+      }
+    });
+    this.activeToolPointers.clear();
+    this.setCursorOverride("grabbing");
+  }
+
+  private updatePinch() {
+    const pointers = Array.from(this.touchPointers.values());
+    if (pointers.length < 2 || !this.initialPinchDistance) {
+      return;
+    }
+    const rect = this.canvas.getBoundingClientRect();
+    const center = {
+      x: (pointers[0].x + pointers[1].x) / 2 - rect.left,
+      y: (pointers[0].y + pointers[1].y) / 2 - rect.top,
+    };
+    if (this.pinchCenter) {
+      this.panX += center.x - this.pinchCenter.x;
+      this.panY += center.y - this.pinchCenter.y;
+    }
+    this.pinchCenter = center;
+    const distance = this.distanceBetween(pointers[0], pointers[1]);
+    const scale = distance / this.initialPinchDistance;
+    this.zoomTo(this.initialPinchZoom * scale, center);
+  }
+
+  private finishPinch() {
+    this.isPinching = false;
+    this.initialPinchDistance = null;
+    this.initialPinchZoom = this.zoom;
+    this.pinchCenter = null;
+    if (this.spacePressed) {
+      this.setCursorOverride("grab");
+    } else {
+      this.setCursorOverride(null);
+    }
+  }
+
+  private distanceBetween(a: { x: number; y: number }, b: { x: number; y: number }) {
+    return Math.hypot(a.x - b.x, a.y - b.y);
+  }
+
+  private updateCursor() {
+    this.canvas.style.cursor = this.cursorOverride ?? this.baseCursor;
+  }
+
+  private setCursorOverride(cursor: string | null) {
+    this.cursorOverride = cursor;
+    this.updateCursor();
+  }
+
+  private zoomTo(zoom: number, center?: { x: number; y: number }) {
+    const clamped = Math.min(this.maxZoom, Math.max(this.minZoom, zoom));
+    if (center) {
+      const worldX = (center.x - this.panX) / this.zoom;
+      const worldY = (center.y - this.panY) / this.zoom;
+      this.zoom = clamped;
+      this.panX = center.x - worldX * this.zoom;
+      this.panY = center.y - worldY * this.zoom;
+    } else {
+      this.zoom = clamped;
+    }
+    this.updateTransform();
+  }
+
+  private updateTransform(options: { suppress?: boolean } = {}) {
+    this.ctx.setTransform(
+      this.pixelRatio * this.zoom,
+      0,
+      0,
+      this.pixelRatio * this.zoom,
+      this.panX * this.pixelRatio,
+      this.panY * this.pixelRatio,
+    );
+    if (!options.suppress) {
+      this.emitViewChange();
+    }
+  }
+
+  private emitViewChange() {
+    const state = this.getViewState();
+    this.viewListeners.forEach((listener) => listener(state));
+  }
+
+  private clampZoom(value: number) {
+    return Math.min(this.maxZoom, Math.max(this.minZoom, value));
+  }
+
+  getViewState(): ViewState {
+    return { zoom: this.zoom, panX: this.panX, panY: this.panY };
+  }
+
+  onViewChange(listener: (state: ViewState) => void) {
+    this.viewListeners.add(listener);
+    listener(this.getViewState());
+    return () => {
+      this.viewListeners.delete(listener);
+    };
+  }
+
+  setViewState(state: ViewState) {
+    this.zoom = this.clampZoom(state.zoom);
+    this.panX = state.panX;
+    this.panY = state.panY;
+    this.updateTransform();
+  }
+
+  syncViewState(state: ViewState) {
+    this.zoom = this.clampZoom(state.zoom);
+    this.panX = state.panX;
+    this.panY = state.panY;
+    this.updateTransform({ suppress: true });
+  }
+
+  zoomIn(center?: { x: number; y: number }) {
+    this.zoomTo(this.zoom * 1.25, center);
+  }
+
+  zoomOut(center?: { x: number; y: number }) {
+    this.zoomTo(this.zoom / 1.25, center);
+  }
+
+  resetView() {
+    this.zoom = 1;
+    this.panX = 0;
+    this.panY = 0;
+    this.updateTransform();
+  }
+
+  get zoomFactor() {
+    return this.zoom;
+  }
+
+  get pixelRatioValue() {
+    return this.pixelRatio;
+  }
+
+  get lineWidthOnCanvas() {
+    return this.lineWidthValue / this.zoom;
+  }
+
+  getCanvasPoint(e: PointerEvent) {
+    const rect = this.canvas.getBoundingClientRect();
+    const fallback = e as { offsetX?: number; offsetY?: number };
+    const hasOffsetX =
+      typeof fallback.offsetX === "number" && !Number.isNaN(fallback.offsetX);
+    const hasOffsetY =
+      typeof fallback.offsetY === "number" && !Number.isNaN(fallback.offsetY);
+    const hasClientX = typeof e.clientX === "number" && !Number.isNaN(e.clientX);
+    const hasClientY = typeof e.clientY === "number" && !Number.isNaN(e.clientY);
+    const cssX = hasOffsetX
+      ? fallback.offsetX!
+      : hasClientX
+        ? e.clientX - rect.left
+        : 0;
+    const cssY = hasOffsetY
+      ? fallback.offsetY!
+      : hasClientY
+        ? e.clientY - rect.top
+        : 0;
+    return {
+      x: (cssX - this.panX) / this.zoom,
+      y: (cssY - this.panY) / this.zoom,
+    };
+  }
+
+  canvasToScreen(x: number, y: number) {
+    return {
+      x: x * this.zoom + this.panX,
+      y: y * this.zoom + this.panY,
+    };
+  }
 
   saveState() {
     this.undoStack.push(
@@ -150,8 +541,21 @@ export class Editor {
   destroy(): void {
     this.currentTool?.destroy?.();
     window.removeEventListener("resize", this.handleResize);
+    window.removeEventListener("keydown", this.handleKeyDown, true);
+    window.removeEventListener("keyup", this.handleKeyUp, true);
     this.canvas.removeEventListener("pointerdown", this.handlePointerDown);
     this.canvas.removeEventListener("pointermove", this.handlePointerMove);
     this.canvas.removeEventListener("pointerup", this.handlePointerUp);
+    this.canvas.removeEventListener("pointercancel", this.handlePointerUp);
+    this.canvas.removeEventListener("pointerleave", this.handlePointerUp);
+    this.canvas.removeEventListener("wheel", this.handleWheel);
+    this.canvas.removeEventListener("contextmenu", this.preventContextMenu);
+    this.viewListeners.clear();
   }
+}
+
+export interface ViewState {
+  zoom: number;
+  panX: number;
+  panY: number;
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,4 +1,4 @@
-import { Editor } from "./core/Editor.js";
+import { Editor, ViewState } from "./core/Editor.js";
 import { Shortcuts } from "./core/Shortcuts.js";
 import { PencilTool } from "./tools/PencilTool.js";
 import { EraserTool } from "./tools/EraserTool.js";
@@ -38,6 +38,13 @@ export function initEditor(): EditorHandle {
   const canvases = Array.from(
     document.querySelectorAll<HTMLCanvasElement>("canvas"),
   );
+
+  const listeners: Array<() => void> = [];
+
+  const createHTMLElement = <T extends HTMLElement>(tag: string): T | null => {
+    const el = document.createElement(tag);
+    return el instanceof HTMLElement ? (el as T) : null;
+  };
 
   const toolConstructors: Record<string, new () => Tool> = {
     pencil: PencilTool,
@@ -116,6 +123,47 @@ export function initEditor(): EditorHandle {
     throw new Error("Missing #formatSelect select");
   }
 
+  const zoomControls = createHTMLElement<HTMLDivElement>("div");
+  const zoomOutBtn = createHTMLElement<HTMLButtonElement>("button");
+  const zoomDisplay = createHTMLElement<HTMLSpanElement>("span");
+  const zoomInBtn = createHTMLElement<HTMLButtonElement>("button");
+  const zoomResetBtn = createHTMLElement<HTMLButtonElement>("button");
+
+  if (zoomControls) {
+    zoomControls.className = "group zoom-controls";
+  }
+  if (zoomOutBtn) {
+    zoomOutBtn.type = "button";
+    zoomOutBtn.className = "tool-button";
+    zoomOutBtn.textContent = "-";
+    zoomOutBtn.title = "Zoom out (Ctrl+-)";
+    zoomOutBtn.setAttribute("aria-label", "Zoom out");
+  }
+  if (zoomDisplay) {
+    zoomDisplay.className = "zoom-display";
+    zoomDisplay.textContent = "100%";
+    zoomDisplay.setAttribute("aria-live", "polite");
+  }
+  if (zoomInBtn) {
+    zoomInBtn.type = "button";
+    zoomInBtn.className = "tool-button";
+    zoomInBtn.textContent = "+";
+    zoomInBtn.title = "Zoom in (Ctrl+=)";
+    zoomInBtn.setAttribute("aria-label", "Zoom in");
+  }
+  if (zoomResetBtn) {
+    zoomResetBtn.type = "button";
+    zoomResetBtn.className = "tool-button";
+    zoomResetBtn.textContent = "Reset";
+    zoomResetBtn.title = "Reset zoom (Ctrl+0)";
+    zoomResetBtn.setAttribute("aria-label", "Reset zoom");
+  }
+
+  if (zoomControls && zoomOutBtn && zoomDisplay && zoomInBtn && zoomResetBtn) {
+    zoomControls.append(zoomOutBtn, zoomDisplay, zoomInBtn, zoomResetBtn);
+    toolbar.appendChild(zoomControls);
+  }
+
   if (layerSelect) {
     layerSelect.innerHTML = "";
   }
@@ -154,7 +202,6 @@ export function initEditor(): EditorHandle {
 
   const undoBtn = document.getElementById("undo") as HTMLButtonElement | null;
   const redoBtn = document.getElementById("redo") as HTMLButtonElement | null;
-  const listeners: Array<() => void> = [];
 
   const recentColors: string[] = [];
   const maxRecentColors = 10;
@@ -194,12 +241,27 @@ export function initEditor(): EditorHandle {
 
   let editor: Editor; // set after editors created
 
+  const updateZoomDisplay = (zoom: number) => {
+    if (zoomDisplay) {
+      zoomDisplay.textContent = `${Math.round(zoom * 100)}%`;
+    }
+  };
+
   const updateHistoryButtons = () => {
     if (undoBtn) undoBtn.disabled = !editor?.canUndo;
     if (redoBtn) redoBtn.disabled = !editor?.canRedo;
   };
 
   const editors: Editor[] = [];
+
+  const syncView = (source: Editor, state: ViewState) => {
+    editors.forEach((target) => {
+      if (target !== source) {
+        target.syncViewState(state);
+      }
+    });
+    updateZoomDisplay(state.zoom);
+  };
   canvases.forEach((c) => {
     try {
       const e = new Editor(
@@ -214,6 +276,8 @@ export function initEditor(): EditorHandle {
         fontSize ?? undefined,
       );
       editors.push(e);
+      const unsubscribe = e.onViewChange((state) => syncView(e, state));
+      listeners.push(unsubscribe);
     } catch {
       /* skip canvases without 2D context */
     }
@@ -238,6 +302,7 @@ export function initEditor(): EditorHandle {
 
   // active editor defaults to the first successfully created editor
   editor = editors[0];
+  updateZoomDisplay(editor.zoomFactor);
 
   // default tool
   editor.setTool(new PencilTool());
@@ -246,6 +311,62 @@ export function initEditor(): EditorHandle {
 
   // keyboard shortcuts
   const shortcuts = new Shortcuts(editor);
+
+  const getCanvasCenter = () => {
+    const rect = editor.canvas.getBoundingClientRect();
+    return { x: rect.width / 2, y: rect.height / 2 };
+  };
+
+  listen(
+    zoomOutBtn,
+    "click",
+    () => {
+      editor.zoomOut(getCanvasCenter());
+    },
+    listeners,
+  );
+
+  listen(
+    zoomInBtn,
+    "click",
+    () => {
+      editor.zoomIn(getCanvasCenter());
+    },
+    listeners,
+  );
+
+  listen(
+    zoomResetBtn,
+    "click",
+    () => {
+      editor.resetView();
+    },
+    listeners,
+  );
+
+  const handleZoomShortcut = (ev: KeyboardEvent) => {
+    if (!(ev.ctrlKey || ev.metaKey)) return;
+    const target = ev.target;
+    if (
+      target instanceof HTMLElement &&
+      target.closest("input, textarea, select, [contenteditable]")
+    ) {
+      return;
+    }
+    const key = ev.key;
+    if (key === "=" || key === "+") {
+      ev.preventDefault();
+      editor.zoomIn(getCanvasCenter());
+    } else if (key === "-") {
+      ev.preventDefault();
+      editor.zoomOut(getCanvasCenter());
+    } else if (key === "0") {
+      ev.preventDefault();
+      editor.resetView();
+    }
+  };
+  document.addEventListener("keydown", handleZoomShortcut);
+  listeners.push(() => document.removeEventListener("keydown", handleZoomShortcut));
 
   // map button id to tool constructor
   Object.entries(toolConstructors).forEach(([id, ToolCtor]) =>
@@ -379,6 +500,7 @@ export function initEditor(): EditorHandle {
     const ToolCtor = editorToolConstructors.get(editor) ?? activeToolCtor;
     editor.setTool(new ToolCtor());
     updateHistoryButtons();
+    updateZoomDisplay(editor.zoomFactor);
     if (layerSelect) layerSelect.value = String(index);
   }
 

--- a/src/tools/BucketFillTool.ts
+++ b/src/tools/BucketFillTool.ts
@@ -19,9 +19,10 @@ export class BucketFillTool implements Tool {
       return;
     }
 
-    const dpr = window.devicePixelRatio || 1;
-    const sx = Math.max(0, Math.min(width - 1, Math.floor(e.offsetX * dpr)));
-    const sy = Math.max(0, Math.min(height - 1, Math.floor(e.offsetY * dpr)));
+    const { x, y } = editor.getCanvasPoint(e);
+    const dpr = editor.pixelRatioValue;
+    const sx = Math.max(0, Math.min(width - 1, Math.floor(x * dpr)));
+    const sy = Math.max(0, Math.min(height - 1, Math.floor(y * dpr)));
     const start = sy * width + sx;
     const targetOffset = start * 4;
     const tr = data[targetOffset];

--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -7,8 +7,9 @@ export class CircleTool extends DrawingTool {
   private imageData: ImageData | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
-    this.startX = e.offsetX;
-    this.startY = e.offsetY;
+    const { x, y } = editor.getCanvasPoint(e);
+    this.startX = x;
+    this.startY = y;
     const ctx = editor.ctx;
     this.applyStroke(ctx, editor);
     if (typeof ctx.getImageData === "function") {
@@ -23,8 +24,9 @@ export class CircleTool extends DrawingTool {
     const ctx = editor.ctx;
     ctx.putImageData(this.imageData, 0, 0);
     this.applyStroke(ctx, editor);
-    const dx = e.offsetX - this.startX;
-    const dy = e.offsetY - this.startY;
+    const { x, y } = editor.getCanvasPoint(e);
+    const dx = x - this.startX;
+    const dy = y - this.startY;
     let radiusX = Math.abs(dx);
     let radiusY = Math.abs(dy);
     if (e.shiftKey) {
@@ -47,8 +49,9 @@ export class CircleTool extends DrawingTool {
       ctx.putImageData(this.imageData, 0, 0);
     }
     this.applyStroke(ctx, editor);
-    const dx = e.offsetX - this.startX;
-    const dy = e.offsetY - this.startY;
+    const { x, y } = editor.getCanvasPoint(e);
+    const dx = x - this.startX;
+    const dy = y - this.startY;
     let radiusX = Math.abs(dx);
     let radiusY = Math.abs(dy);
     if (e.shiftKey) {

--- a/src/tools/DrawingTool.ts
+++ b/src/tools/DrawingTool.ts
@@ -15,7 +15,7 @@ export abstract class DrawingTool implements Tool {
     ctx: CanvasRenderingContext2D,
     editor: Editor,
   ): void {
-    ctx.lineWidth = editor.lineWidthValue;
+    ctx.lineWidth = editor.lineWidthOnCanvas;
     ctx.strokeStyle = editor.strokeStyle;
     ctx.fillStyle = editor.fillStyle;
   }

--- a/src/tools/EraserTool.ts
+++ b/src/tools/EraserTool.ts
@@ -6,28 +6,22 @@ export class EraserTool extends DrawingTool {
     const ctx = editor.ctx;
     ctx.globalCompositeOperation = "destination-out";
     this.applyStroke(ctx, editor);
+    const { x, y } = editor.getCanvasPoint(e);
+    const size = editor.lineWidthOnCanvas;
     ctx.beginPath();
-    ctx.moveTo(e.offsetX, e.offsetY);
-    ctx.clearRect(
-      e.offsetX - editor.lineWidthValue / 2,
-      e.offsetY - editor.lineWidthValue / 2,
-      editor.lineWidthValue,
-      editor.lineWidthValue,
-    );
+    ctx.moveTo(x, y);
+    ctx.clearRect(x - size / 2, y - size / 2, size, size);
   }
 
   onPointerMove(e: PointerEvent, editor: Editor) {
     if (e.buttons !== 1) return;
     const ctx = editor.ctx;
     this.applyStroke(ctx, editor);
-    ctx.lineTo(e.offsetX, e.offsetY);
+    const { x, y } = editor.getCanvasPoint(e);
+    const size = editor.lineWidthOnCanvas;
+    ctx.lineTo(x, y);
     ctx.stroke();
-    ctx.clearRect(
-      e.offsetX - editor.lineWidthValue / 2,
-      e.offsetY - editor.lineWidthValue / 2,
-      editor.lineWidthValue,
-      editor.lineWidthValue,
-    );
+    ctx.clearRect(x - size / 2, y - size / 2, size, size);
   }
 
   onPointerUp(_e: PointerEvent, editor: Editor) {

--- a/src/tools/EyedropperTool.ts
+++ b/src/tools/EyedropperTool.ts
@@ -10,9 +10,10 @@ export class EyedropperTool implements Tool {
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
     const { width, height } = editor.canvas;
-    const dpr = window.devicePixelRatio || 1;
-    const x = Math.max(0, Math.min(width - 1, Math.floor(e.offsetX * dpr)));
-    const y = Math.max(0, Math.min(height - 1, Math.floor(e.offsetY * dpr)));
+    const dpr = editor.pixelRatioValue;
+    const { x: worldX, y: worldY } = editor.getCanvasPoint(e);
+    const x = Math.max(0, Math.min(width - 1, Math.floor(worldX * dpr)));
+    const y = Math.max(0, Math.min(height - 1, Math.floor(worldY * dpr)));
     const { data } = editor.ctx.getImageData(x, y, 1, 1);
     const [r, g, b] = data;
     const toHex = (v: number) => v.toString(16).padStart(2, "0");

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -8,8 +8,9 @@ export class LineTool extends DrawingTool {
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
-    this.startX = e.offsetX;
-    this.startY = e.offsetY;
+    const { x, y } = editor.getCanvasPoint(e);
+    this.startX = x;
+    this.startY = y;
     this.applyStroke(ctx, editor);
     this.imageData = ctx.getImageData(
       0,
@@ -26,8 +27,7 @@ export class LineTool extends DrawingTool {
     this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
-    let x = e.offsetX;
-    let y = e.offsetY;
+    let { x, y } = editor.getCanvasPoint(e);
     if (e.shiftKey) {
       const dx = x - this.startX;
       const dy = y - this.startY;
@@ -50,8 +50,7 @@ export class LineTool extends DrawingTool {
     this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
-    let x = e.offsetX;
-    let y = e.offsetY;
+    let { x, y } = editor.getCanvasPoint(e);
     if (e.shiftKey) {
       const dx = x - this.startX;
       const dy = y - this.startY;

--- a/src/tools/PencilTool.ts
+++ b/src/tools/PencilTool.ts
@@ -5,15 +5,17 @@ export class PencilTool extends DrawingTool {
   onPointerDown(e: PointerEvent, editor: Editor) {
     this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
+    const { x, y } = editor.getCanvasPoint(e);
     ctx.beginPath();
-    ctx.moveTo(e.offsetX, e.offsetY);
+    ctx.moveTo(x, y);
   }
 
   onPointerMove(e: PointerEvent, editor: Editor) {
     if (e.buttons !== 1) return;
     this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
-    ctx.lineTo(e.offsetX, e.offsetY);
+    const { x, y } = editor.getCanvasPoint(e);
+    ctx.lineTo(x, y);
     ctx.stroke();
   }
 

--- a/src/tools/RectangleTool.ts
+++ b/src/tools/RectangleTool.ts
@@ -7,8 +7,9 @@ export class RectangleTool extends DrawingTool {
   private imageData: ImageData | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor) {
-    this.startX = e.offsetX;
-    this.startY = e.offsetY;
+    const { x, y } = editor.getCanvasPoint(e);
+    this.startX = x;
+    this.startY = y;
     this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
     this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
@@ -20,8 +21,7 @@ export class RectangleTool extends DrawingTool {
     ctx.putImageData(this.imageData, 0, 0);
     this.applyStroke(editor.ctx, editor);
 
-    const x = e.offsetX;
-    const y = e.offsetY;
+    const { x, y } = editor.getCanvasPoint(e);
     let width = x - this.startX;
     let height = y - this.startY;
     if (e.shiftKey) {
@@ -42,8 +42,7 @@ export class RectangleTool extends DrawingTool {
     }
 
     this.applyStroke(editor.ctx, editor);
-    const x = e.offsetX;
-    const y = e.offsetY;
+    const { x, y } = editor.getCanvasPoint(e);
     let width = x - this.startX;
     let height = y - this.startY;
     if (e.shiftKey) {

--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -7,16 +7,21 @@ export class TextTool implements Tool {
   keydownListener:
     | ((this: HTMLTextAreaElement, ev: KeyboardEvent) => void)
     | null = null;
+  private viewUnsubscribe: (() => void) | null = null;
+  private anchor: { x: number; y: number } | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
     this.cleanup();
     const textarea = document.createElement("textarea");
     textarea.style.position = "absolute";
     const parent = editor.canvas.parentElement || document.body;
-    textarea.style.left = `${e.offsetX}px`;
-    textarea.style.top = `${e.offsetY}px`;
+    const point = editor.getCanvasPoint(e);
+    this.anchor = point;
+    const screen = editor.canvasToScreen(point.x, point.y);
+    textarea.style.left = `${screen.x}px`;
+    textarea.style.top = `${screen.y}px`;
     textarea.style.color = editor.strokeStyle;
-    textarea.style.fontSize = `${editor.fontSizeValue}px`;
+    textarea.style.fontSize = `${editor.fontSizeValue * editor.zoomFactor}px`;
     textarea.style.fontFamily = editor.fontFamilyValue;
     textarea.style.background = "transparent";
     textarea.style.border = "none";
@@ -26,11 +31,13 @@ export class TextTool implements Tool {
 
     const commit = () => {
       const text = textarea.value;
+      const anchor = this.anchor;
       this.cleanup();
-      if (text) {
+      if (text && anchor) {
         editor.ctx.fillStyle = editor.strokeStyle;
-        editor.ctx.font = `${editor.fontSizeValue}px ${editor.fontFamilyValue}`;
-        editor.ctx.fillText(text, e.offsetX, e.offsetY);
+        const fontSize = editor.fontSizeValue / editor.zoomFactor;
+        editor.ctx.font = `${fontSize}px ${editor.fontFamilyValue}`;
+        editor.ctx.fillText(text, anchor.x, anchor.y);
       }
     };
 
@@ -53,6 +60,13 @@ export class TextTool implements Tool {
     textarea.addEventListener("keydown", this.keydownListener);
 
     this.textarea = textarea;
+    this.viewUnsubscribe = editor.onViewChange((state) => {
+      if (!this.textarea || !this.anchor) return;
+      const screenPos = editor.canvasToScreen(this.anchor.x, this.anchor.y);
+      this.textarea.style.left = `${screenPos.x}px`;
+      this.textarea.style.top = `${screenPos.y}px`;
+      this.textarea.style.fontSize = `${editor.fontSizeValue * state.zoom}px`;
+    });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -79,9 +93,14 @@ export class TextTool implements Tool {
     if (this.keydownListener) {
       this.textarea.removeEventListener("keydown", this.keydownListener);
     }
+    if (this.viewUnsubscribe) {
+      this.viewUnsubscribe();
+      this.viewUnsubscribe = null;
+    }
     this.textarea.remove();
     this.textarea = null;
     this.blurListener = null;
     this.keydownListener = null;
+    this.anchor = null;
   }
 }


### PR DESCRIPTION
## Summary
- add persistent zoom/pan state to the editor, including pinch, wheel, and panning gestures
- surface zoom controls, keyboard shortcuts, and synchronized view state across layers in the UI
- normalize tool coordinate handling so drawing, fill, and text tools respect the current transform

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60d0d6114832888ccbca3ae79bbab