### PR TITLE
Add tool lifecycle hooks and ensure text tool cleanup

### DIFF
--- a/dist/core/Editor.js
+++ b/dist/core/Editor.js
@@ -39,9 +39,13 @@ export class Editor {
         this.canvas.addEventListener("pointerup", this.handlePointerUp);
     }
     setTool(tool) {
-        this.currentTool?.destroy?.();
+        if (this.currentTool === tool) {
+            return;
+        }
+        this.currentTool?.onDeactivate?.(this);
         this.currentTool = tool;
         this.canvas.style.cursor = tool.cursor || "crosshair";
+        this.currentTool.onActivate?.(this);
     }
     adjustForPixelRatio() {
         const dpr = window.devicePixelRatio || 1;
@@ -103,6 +107,7 @@ export class Editor {
      * Should be called before discarding the instance to prevent leaks.
      */
     destroy() {
+        this.currentTool?.onDeactivate?.(this);
         this.currentTool?.destroy?.();
         window.removeEventListener("resize", this.handleResize);
         this.canvas.removeEventListener("pointerdown", this.handlePointerDown);

--- a/dist/tools/TextTool.js
+++ b/dist/tools/TextTool.js
@@ -56,6 +56,9 @@ export class TextTool {
             this.cleanup();
         }
     }
+    onDeactivate(_editor) {
+        this.cleanup();
+    }
     destroy() {
         this.cleanup();
     }

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -41,9 +41,16 @@ export class Editor {
   }
 
   setTool(tool: Tool) {
-    this.currentTool?.destroy?.();
+    if (this.currentTool === tool) {
+      return;
+    }
+
+    this.currentTool?.onDeactivate?.(this);
+
     this.currentTool = tool;
     this.canvas.style.cursor = tool.cursor || "crosshair";
+
+    this.currentTool.onActivate?.(this);
   }
 
   private handlePointerDown = (e: PointerEvent) => {
@@ -148,6 +155,7 @@ export class Editor {
    * Should be called before discarding the instance to prevent leaks.
    */
   destroy(): void {
+    this.currentTool?.onDeactivate?.(this);
     this.currentTool?.destroy?.();
     window.removeEventListener("resize", this.handleResize);
     this.canvas.removeEventListener("pointerdown", this.handlePointerDown);

--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -67,6 +67,10 @@ export class TextTool implements Tool {
     }
   }
 
+  onDeactivate(_editor: Editor): void {
+    this.cleanup();
+  }
+
   destroy(): void {
     this.cleanup();
   }

--- a/src/tools/Tool.ts
+++ b/src/tools/Tool.ts
@@ -1,9 +1,53 @@
 import { Editor } from "../core/Editor.js";
 
+/**
+ * Contract implemented by every editor tool.
+ *
+ * Tools can participate in a simple lifecycle in addition to responding to
+ * pointer events. When a tool is selected via {@link Editor.setTool} the
+ * following flow occurs:
+ *
+ * 1. The previously active tool receives {@link Tool.onDeactivate}.
+ * 2. The new tool is assigned and receives {@link Tool.onActivate}.
+ * 3. Pointer events are forwarded to the active tool until another tool is
+ *    chosen.
+ * 4. When the editor itself is destroyed the current tool receives
+ *    {@link Tool.onDeactivate} (if it has not already) followed by
+ *    {@link Tool.destroy}.
+ *
+ * Implementations that attach DOM listeners or allocate resources should tear
+ * them down inside {@link Tool.onDeactivate} so switching away from the tool
+ * does not leak resources. {@link Tool.destroy} acts as a finalizer for
+ * releasing anything that outlives a single activation.
+ */
 export interface Tool {
+  /** Optional cursor that should be displayed while the tool is active. */
   cursor?: string;
+
+  /**
+   * Invoked immediately after the tool becomes the active tool for an editor.
+   * Ideal for setting up listeners that depend on the editor state.
+   */
+  onActivate?(editor: Editor): void;
+
+  /** Handle pointer down events occurring on the editor's canvas. */
   onPointerDown(e: PointerEvent, editor: Editor): void;
+
+  /** Handle pointer move events occurring on the editor's canvas. */
   onPointerMove(e: PointerEvent, editor: Editor): void;
+
+  /** Handle pointer up events occurring on the editor's canvas. */
   onPointerUp(e: PointerEvent, editor: Editor): void;
+
+  /**
+   * Called when the tool is replaced by another tool. Implementations should
+   * clean up DOM listeners or transient resources created during activation.
+   */
+  onDeactivate?(editor: Editor): void;
+
+  /**
+   * Final teardown hook invoked when the tool is permanently discarded. Any
+   * remaining resources should be released here.
+   */
   destroy?(): void;
 }


### PR DESCRIPTION
## Summary
- document the Tool interface lifecycle and add optional activate/deactivate hooks
- update the editor to honour the new lifecycle callbacks and refresh compiled outputs
- ensure the text tool removes DOM listeners when deactivated and rebuild distribution files

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60d0a6b8883289bf5e4d85569ea31