### PR TITLE
Normalize pointer handling with a shared DPR service

### DIFF
--- a/src/core/DevicePixelRatioService.ts
+++ b/src/core/DevicePixelRatioService.ts
@@ -1,0 +1,234 @@
+export interface NormalizedPointerEvent {
+  /**
+   * The original pointer event. Consumers should inspect this for modifier
+   * keys, button state, etc.
+   */
+  readonly originalEvent: PointerEvent;
+  /** Logical canvas X coordinate expressed in CSS pixels. */
+  readonly x: number;
+  /** Logical canvas Y coordinate expressed in CSS pixels. */
+  readonly y: number;
+  /** Device pixel X coordinate clamped to the canvas width. */
+  readonly deviceX: number;
+  /** Device pixel Y coordinate clamped to the canvas height. */
+  readonly deviceY: number;
+}
+
+interface WorkerLike {
+  postMessage(message: unknown): void;
+}
+
+export interface CanvasDprHandle {
+  readonly canvas: HTMLCanvasElement;
+  readonly context: CanvasRenderingContext2D;
+  readonly dpr: number;
+  resize(): void;
+  normalizeEvent(event: PointerEvent): NormalizedPointerEvent;
+  destroy(): void;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Service that centralizes device-pixel-ratio management for one or more
+ * canvases. It keeps contexts scaled appropriately, exposes helpers for
+ * pointer-event normalization, and can broadcast DPR changes to workers.
+ */
+export class DevicePixelRatioService {
+  private readonly win: Window;
+  private readonly canvases = new Set<CanvasRegistration>();
+  private readonly workers = new Set<WorkerLike>();
+  private readonly resizeListener: () => void;
+  private dpr: number;
+
+  constructor(win: Window = window) {
+    this.win = win;
+    this.dpr = this.readDevicePixelRatio();
+    this.resizeListener = () => this.handleResize();
+    this.win.addEventListener("resize", this.resizeListener);
+  }
+
+  /** The active device pixel ratio used by the service. */
+  get devicePixelRatio(): number {
+    return this.dpr;
+  }
+
+  /** Register a worker-like object to receive DPR updates. */
+  registerWorker(worker: WorkerLike): () => void {
+    this.workers.add(worker);
+    this.sendDpr(worker);
+    return () => {
+      this.workers.delete(worker);
+    };
+  }
+
+  /** Register a canvas/context pair with the service. */
+  registerCanvas(
+    canvas: HTMLCanvasElement,
+    context: CanvasRenderingContext2D,
+  ): CanvasDprHandle {
+    const registration = new CanvasRegistration(this, canvas, context);
+    this.canvases.add(registration);
+    registration.resize();
+    return registration;
+  }
+
+  /** Stop managing canvases and remove window listeners. */
+  destroy(): void {
+    this.win.removeEventListener("resize", this.resizeListener);
+    this.canvases.forEach((registration) => registration.disposeInternal());
+    this.canvases.clear();
+    this.workers.clear();
+  }
+
+  private unregister(registration: CanvasRegistration): void {
+    this.canvases.delete(registration);
+  }
+
+  private readDevicePixelRatio(): number {
+    return Number(this.win.devicePixelRatio) || 1;
+  }
+
+  private handleResize(): void {
+    const next = this.readDevicePixelRatio();
+    const changed = next !== this.dpr;
+    if (changed) {
+      this.dpr = next;
+    }
+    this.canvases.forEach((registration) => registration.resize());
+    if (changed) {
+      this.broadcastDpr();
+    }
+  }
+
+  private applyToCanvas(
+    canvas: HTMLCanvasElement,
+    context: CanvasRenderingContext2D,
+  ): void {
+    const rect = canvas.getBoundingClientRect();
+    const width = Math.max(1, Math.round(rect.width * this.dpr));
+    const height = Math.max(1, Math.round(rect.height * this.dpr));
+    if (canvas.width !== width) {
+      canvas.width = width;
+    }
+    if (canvas.height !== height) {
+      canvas.height = height;
+    }
+    context.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
+  }
+
+  private normalizePointer(
+    canvas: HTMLCanvasElement,
+    event: PointerEvent,
+  ): NormalizedPointerEvent {
+    const rect = canvas.getBoundingClientRect();
+    const relativeX = (event.clientX ?? NaN) - rect.left;
+    const relativeY = (event.clientY ?? NaN) - rect.top;
+    const hasClient = Number.isFinite(relativeX) && Number.isFinite(relativeY);
+
+    const logicalX = clamp(
+      hasClient
+        ? relativeX
+        : typeof event.offsetX === "number"
+          ? event.offsetX
+          : 0,
+      0,
+      rect.width,
+    );
+    const logicalY = clamp(
+      hasClient
+        ? relativeY
+        : typeof event.offsetY === "number"
+          ? event.offsetY
+          : 0,
+      0,
+      rect.height,
+    );
+
+    const deviceX = clamp(
+      Math.round(logicalX * this.dpr),
+      0,
+      Math.max(0, canvas.width - 1),
+    );
+    const deviceY = clamp(
+      Math.round(logicalY * this.dpr),
+      0,
+      Math.max(0, canvas.height - 1),
+    );
+
+    return {
+      originalEvent: event,
+      x: logicalX,
+      y: logicalY,
+      deviceX,
+      deviceY,
+    };
+  }
+
+  private broadcastDpr(): void {
+    this.workers.forEach((worker) => this.sendDpr(worker));
+  }
+
+  private sendDpr(worker: WorkerLike): void {
+    worker.postMessage({ type: "dpr:update", value: this.dpr });
+  }
+
+  normalizeFor(
+    registration: CanvasRegistration,
+    event: PointerEvent,
+  ): NormalizedPointerEvent {
+    if (!registration.isDisposed()) {
+      this.applyToCanvas(registration.canvas, registration.context);
+    }
+    return this.normalizePointer(registration.canvas, event);
+  }
+
+  resizeFor(registration: CanvasRegistration): void {
+    if (registration.isDisposed()) return;
+    this.applyToCanvas(registration.canvas, registration.context);
+  }
+
+  destroyRegistration(registration: CanvasRegistration): void {
+    registration.disposeInternal();
+    this.unregister(registration);
+  }
+}
+
+class CanvasRegistration implements CanvasDprHandle {
+  private disposed = false;
+
+  constructor(
+    private readonly service: DevicePixelRatioService,
+    public readonly canvas: HTMLCanvasElement,
+    public readonly context: CanvasRenderingContext2D,
+  ) {}
+
+  get dpr(): number {
+    return this.service.devicePixelRatio;
+  }
+
+  resize(): void {
+    if (this.disposed) return;
+    this.service.resizeFor(this);
+  }
+
+  normalizeEvent(event: PointerEvent): NormalizedPointerEvent {
+    return this.service.normalizeFor(this, event);
+  }
+
+  destroy(): void {
+    if (this.disposed) return;
+    this.service.destroyRegistration(this);
+  }
+
+  disposeInternal(): void {
+    this.disposed = true;
+  }
+
+  isDisposed(): boolean {
+    return this.disposed;
+  }
+}
+

--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -1,4 +1,9 @@
 import { Tool } from "../tools/Tool.js";
+import {
+  CanvasDprHandle,
+  DevicePixelRatioService,
+  NormalizedPointerEvent,
+} from "./DevicePixelRatioService.js";
 
 export class Editor {
   canvas: HTMLCanvasElement;
@@ -6,6 +11,8 @@ export class Editor {
   private undoStack: ImageData[] = [];
   private redoStack: ImageData[] = [];
   private currentTool: Tool | null = null;
+  private readonly dprHandle: CanvasDprHandle;
+  private readonly ownedDprService?: DevicePixelRatioService;
   colorPicker: HTMLInputElement;
   lineWidth: HTMLInputElement;
   fillMode: HTMLInputElement;
@@ -21,6 +28,7 @@ export class Editor {
     onChange?: () => void,
     fontFamily?: HTMLSelectElement | null,
     fontSize?: HTMLInputElement | null,
+    devicePixelRatioService?: DevicePixelRatioService,
   ) {
     this.canvas = canvas;
     const ctx = canvas.getContext("2d");
@@ -32,8 +40,11 @@ export class Editor {
     this.onChange = onChange;
     this.fontFamily = fontFamily ?? null;
     this.fontSize = fontSize ?? null;
-    this.adjustForPixelRatio();
-    window.addEventListener("resize", this.handleResize);
+    const service = devicePixelRatioService ?? new DevicePixelRatioService();
+    if (!devicePixelRatioService) {
+      this.ownedDprService = service;
+    }
+    this.dprHandle = service.registerCanvas(canvas, ctx);
 
     this.canvas.addEventListener("pointerdown", this.handlePointerDown);
     this.canvas.addEventListener("pointermove", this.handlePointerMove);
@@ -62,26 +73,9 @@ export class Editor {
     this.canvas.releasePointerCapture(e.pointerId);
   };
 
-  private adjustForPixelRatio() {
-    const dpr = window.devicePixelRatio || 1;
-    const rect = this.canvas.getBoundingClientRect();
-    this.canvas.width = rect.width * dpr;
-    this.canvas.height = rect.height * dpr;
-    this.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-    // Reset any existing transforms
-    this.ctx.scale(1, 1);
+  normalizeEvent(event: PointerEvent): NormalizedPointerEvent {
+    return this.dprHandle.normalizeEvent(event);
   }
-
-  private handleResize = () => {
-    const data = this.ctx.getImageData(
-      0,
-      0,
-      this.canvas.width,
-      this.canvas.height,
-    );
-    this.adjustForPixelRatio();
-    this.ctx.putImageData(data, 0, 0);
-  };
 
   saveState() {
     this.undoStack.push(
@@ -149,9 +143,10 @@ export class Editor {
    */
   destroy(): void {
     this.currentTool?.destroy?.();
-    window.removeEventListener("resize", this.handleResize);
     this.canvas.removeEventListener("pointerdown", this.handlePointerDown);
     this.canvas.removeEventListener("pointermove", this.handlePointerMove);
     this.canvas.removeEventListener("pointerup", this.handlePointerUp);
+    this.dprHandle.destroy();
+    this.ownedDprService?.destroy();
   }
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,4 +1,5 @@
 import { Editor } from "./core/Editor.js";
+import { DevicePixelRatioService } from "./core/DevicePixelRatioService.js";
 import { Shortcuts } from "./core/Shortcuts.js";
 import { PencilTool } from "./tools/PencilTool.js";
 import { EraserTool } from "./tools/EraserTool.js";
@@ -199,6 +200,7 @@ export function initEditor(): EditorHandle {
     if (redoBtn) redoBtn.disabled = !editor?.canRedo;
   };
 
+  const dprService = new DevicePixelRatioService();
   const editors: Editor[] = [];
   canvases.forEach((c) => {
     try {
@@ -212,6 +214,7 @@ export function initEditor(): EditorHandle {
         },
         fontFamily ?? undefined,
         fontSize ?? undefined,
+        dprService,
       );
       editors.push(e);
     } catch {
@@ -390,6 +393,7 @@ export function initEditor(): EditorHandle {
       listeners.forEach((fn) => fn());
       shortcuts.destroy();
       editors.forEach((e) => e.destroy());
+      dprService.destroy();
     },
   };
   recordColor(colorPicker.value);

--- a/src/tools/BucketFillTool.ts
+++ b/src/tools/BucketFillTool.ts
@@ -19,9 +19,9 @@ export class BucketFillTool implements Tool {
       return;
     }
 
-    const dpr = window.devicePixelRatio || 1;
-    const sx = Math.max(0, Math.min(width - 1, Math.floor(e.offsetX * dpr)));
-    const sy = Math.max(0, Math.min(height - 1, Math.floor(e.offsetY * dpr)));
+    const { deviceX, deviceY } = editor.normalizeEvent(e);
+    const sx = Math.max(0, Math.min(width - 1, Math.floor(deviceX)));
+    const sy = Math.max(0, Math.min(height - 1, Math.floor(deviceY)));
     const start = sy * width + sx;
     const targetOffset = start * 4;
     const tr = data[targetOffset];

--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -7,8 +7,9 @@ export class CircleTool extends DrawingTool {
   private imageData: ImageData | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
-    this.startX = e.offsetX;
-    this.startY = e.offsetY;
+    const { x, y } = editor.normalizeEvent(e);
+    this.startX = x;
+    this.startY = y;
     const ctx = editor.ctx;
     this.applyStroke(ctx, editor);
     if (typeof ctx.getImageData === "function") {
@@ -23,8 +24,9 @@ export class CircleTool extends DrawingTool {
     const ctx = editor.ctx;
     ctx.putImageData(this.imageData, 0, 0);
     this.applyStroke(ctx, editor);
-    const dx = e.offsetX - this.startX;
-    const dy = e.offsetY - this.startY;
+    const normalized = editor.normalizeEvent(e);
+    const dx = normalized.x - this.startX;
+    const dy = normalized.y - this.startY;
     let radiusX = Math.abs(dx);
     let radiusY = Math.abs(dy);
     if (e.shiftKey) {
@@ -47,8 +49,9 @@ export class CircleTool extends DrawingTool {
       ctx.putImageData(this.imageData, 0, 0);
     }
     this.applyStroke(ctx, editor);
-    const dx = e.offsetX - this.startX;
-    const dy = e.offsetY - this.startY;
+    const normalized = editor.normalizeEvent(e);
+    const dx = normalized.x - this.startX;
+    const dy = normalized.y - this.startY;
     let radiusX = Math.abs(dx);
     let radiusY = Math.abs(dy);
     if (e.shiftKey) {

--- a/src/tools/EraserTool.ts
+++ b/src/tools/EraserTool.ts
@@ -6,11 +6,12 @@ export class EraserTool extends DrawingTool {
     const ctx = editor.ctx;
     ctx.globalCompositeOperation = "destination-out";
     this.applyStroke(ctx, editor);
+    const { x, y } = editor.normalizeEvent(e);
     ctx.beginPath();
-    ctx.moveTo(e.offsetX, e.offsetY);
+    ctx.moveTo(x, y);
     ctx.clearRect(
-      e.offsetX - editor.lineWidthValue / 2,
-      e.offsetY - editor.lineWidthValue / 2,
+      x - editor.lineWidthValue / 2,
+      y - editor.lineWidthValue / 2,
       editor.lineWidthValue,
       editor.lineWidthValue,
     );
@@ -20,11 +21,12 @@ export class EraserTool extends DrawingTool {
     if (e.buttons !== 1) return;
     const ctx = editor.ctx;
     this.applyStroke(ctx, editor);
-    ctx.lineTo(e.offsetX, e.offsetY);
+    const { x, y } = editor.normalizeEvent(e);
+    ctx.lineTo(x, y);
     ctx.stroke();
     ctx.clearRect(
-      e.offsetX - editor.lineWidthValue / 2,
-      e.offsetY - editor.lineWidthValue / 2,
+      x - editor.lineWidthValue / 2,
+      y - editor.lineWidthValue / 2,
       editor.lineWidthValue,
       editor.lineWidthValue,
     );

--- a/src/tools/EyedropperTool.ts
+++ b/src/tools/EyedropperTool.ts
@@ -10,9 +10,9 @@ export class EyedropperTool implements Tool {
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
     const { width, height } = editor.canvas;
-    const dpr = window.devicePixelRatio || 1;
-    const x = Math.max(0, Math.min(width - 1, Math.floor(e.offsetX * dpr)));
-    const y = Math.max(0, Math.min(height - 1, Math.floor(e.offsetY * dpr)));
+    const { deviceX, deviceY } = editor.normalizeEvent(e);
+    const x = Math.max(0, Math.min(width - 1, Math.floor(deviceX)));
+    const y = Math.max(0, Math.min(height - 1, Math.floor(deviceY)));
     const { data } = editor.ctx.getImageData(x, y, 1, 1);
     const [r, g, b] = data;
     const toHex = (v: number) => v.toString(16).padStart(2, "0");

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -8,8 +8,9 @@ export class LineTool extends DrawingTool {
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
     const ctx = editor.ctx;
-    this.startX = e.offsetX;
-    this.startY = e.offsetY;
+    const { x, y } = editor.normalizeEvent(e);
+    this.startX = x;
+    this.startY = y;
     this.applyStroke(ctx, editor);
     this.imageData = ctx.getImageData(
       0,
@@ -26,8 +27,9 @@ export class LineTool extends DrawingTool {
     this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
-    let x = e.offsetX;
-    let y = e.offsetY;
+    const normalized = editor.normalizeEvent(e);
+    let x = normalized.x;
+    let y = normalized.y;
     if (e.shiftKey) {
       const dx = x - this.startX;
       const dy = y - this.startY;
@@ -50,8 +52,9 @@ export class LineTool extends DrawingTool {
     this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
-    let x = e.offsetX;
-    let y = e.offsetY;
+    const normalized = editor.normalizeEvent(e);
+    let x = normalized.x;
+    let y = normalized.y;
     if (e.shiftKey) {
       const dx = x - this.startX;
       const dy = y - this.startY;

--- a/src/tools/PencilTool.ts
+++ b/src/tools/PencilTool.ts
@@ -5,15 +5,17 @@ export class PencilTool extends DrawingTool {
   onPointerDown(e: PointerEvent, editor: Editor) {
     this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
+    const { x, y } = editor.normalizeEvent(e);
     ctx.beginPath();
-    ctx.moveTo(e.offsetX, e.offsetY);
+    ctx.moveTo(x, y);
   }
 
   onPointerMove(e: PointerEvent, editor: Editor) {
     if (e.buttons !== 1) return;
     this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
-    ctx.lineTo(e.offsetX, e.offsetY);
+    const { x, y } = editor.normalizeEvent(e);
+    ctx.lineTo(x, y);
     ctx.stroke();
   }
 

--- a/src/tools/RectangleTool.ts
+++ b/src/tools/RectangleTool.ts
@@ -7,8 +7,9 @@ export class RectangleTool extends DrawingTool {
   private imageData: ImageData | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor) {
-    this.startX = e.offsetX;
-    this.startY = e.offsetY;
+    const { x, y } = editor.normalizeEvent(e);
+    this.startX = x;
+    this.startY = y;
     this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
     this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
@@ -20,8 +21,7 @@ export class RectangleTool extends DrawingTool {
     ctx.putImageData(this.imageData, 0, 0);
     this.applyStroke(editor.ctx, editor);
 
-    const x = e.offsetX;
-    const y = e.offsetY;
+    const { x, y } = editor.normalizeEvent(e);
     let width = x - this.startX;
     let height = y - this.startY;
     if (e.shiftKey) {
@@ -42,8 +42,7 @@ export class RectangleTool extends DrawingTool {
     }
 
     this.applyStroke(editor.ctx, editor);
-    const x = e.offsetX;
-    const y = e.offsetY;
+    const { x, y } = editor.normalizeEvent(e);
     let width = x - this.startX;
     let height = y - this.startY;
     if (e.shiftKey) {

--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -13,8 +13,9 @@ export class TextTool implements Tool {
     const textarea = document.createElement("textarea");
     textarea.style.position = "absolute";
     const parent = editor.canvas.parentElement || document.body;
-    textarea.style.left = `${e.offsetX}px`;
-    textarea.style.top = `${e.offsetY}px`;
+    const { x, y } = editor.normalizeEvent(e);
+    textarea.style.left = `${x}px`;
+    textarea.style.top = `${y}px`;
     textarea.style.color = editor.strokeStyle;
     textarea.style.fontSize = `${editor.fontSizeValue}px`;
     textarea.style.fontFamily = editor.fontFamilyValue;
@@ -30,7 +31,7 @@ export class TextTool implements Tool {
       if (text) {
         editor.ctx.fillStyle = editor.strokeStyle;
         editor.ctx.font = `${editor.fontSizeValue}px ${editor.fontFamilyValue}`;
-        editor.ctx.fillText(text, e.offsetX, e.offsetY);
+        editor.ctx.fillText(text, x, y);
       }
     };
 

--- a/tests/bucketFillTool.test.ts
+++ b/tests/bucketFillTool.test.ts
@@ -1,3 +1,4 @@
+import { DevicePixelRatioService } from "../src/core/DevicePixelRatioService.js";
 import { Editor } from "../src/core/Editor.js";
 import { BucketFillTool } from "../src/tools/BucketFillTool.js";
 
@@ -5,6 +6,7 @@ describe("BucketFillTool", () => {
   let canvas: HTMLCanvasElement;
   let ctx: Partial<CanvasRenderingContext2D>;
   let editor: Editor;
+  let dprService: DevicePixelRatioService;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -39,18 +41,41 @@ describe("BucketFillTool", () => {
       scale: jest.fn(),
     };
     canvas.getContext = jest.fn().mockReturnValue(ctx as CanvasRenderingContext2D);
+    canvas.getBoundingClientRect = () => ({
+      width: 100,
+      height: 100,
+      top: 0,
+      left: 0,
+      bottom: 100,
+      right: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
 
+    dprService = new DevicePixelRatioService();
     editor = new Editor(
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
       document.getElementById("fillMode") as HTMLInputElement,
+      undefined,
+      undefined,
+      dprService,
     );
+  });
+
+  afterEach(() => {
+    editor.destroy();
+    dprService.destroy();
   });
 
   it("fills enclosed areas with the selected color", () => {
     const tool = new BucketFillTool();
-    tool.onPointerDown({ offsetX: 2, offsetY: 2 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 2, offsetY: 2, clientX: 2, clientY: 2 } as PointerEvent,
+      editor,
+    );
 
     const image = (ctx.getImageData as jest.Mock).mock.results[0].value as ImageData;
     const center = (2 * 5 + 2) * 4;
@@ -81,7 +106,10 @@ describe("BucketFillTool", () => {
     (ctx.getImageData as jest.Mock).mockReturnValueOnce(image);
 
     const tool = new BucketFillTool();
-    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 0, offsetY: 0, clientX: 0, clientY: 0 } as PointerEvent,
+      editor,
+    );
 
     const last = (width * height - 1) * 4;
     expect(image.data[last]).toBe(0);

--- a/tests/circleTool.test.ts
+++ b/tests/circleTool.test.ts
@@ -1,9 +1,11 @@
+import { DevicePixelRatioService } from "../src/core/DevicePixelRatioService.js";
 import { Editor } from "../src/core/Editor.js";
 import { CircleTool } from "../src/tools/CircleTool.js";
 
 describe("CircleTool", () => {
   let editor: Editor;
   let ctx: Partial<CanvasRenderingContext2D>;
+  let dprService: DevicePixelRatioService;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -30,20 +32,45 @@ describe("CircleTool", () => {
     canvas.getContext = jest
       .fn()
       .mockReturnValue(ctx as CanvasRenderingContext2D);
+    canvas.getBoundingClientRect = () => ({
+      width: 100,
+      height: 100,
+      top: 0,
+      left: 0,
+      bottom: 100,
+      right: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+    dprService = new DevicePixelRatioService();
     editor = new Editor(
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
       document.getElementById("fillMode") as HTMLInputElement,
+      undefined,
+      undefined,
+      dprService,
     );
+  });
+
+  afterEach(() => {
+    editor.destroy();
+    dprService.destroy();
   });
 
   it("previews circle during pointer move", () => {
     const tool = new CircleTool();
-    tool.onPointerDown({ offsetX: 2, offsetY: 3 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 2, offsetY: 3, clientX: 2, clientY: 3 } as PointerEvent,
+      editor,
+    );
     tool.onPointerMove({
       offsetX: 5,
       offsetY: 7,
+      clientX: 5,
+      clientY: 7,
       buttons: 1,
     } as PointerEvent, editor);
 
@@ -63,15 +90,33 @@ describe("CircleTool", () => {
   it("fills circle on pointer up when enabled", () => {
     const tool = new CircleTool();
     (document.getElementById("fillMode") as HTMLInputElement).checked = true;
-    tool.onPointerDown({ offsetX: 2, offsetY: 3 } as PointerEvent, editor);
-    tool.onPointerUp({ offsetX: 5, offsetY: 7 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 2, offsetY: 3, clientX: 2, clientY: 3 } as PointerEvent,
+      editor,
+    );
+    tool.onPointerUp(
+      { offsetX: 5, offsetY: 7, clientX: 5, clientY: 7 } as PointerEvent,
+      editor,
+    );
     expect(ctx.fill).toHaveBeenCalled();
   });
 
   it("constrains to a circle when shift is held", () => {
     const tool = new CircleTool();
-    tool.onPointerDown({ offsetX: 2, offsetY: 3 } as PointerEvent, editor);
-    tool.onPointerUp({ offsetX: 5, offsetY: 7, shiftKey: true } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 2, offsetY: 3, clientX: 2, clientY: 3 } as PointerEvent,
+      editor,
+    );
+    tool.onPointerUp(
+      {
+        offsetX: 5,
+        offsetY: 7,
+        clientX: 5,
+        clientY: 7,
+        shiftKey: true,
+      } as PointerEvent,
+      editor,
+    );
     const dx = 5 - 2;
     const dy = 7 - 3;
     const radius = Math.max(Math.abs(dx), Math.abs(dy));

--- a/tests/colorRendering.test.ts
+++ b/tests/colorRendering.test.ts
@@ -1,3 +1,4 @@
+import { DevicePixelRatioService } from "../src/core/DevicePixelRatioService.js";
 import { Editor } from "../src/core/Editor.js";
 import { PencilTool } from "../src/tools/PencilTool.js";
 import { RectangleTool } from "../src/tools/RectangleTool.js";
@@ -10,6 +11,7 @@ describe("color rendering", () => {
     lineWidth: number;
   };
   let editor: Editor;
+  let dprService: DevicePixelRatioService;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -48,46 +50,63 @@ describe("color rendering", () => {
 
     canvas.getContext = jest.fn().mockReturnValue(ctx);
     canvas.getBoundingClientRect = () => ({
-      width: 0,
-      height: 0,
+      width: 100,
+      height: 100,
       left: 0,
       top: 0,
-      right: 0,
-      bottom: 0,
+      right: 100,
+      bottom: 100,
       x: 0,
       y: 0,
       toJSON: () => {},
     });
 
+    dprService = new DevicePixelRatioService();
     editor = new Editor(
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
       document.getElementById("fillMode") as HTMLInputElement,
+      undefined,
+      undefined,
+      dprService,
     );
   });
 
   afterEach(() => {
     editor.destroy();
+    dprService.destroy();
   });
 
   it("uses the selected color for strokes and fills", () => {
     const colorPicker = document.getElementById("colorPicker") as HTMLInputElement;
 
     const pencil = new PencilTool();
-    pencil.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+    pencil.onPointerDown(
+      { offsetX: 0, offsetY: 0, clientX: 0, clientY: 0 } as PointerEvent,
+      editor,
+    );
     expect(ctx.strokeStyle).toBe("#111111");
 
     colorPicker.value = "#ff0000";
-    pencil.onPointerDown({ offsetX: 1, offsetY: 1 } as PointerEvent, editor);
+    pencil.onPointerDown(
+      { offsetX: 1, offsetY: 1, clientX: 1, clientY: 1 } as PointerEvent,
+      editor,
+    );
     expect(ctx.strokeStyle).toBe("#ff0000");
 
     const fillMode = document.getElementById("fillMode") as HTMLInputElement;
     fillMode.checked = true;
     colorPicker.value = "#00ff00";
     const rect = new RectangleTool();
-    rect.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
-    rect.onPointerUp({ offsetX: 2, offsetY: 2 } as PointerEvent, editor);
+    rect.onPointerDown(
+      { offsetX: 0, offsetY: 0, clientX: 0, clientY: 0 } as PointerEvent,
+      editor,
+    );
+    rect.onPointerUp(
+      { offsetX: 2, offsetY: 2, clientX: 2, clientY: 2 } as PointerEvent,
+      editor,
+    );
     expect(ctx.strokeStyle).toBe("#00ff00");
     expect(ctx.fillStyle).toBe("#00ff00");
   });

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -84,6 +84,8 @@ describe("editor toolbar controls", () => {
     const event = new MouseEvent(type, { bubbles: true } as MouseEventInit);
     Object.defineProperty(event, "offsetX", { value: x });
     Object.defineProperty(event, "offsetY", { value: y });
+    Object.defineProperty(event, "clientX", { value: x });
+    Object.defineProperty(event, "clientY", { value: y });
     Object.defineProperty(event, "buttons", { value: buttons });
     Object.defineProperty(event, "pointerId", { value: 1 });
     canvas.dispatchEvent(event);

--- a/tests/eraserTool.test.ts
+++ b/tests/eraserTool.test.ts
@@ -1,9 +1,11 @@
+import { DevicePixelRatioService } from "../src/core/DevicePixelRatioService.js";
 import { Editor } from "../src/core/Editor.js";
 import { EraserTool } from "../src/tools/EraserTool.js";
 
 describe("EraserTool", () => {
   let editor: Editor;
   let ctx: Partial<CanvasRenderingContext2D>;
+  let dprService: DevicePixelRatioService;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -30,21 +32,50 @@ describe("EraserTool", () => {
     canvas.getContext = jest
       .fn()
       .mockReturnValue(ctx as CanvasRenderingContext2D);
+    canvas.getBoundingClientRect = () => ({
+      width: 100,
+      height: 100,
+      top: 0,
+      left: 0,
+      bottom: 100,
+      right: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+    dprService = new DevicePixelRatioService();
     editor = new Editor(
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
       document.getElementById("fillMode") as HTMLInputElement,
+      undefined,
+      undefined,
+      dprService,
     );
+  });
+
+  afterEach(() => {
+    editor.destroy();
+    dprService.destroy();
   });
 
   it("uses destination-out compositing to erase", () => {
     const tool = new EraserTool();
-    tool.onPointerDown({ offsetX: 5, offsetY: 5 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 5, offsetY: 5, clientX: 5, clientY: 5 } as PointerEvent,
+      editor,
+    );
     expect(ctx.globalCompositeOperation).toBe("destination-out");
 
     tool.onPointerMove(
-      { offsetX: 10, offsetY: 10, buttons: 1 } as PointerEvent,
+      {
+        offsetX: 10,
+        offsetY: 10,
+        clientX: 10,
+        clientY: 10,
+        buttons: 1,
+      } as PointerEvent,
       editor,
     );
     expect(ctx.lineTo).toHaveBeenCalledWith(10, 10);
@@ -57,7 +88,10 @@ describe("EraserTool", () => {
 
   it("restores compositing mode on pointer up", () => {
     const tool = new EraserTool();
-    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 0, offsetY: 0, clientX: 0, clientY: 0 } as PointerEvent,
+      editor,
+    );
     expect(ctx.globalCompositeOperation).toBe("destination-out");
 
     tool.onPointerUp({} as PointerEvent, editor);

--- a/tests/eyedropperTool.test.ts
+++ b/tests/eyedropperTool.test.ts
@@ -1,3 +1,4 @@
+import { DevicePixelRatioService } from "../src/core/DevicePixelRatioService.js";
 import { Editor } from "../src/core/Editor.js";
 import { EyedropperTool } from "../src/tools/EyedropperTool.js";
 import { initEditor, type EditorHandle } from "../src/editor.js";
@@ -6,6 +7,7 @@ describe("EyedropperTool", () => {
   let canvas: HTMLCanvasElement;
   let editor: Editor;
   let ctx: Partial<CanvasRenderingContext2D>;
+  let dprService: DevicePixelRatioService;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -24,27 +26,39 @@ describe("EyedropperTool", () => {
     };
     canvas.getContext = jest.fn().mockReturnValue(ctx as CanvasRenderingContext2D);
     canvas.getBoundingClientRect = () => ({
-      width: 0,
-      height: 0,
+      width: 100,
+      height: 100,
       left: 0,
       top: 0,
-      right: 0,
-      bottom: 0,
+      right: 100,
+      bottom: 100,
       x: 0,
       y: 0,
       toJSON: () => {},
     });
+    dprService = new DevicePixelRatioService();
     editor = new Editor(
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
       document.getElementById("fillMode") as HTMLInputElement,
+      undefined,
+      undefined,
+      dprService,
     );
+  });
+
+  afterEach(() => {
+    editor.destroy();
+    dprService.destroy();
   });
 
   it("updates the color picker based on canvas pixel", () => {
     const tool = new EyedropperTool();
-    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 0, offsetY: 0, clientX: 0, clientY: 0 } as PointerEvent,
+      editor,
+    );
     expect(editor.colorPicker.value).toBe("#0c2238");
   });
 
@@ -76,7 +90,10 @@ describe("EyedropperTool", () => {
       recordColor(colorPicker.value);
     });
 
-    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 0, offsetY: 0, clientX: 0, clientY: 0 } as PointerEvent,
+      editor,
+    );
 
     expect(recentColors[0]).toBe("#0c2238");
     expect(colorHistory.children).toHaveLength(1);
@@ -140,7 +157,10 @@ describe("EyedropperTool color history", () => {
     const history = document.getElementById("colorHistory") as HTMLDivElement;
     expect(history.children).toHaveLength(1);
     const tool = new EyedropperTool();
-    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, handle.editor);
+    tool.onPointerDown(
+      { offsetX: 0, offsetY: 0, clientX: 0, clientY: 0 } as PointerEvent,
+      handle.editor,
+    );
     expect(history.children).toHaveLength(2);
     const swatch = history.children[0] as HTMLButtonElement;
     expect(swatch.style.backgroundColor).toBe("rgb(12, 34, 56)");

--- a/tests/lineTool.test.ts
+++ b/tests/lineTool.test.ts
@@ -1,9 +1,11 @@
+import { DevicePixelRatioService } from "../src/core/DevicePixelRatioService.js";
 import { Editor } from "../src/core/Editor.js";
 import { LineTool } from "../src/tools/LineTool.js";
 
 describe("LineTool", () => {
   let editor: Editor;
   let ctx: Partial<CanvasRenderingContext2D>;
+  let dprService: DevicePixelRatioService;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -38,23 +40,51 @@ describe("LineTool", () => {
     canvas.getContext = jest
       .fn()
       .mockReturnValue(ctx as CanvasRenderingContext2D);
+    canvas.getBoundingClientRect = () => ({
+      width: 100,
+      height: 100,
+      top: 0,
+      left: 0,
+      bottom: 100,
+      right: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+    dprService = new DevicePixelRatioService();
     editor = new Editor(
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
       document.getElementById("fillMode") as HTMLInputElement,
+      undefined,
+      undefined,
+      dprService,
     );
+  });
+
+  afterEach(() => {
+    editor.destroy();
+    dprService.destroy();
   });
 
   it("renders line preview during drag", () => {
     const tool = new LineTool();
-    tool.onPointerDown({ offsetX: 1, offsetY: 2 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 1, offsetY: 2, clientX: 1, clientY: 2 } as PointerEvent,
+      editor,
+    );
     tool.onPointerMove({
       offsetX: 3,
       offsetY: 4,
+      clientX: 3,
+      clientY: 4,
       buttons: 1,
     } as PointerEvent, editor);
-    tool.onPointerUp({ offsetX: 3, offsetY: 4 } as PointerEvent, editor);
+    tool.onPointerUp(
+      { offsetX: 3, offsetY: 4, clientX: 3, clientY: 4 } as PointerEvent,
+      editor,
+    );
 
     expect(ctx.getImageData).toHaveBeenCalled();
     const image = (ctx.getImageData as jest.Mock).mock.results[0].value;
@@ -73,8 +103,14 @@ describe("LineTool", () => {
 
   it("draws line on pointer up", () => {
     const tool = new LineTool();
-    tool.onPointerDown({ offsetX: 1, offsetY: 2 } as PointerEvent, editor);
-    tool.onPointerUp({ offsetX: 5, offsetY: 6 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 1, offsetY: 2, clientX: 1, clientY: 2 } as PointerEvent,
+      editor,
+    );
+    tool.onPointerUp(
+      { offsetX: 5, offsetY: 6, clientX: 5, clientY: 6 } as PointerEvent,
+      editor,
+    );
     expect(ctx.putImageData).toHaveBeenCalled();
     expect(ctx.beginPath).toHaveBeenCalled();
     expect(ctx.moveTo).toHaveBeenCalledWith(1, 2);
@@ -86,8 +122,14 @@ describe("LineTool", () => {
   it("supports undo after drawing", () => {
     const tool = new LineTool();
     editor.saveState();
-    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
-    tool.onPointerUp({ offsetX: 1, offsetY: 1 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 0, offsetY: 0, clientX: 0, clientY: 0 } as PointerEvent,
+      editor,
+    );
+    tool.onPointerUp(
+      { offsetX: 1, offsetY: 1, clientX: 1, clientY: 1 } as PointerEvent,
+      editor,
+    );
     editor.undo();
     expect(ctx.clearRect).toHaveBeenCalledTimes(1);
     expect(ctx.putImageData).toHaveBeenCalledTimes(2);
@@ -95,10 +137,15 @@ describe("LineTool", () => {
 
   it("snaps angles to 45° increments when shift is held", () => {
     const tool = new LineTool();
-    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 0, offsetY: 0, clientX: 0, clientY: 0 } as PointerEvent,
+      editor,
+    );
     tool.onPointerMove({
       offsetX: 10,
       offsetY: 5,
+      clientX: 10,
+      clientY: 5,
       buttons: 1,
       shiftKey: true,
     } as PointerEvent, editor);

--- a/tests/rectangleTool.test.ts
+++ b/tests/rectangleTool.test.ts
@@ -1,3 +1,4 @@
+import { DevicePixelRatioService } from "../src/core/DevicePixelRatioService.js";
 import { Editor } from "../src/core/Editor.js";
 import { RectangleTool } from "../src/tools/RectangleTool.js";
 import { DrawingTool } from "../src/tools/DrawingTool.js";
@@ -5,6 +6,7 @@ import { DrawingTool } from "../src/tools/DrawingTool.js";
 describe("RectangleTool", () => {
   let editor: Editor;
   let ctx: Partial<CanvasRenderingContext2D>;
+  let dprService: DevicePixelRatioService;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -53,42 +55,67 @@ describe("RectangleTool", () => {
       toJSON: () => {},
     });
 
+    dprService = new DevicePixelRatioService();
     editor = new Editor(
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
       document.getElementById("fillMode") as HTMLInputElement,
+      undefined,
+      undefined,
+      dprService,
     );
   });
 
   afterEach(() => {
     editor.destroy();
+    dprService.destroy();
   });
 
   it("draws a rectangle on pointer up", () => {
     const tool = new RectangleTool();
     expect(tool).toBeInstanceOf(DrawingTool);
-    tool.onPointerDown({ offsetX: 10, offsetY: 15 } as PointerEvent, editor);
-    tool.onPointerUp({ offsetX: 20, offsetY: 25 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 10, offsetY: 15, clientX: 10, clientY: 15 } as PointerEvent,
+      editor,
+    );
+    tool.onPointerUp(
+      { offsetX: 20, offsetY: 25, clientX: 20, clientY: 25 } as PointerEvent,
+      editor,
+    );
     expect(ctx.strokeRect).toHaveBeenCalledWith(10, 15, 10, 10);
   });
 
   it("fills a rectangle when fill mode is enabled", () => {
     const tool = new RectangleTool();
     (document.getElementById("fillMode") as HTMLInputElement).checked = true;
-    tool.onPointerDown({ offsetX: 10, offsetY: 15 } as PointerEvent, editor);
-    tool.onPointerUp({ offsetX: 20, offsetY: 25 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 10, offsetY: 15, clientX: 10, clientY: 15 } as PointerEvent,
+      editor,
+    );
+    tool.onPointerUp(
+      { offsetX: 20, offsetY: 25, clientX: 20, clientY: 25 } as PointerEvent,
+      editor,
+    );
     expect(ctx.fillRect).toHaveBeenCalledWith(10, 15, 10, 10);
   });
 
   it("constrains to a square when shift is held", () => {
     const tool = new RectangleTool();
-    tool.onPointerDown({ offsetX: 10, offsetY: 15 } as PointerEvent, editor);
-    tool.onPointerUp({
-      offsetX: 30,
-      offsetY: 25,
-      shiftKey: true,
-    } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 10, offsetY: 15, clientX: 10, clientY: 15 } as PointerEvent,
+      editor,
+    );
+    tool.onPointerUp(
+      {
+        offsetX: 30,
+        offsetY: 25,
+        clientX: 30,
+        clientY: 25,
+        shiftKey: true,
+      } as PointerEvent,
+      editor,
+    );
     expect(ctx.strokeRect).toHaveBeenLastCalledWith(10, 15, 10, 10);
   });
 });

--- a/tests/textTool.test.ts
+++ b/tests/textTool.test.ts
@@ -1,3 +1,4 @@
+import { DevicePixelRatioService } from "../src/core/DevicePixelRatioService.js";
 import { Editor } from "../src/core/Editor.js";
 import { TextTool } from "../src/tools/TextTool.js";
 
@@ -6,6 +7,7 @@ describe("TextTool", () => {
   let ctx: Partial<CanvasRenderingContext2D>;
   let canvas: HTMLCanvasElement;
   let mockImage: ImageData;
+  let dprService: DevicePixelRatioService;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -45,10 +47,10 @@ describe("TextTool", () => {
     canvas.getBoundingClientRect = () => ({
       left: 0,
       top: 0,
-      right: 0,
-      bottom: 0,
-      width: 0,
-      height: 0,
+      right: 100,
+      bottom: 100,
+      width: 100,
+      height: 100,
       x: 0,
       y: 0,
       toJSON: () => {},
@@ -65,6 +67,7 @@ describe("TextTool", () => {
       toJSON: () => {},
     });
 
+    dprService = new DevicePixelRatioService();
     editor = new Editor(
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
@@ -73,16 +76,21 @@ describe("TextTool", () => {
       undefined,
       document.getElementById("fontFamily") as HTMLSelectElement,
       document.getElementById("fontSize") as HTMLInputElement,
+      dprService,
     );
   });
 
   afterEach(() => {
     editor.destroy();
+    dprService.destroy();
   });
 
   it("creates textarea overlay on pointer down", () => {
     const tool = new TextTool();
-    tool.onPointerDown({ offsetX: 10, offsetY: 20 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 10, offsetY: 20, clientX: 10, clientY: 20 } as PointerEvent,
+      editor,
+    );
     const ta = document.querySelector("textarea") as HTMLTextAreaElement;
     expect(ta).toBeTruthy();
     expect(ta.style.left).toBe("10px");
@@ -101,7 +109,10 @@ describe("TextTool", () => {
 
   it("commits text on Enter", () => {
     const tool = new TextTool();
-    tool.onPointerDown({ offsetX: 5, offsetY: 6 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 5, offsetY: 6, clientX: 5, clientY: 6 } as PointerEvent,
+      editor,
+    );
     const ta = document.querySelector("textarea") as HTMLTextAreaElement;
     ta.value = "hello";
     ta.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
@@ -112,7 +123,10 @@ describe("TextTool", () => {
 
   it("cancels text on Escape", () => {
     const tool = new TextTool();
-    tool.onPointerDown({ offsetX: 7, offsetY: 8 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 7, offsetY: 8, clientX: 7, clientY: 8 } as PointerEvent,
+      editor,
+    );
     const ta = document.querySelector("textarea") as HTMLTextAreaElement;
     ta.value = "cancel";
     ta.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
@@ -123,7 +137,10 @@ describe("TextTool", () => {
   it("supports undo with a single step after committing text", () => {
     const tool = new TextTool();
     editor.saveState();
-    tool.onPointerDown({ offsetX: 9, offsetY: 10 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 9, offsetY: 10, clientX: 9, clientY: 10 } as PointerEvent,
+      editor,
+    );
     const ta = document.querySelector("textarea") as HTMLTextAreaElement;
     ta.value = "undo";
     ta.dispatchEvent(

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1,3 +1,4 @@
+import { DevicePixelRatioService } from "../src/core/DevicePixelRatioService.js";
 import { Editor } from "../src/core/Editor.js";
 import { PencilTool } from "../src/tools/PencilTool.js";
 import { LineTool } from "../src/tools/LineTool.js";
@@ -8,6 +9,7 @@ describe("additional tools", () => {
   let canvas: HTMLCanvasElement;
   let ctx: Partial<CanvasRenderingContext2D>;
   let editor: Editor;
+  let dprService: DevicePixelRatioService;
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -41,22 +43,54 @@ describe("additional tools", () => {
     canvas.getContext = jest
       .fn()
       .mockReturnValue(ctx as CanvasRenderingContext2D);
+    canvas.getBoundingClientRect = () => ({
+      width: 100,
+      height: 100,
+      top: 0,
+      left: 0,
+      bottom: 100,
+      right: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+    dprService = new DevicePixelRatioService();
     editor = new Editor(
       canvas,
       document.getElementById("colorPicker") as HTMLInputElement,
       document.getElementById("lineWidth") as HTMLInputElement,
       document.getElementById("fillMode") as HTMLInputElement,
+      undefined,
+      undefined,
+      dprService,
     );
+  });
+
+  afterEach(() => {
+    editor.destroy();
+    dprService.destroy();
   });
 
   it("pencil draws lines", () => {
     const tool = new PencilTool();
-    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
-    tool.onPointerMove(
-      { offsetX: 5, offsetY: 5, buttons: 1 } as PointerEvent,
+    tool.onPointerDown(
+      { offsetX: 0, offsetY: 0, clientX: 0, clientY: 0 } as PointerEvent,
       editor,
     );
-    tool.onPointerUp({ offsetX: 5, offsetY: 5 } as PointerEvent, editor);
+    tool.onPointerMove(
+      {
+        offsetX: 5,
+        offsetY: 5,
+        clientX: 5,
+        clientY: 5,
+        buttons: 1,
+      } as PointerEvent,
+      editor,
+    );
+    tool.onPointerUp(
+      { offsetX: 5, offsetY: 5, clientX: 5, clientY: 5 } as PointerEvent,
+      editor,
+    );
     expect(ctx.beginPath).toHaveBeenCalled();
     expect(ctx.lineTo).toHaveBeenCalledWith(5, 5);
     expect(ctx.closePath).toHaveBeenCalled();
@@ -64,22 +98,37 @@ describe("additional tools", () => {
 
   it("line tool draws a line", () => {
     const tool = new LineTool();
-    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
-    tool.onPointerUp({ offsetX: 3, offsetY: 4 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 0, offsetY: 0, clientX: 0, clientY: 0 } as PointerEvent,
+      editor,
+    );
+    tool.onPointerUp(
+      { offsetX: 3, offsetY: 4, clientX: 3, clientY: 4 } as PointerEvent,
+      editor,
+    );
     expect(ctx.moveTo).toHaveBeenCalledWith(0, 0);
     expect(ctx.lineTo).toHaveBeenCalledWith(3, 4);
   });
 
   it("circle tool draws a circle", () => {
     const tool = new CircleTool();
-    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
-    tool.onPointerUp({ offsetX: 3, offsetY: 4 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 0, offsetY: 0, clientX: 0, clientY: 0 } as PointerEvent,
+      editor,
+    );
+    tool.onPointerUp(
+      { offsetX: 3, offsetY: 4, clientX: 3, clientY: 4 } as PointerEvent,
+      editor,
+    );
     expect(ctx.ellipse).toHaveBeenCalledWith(0, 0, 3, 4, 0, 0, Math.PI * 2);
   });
 
   it("text tool commits text on Enter", () => {
     const tool = new TextTool();
-    tool.onPointerDown({ offsetX: 1, offsetY: 2 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 1, offsetY: 2, clientX: 1, clientY: 2 } as PointerEvent,
+      editor,
+    );
     const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
     textarea.value = "Hi";
     textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
@@ -89,7 +138,10 @@ describe("additional tools", () => {
 
   it("text tool cancels on blur", () => {
     const tool = new TextTool();
-    tool.onPointerDown({ offsetX: 1, offsetY: 2 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 1, offsetY: 2, clientX: 1, clientY: 2 } as PointerEvent,
+      editor,
+    );
     const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
     textarea.value = "Blur";
     textarea.dispatchEvent(new Event("blur"));
@@ -99,7 +151,10 @@ describe("additional tools", () => {
 
   it("text tool cancels on Escape", () => {
     const tool = new TextTool();
-    tool.onPointerDown({ offsetX: 1, offsetY: 2 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 1, offsetY: 2, clientX: 1, clientY: 2 } as PointerEvent,
+      editor,
+    );
     const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
     textarea.value = "Hi";
     textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));


### PR DESCRIPTION
## Summary
- add a DevicePixelRatioService to centralize device-pixel-ratio transforms, resizing, and worker notifications
- expose Editor.normalizeEvent so tools can consume DPR-aware logical and device coordinates
- update tool implementations and tests to rely on normalized pointer data via the shared service

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d60d09af4c832887b1d5f65cbcc42e