### PR TITLE
Add diff-based history for large canvas edits

### DIFF
--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -1,10 +1,36 @@
 import { Tool } from "../tools/Tool.js";
 
+type CanvasRect = { x: number; y: number; width: number; height: number };
+
+type CanvasHistoryEntry =
+  | {
+      type: "snapshot";
+      before: ImageData;
+      after: ImageData;
+    }
+  | {
+      type: "diff";
+      rect: CanvasRect;
+      before: ImageData;
+      after: ImageData;
+    };
+
+type PendingCapture = {
+  before: ImageData;
+  useDiff: boolean;
+  diff?: {
+    rect: CanvasRect;
+    before: ImageData;
+    after: ImageData;
+  };
+};
+
 export class Editor {
   canvas: HTMLCanvasElement;
   ctx: CanvasRenderingContext2D;
-  private undoStack: ImageData[] = [];
-  private redoStack: ImageData[] = [];
+  private undoStack: CanvasHistoryEntry[] = [];
+  private redoStack: CanvasHistoryEntry[] = [];
+  private pendingCapture: PendingCapture | null = null;
   private currentTool: Tool | null = null;
   colorPicker: HTMLInputElement;
   lineWidth: HTMLInputElement;
@@ -59,6 +85,7 @@ export class Editor {
 
   private handlePointerUp = (e: PointerEvent) => {
     this.currentTool?.onPointerUp(e, this);
+    this.commitPendingState();
     this.canvas.releasePointerCapture(e.pointerId);
   };
 
@@ -84,31 +111,98 @@ export class Editor {
   };
 
   saveState() {
-    this.undoStack.push(
-      this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height),
-    );
-    if (this.undoStack.length > 50) this.undoStack.shift();
+    const before = this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height);
+    const useDiff =
+      this.canvas.width * this.canvas.height >
+      Editor.DIFF_CANVAS_AREA_THRESHOLD;
+    this.pendingCapture = { before, useDiff };
     this.redoStack.length = 0;
+  }
+
+  recordDiff(rect: CanvasRect) {
+    if (!this.pendingCapture || !this.pendingCapture.useDiff) return;
+    const normalized = this.normalizeRect(rect);
+    if (!normalized) return;
+    const beforeRegion = this.extractRegion(this.pendingCapture.before, normalized);
+    const afterRegion = this.ctx.getImageData(
+      normalized.x,
+      normalized.y,
+      normalized.width,
+      normalized.height,
+    );
+    this.pendingCapture.diff = {
+      rect: normalized,
+      before: beforeRegion,
+      after: afterRegion,
+    };
+  }
+
+  private commitPendingState() {
+    if (!this.pendingCapture) return;
+    const { diff, before, useDiff } = this.pendingCapture;
+    let entry: CanvasHistoryEntry;
+    if (useDiff && diff) {
+      entry = {
+        type: "diff",
+        rect: diff.rect,
+        before: diff.before,
+        after: diff.after,
+      };
+    } else {
+      const after = this.ctx.getImageData(
+        0,
+        0,
+        this.canvas.width,
+        this.canvas.height,
+      );
+      entry = {
+        type: "snapshot",
+        before,
+        after,
+      };
+    }
+
+    this.undoStack.push(entry);
+    if (this.undoStack.length > Editor.MAX_HISTORY) {
+      this.undoStack.shift();
+    }
+    this.pendingCapture = null;
     this.onChange?.();
   }
 
-  private restoreState(stack: ImageData[], opposite: ImageData[]) {
+  private restoreState(
+    stack: CanvasHistoryEntry[],
+    opposite: CanvasHistoryEntry[],
+    direction: "undo" | "redo",
+  ) {
     if (!stack.length) return;
-    opposite.push(
-      this.ctx.getImageData(0, 0, this.canvas.width, this.canvas.height),
-    );
-    const imageData = stack.pop()!;
-    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-    this.ctx.putImageData(imageData, 0, 0);
+    const entry = stack.pop()!;
+    opposite.push(entry);
+    if (opposite.length > Editor.MAX_HISTORY) {
+      opposite.shift();
+    }
+    this.applyHistoryEntry(entry, direction);
     this.onChange?.();
+  }
+
+  private applyHistoryEntry(
+    entry: CanvasHistoryEntry,
+    direction: "undo" | "redo",
+  ) {
+    const imageData = direction === "undo" ? entry.before : entry.after;
+    if (entry.type === "diff") {
+      this.ctx.putImageData(imageData, entry.rect.x, entry.rect.y);
+    } else {
+      this.ctx.putImageData(imageData, 0, 0);
+    }
   }
 
   undo() {
-    this.restoreState(this.undoStack, this.redoStack);
+    this.restoreState(this.undoStack, this.redoStack, "undo");
   }
 
   redo() {
-    this.restoreState(this.redoStack, this.undoStack);
+    this.restoreState(this.redoStack, this.undoStack, "redo");
   }
 
   get canUndo() {
@@ -154,4 +248,40 @@ export class Editor {
     this.canvas.removeEventListener("pointermove", this.handlePointerMove);
     this.canvas.removeEventListener("pointerup", this.handlePointerUp);
   }
+
+  private normalizeRect(rect: CanvasRect): CanvasRect | null {
+    const scale = window.devicePixelRatio || 1;
+    const scaledX = Math.floor(rect.x * scale);
+    const scaledY = Math.floor(rect.y * scale);
+    const scaledRight = Math.ceil((rect.x + rect.width) * scale);
+    const scaledBottom = Math.ceil((rect.y + rect.height) * scale);
+    const x = Math.max(0, Math.min(this.canvas.width, scaledX));
+    const y = Math.max(0, Math.min(this.canvas.height, scaledY));
+    const right = Math.max(x, Math.min(this.canvas.width, scaledRight));
+    const bottom = Math.max(y, Math.min(this.canvas.height, scaledBottom));
+    const width = right - x;
+    const height = bottom - y;
+    if (width <= 0 || height <= 0) {
+      return null;
+    }
+    return { x, y, width, height };
+  }
+
+  private extractRegion(source: ImageData, rect: CanvasRect): ImageData {
+    const region = new ImageData(rect.width, rect.height);
+    const bytesPerPixel = 4;
+    for (let row = 0; row < rect.height; row++) {
+      const srcStart =
+        ((rect.y + row) * source.width + rect.x) * bytesPerPixel;
+      const destStart = row * rect.width * bytesPerPixel;
+      region.data.set(
+        source.data.subarray(srcStart, srcStart + rect.width * bytesPerPixel),
+        destStart,
+      );
+    }
+    return region;
+  }
+
+  private static readonly MAX_HISTORY = 50;
+  private static readonly DIFF_CANVAS_AREA_THRESHOLD = 512 * 512;
 }

--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -23,15 +23,7 @@ export class CircleTool extends DrawingTool {
     const ctx = editor.ctx;
     ctx.putImageData(this.imageData, 0, 0);
     this.applyStroke(ctx, editor);
-    const dx = e.offsetX - this.startX;
-    const dy = e.offsetY - this.startY;
-    let radiusX = Math.abs(dx);
-    let radiusY = Math.abs(dy);
-    if (e.shiftKey) {
-      const radius = Math.max(radiusX, radiusY);
-      radiusX = radius;
-      radiusY = radius;
-    }
+    const { radiusX, radiusY } = this.getRadii(e);
     ctx.beginPath();
     ctx.ellipse(this.startX, this.startY, radiusX, radiusY, 0, 0, Math.PI * 2);
     ctx.stroke();
@@ -47,6 +39,19 @@ export class CircleTool extends DrawingTool {
       ctx.putImageData(this.imageData, 0, 0);
     }
     this.applyStroke(ctx, editor);
+    const { radiusX, radiusY } = this.getRadii(e);
+    ctx.beginPath();
+    ctx.ellipse(this.startX, this.startY, radiusX, radiusY, 0, 0, Math.PI * 2);
+    ctx.stroke();
+    if (editor.fill) {
+      ctx.fill();
+    }
+    ctx.closePath();
+    this.recordDiff(editor, radiusX, radiusY);
+    this.imageData = null;
+  }
+
+  private getRadii(e: PointerEvent): { radiusX: number; radiusY: number } {
     const dx = e.offsetX - this.startX;
     const dy = e.offsetY - this.startY;
     let radiusX = Math.abs(dx);
@@ -56,14 +61,21 @@ export class CircleTool extends DrawingTool {
       radiusX = radius;
       radiusY = radius;
     }
-    ctx.beginPath();
-    ctx.ellipse(this.startX, this.startY, radiusX, radiusY, 0, 0, Math.PI * 2);
-    ctx.stroke();
-    if (editor.fill) {
-      ctx.fill();
-    }
-    ctx.closePath();
-    this.imageData = null;
+    return { radiusX, radiusY };
+  }
+
+  private recordDiff(editor: Editor, radiusX: number, radiusY: number) {
+    const padding = Math.ceil(editor.lineWidthValue / 2) + 2;
+    const minX = this.startX - radiusX;
+    const maxX = this.startX + radiusX;
+    const minY = this.startY - radiusY;
+    const maxY = this.startY + radiusY;
+    editor.recordDiff({
+      x: minX - padding,
+      y: minY - padding,
+      width: Math.max(1, maxX - minX + padding * 2),
+      height: Math.max(1, maxY - minY + padding * 2),
+    });
   }
 }
 

--- a/src/tools/EraserTool.ts
+++ b/src/tools/EraserTool.ts
@@ -2,6 +2,11 @@ import { Editor } from "../core/Editor.js";
 import { DrawingTool } from "./DrawingTool.js";
 
 export class EraserTool extends DrawingTool {
+  private minX: number | null = null;
+  private minY: number | null = null;
+  private maxX: number | null = null;
+  private maxY: number | null = null;
+
   onPointerDown(e: PointerEvent, editor: Editor) {
     const ctx = editor.ctx;
     ctx.globalCompositeOperation = "destination-out";
@@ -14,6 +19,10 @@ export class EraserTool extends DrawingTool {
       editor.lineWidthValue,
       editor.lineWidthValue,
     );
+    this.minX = e.offsetX;
+    this.maxX = e.offsetX;
+    this.minY = e.offsetY;
+    this.maxY = e.offsetY;
   }
 
   onPointerMove(e: PointerEvent, editor: Editor) {
@@ -28,11 +37,51 @@ export class EraserTool extends DrawingTool {
       editor.lineWidthValue,
       editor.lineWidthValue,
     );
+    this.updateBounds(e.offsetX, e.offsetY);
   }
 
-  onPointerUp(_e: PointerEvent, editor: Editor) {
+  onPointerUp(e: PointerEvent, editor: Editor) {
     const ctx = editor.ctx;
+    this.updateBounds(e.offsetX, e.offsetY);
     ctx.closePath();
     ctx.globalCompositeOperation = "source-over";
+    this.commitBounds(editor);
+  }
+
+  private updateBounds(x: number, y: number) {
+    if (this.minX === null || this.maxX === null || this.minY === null || this.maxY === null) {
+      this.minX = x;
+      this.maxX = x;
+      this.minY = y;
+      this.maxY = y;
+      return;
+    }
+    this.minX = Math.min(this.minX, x);
+    this.maxX = Math.max(this.maxX, x);
+    this.minY = Math.min(this.minY, y);
+    this.maxY = Math.max(this.maxY, y);
+  }
+
+  private commitBounds(editor: Editor) {
+    if (
+      this.minX === null ||
+      this.maxX === null ||
+      this.minY === null ||
+      this.maxY === null
+    ) {
+      return;
+    }
+    const padding = Math.ceil(editor.lineWidthValue / 2) + 2;
+    const minX = Math.min(this.minX, this.maxX);
+    const maxX = Math.max(this.minX, this.maxX);
+    const minY = Math.min(this.minY, this.maxY);
+    const maxY = Math.max(this.minY, this.maxY);
+    editor.recordDiff({
+      x: minX - padding,
+      y: minY - padding,
+      width: Math.max(1, maxX - minX + padding * 2),
+      height: Math.max(1, maxY - minY + padding * 2),
+    });
+    this.minX = this.minY = this.maxX = this.maxY = null;
   }
 }

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -26,17 +26,7 @@ export class LineTool extends DrawingTool {
     this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
-    let x = e.offsetX;
-    let y = e.offsetY;
-    if (e.shiftKey) {
-      const dx = x - this.startX;
-      const dy = y - this.startY;
-      const angle = Math.atan2(dy, dx);
-      const snapped = Math.round(angle / (Math.PI / 4)) * (Math.PI / 4);
-      const length = Math.sqrt(dx * dx + dy * dy);
-      x = this.startX + length * Math.cos(snapped);
-      y = this.startY + length * Math.sin(snapped);
-    }
+    const { x, y } = this.getEndPoint(e);
     ctx.lineTo(x, y);
     ctx.stroke();
     ctx.closePath();
@@ -50,6 +40,15 @@ export class LineTool extends DrawingTool {
     this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
+    const { x, y } = this.getEndPoint(e);
+    ctx.lineTo(x, y);
+    ctx.stroke();
+    ctx.closePath();
+    this.recordDiff(editor, x, y);
+    this.imageData = null;
+  }
+
+  private getEndPoint(e: PointerEvent): { x: number; y: number } {
     let x = e.offsetX;
     let y = e.offsetY;
     if (e.shiftKey) {
@@ -61,9 +60,20 @@ export class LineTool extends DrawingTool {
       x = this.startX + length * Math.cos(snapped);
       y = this.startY + length * Math.sin(snapped);
     }
-    ctx.lineTo(x, y);
-    ctx.stroke();
-    ctx.closePath();
-    this.imageData = null;
+    return { x, y };
+  }
+
+  private recordDiff(editor: Editor, endX: number, endY: number) {
+    const padding = Math.ceil(editor.lineWidthValue / 2) + 2;
+    const minX = Math.min(this.startX, endX);
+    const maxX = Math.max(this.startX, endX);
+    const minY = Math.min(this.startY, endY);
+    const maxY = Math.max(this.startY, endY);
+    editor.recordDiff({
+      x: minX - padding,
+      y: minY - padding,
+      width: Math.max(1, maxX - minX + padding * 2),
+      height: Math.max(1, maxY - minY + padding * 2),
+    });
   }
 }

--- a/src/tools/PencilTool.ts
+++ b/src/tools/PencilTool.ts
@@ -2,11 +2,20 @@ import { Editor } from "../core/Editor.js";
 import { DrawingTool } from "./DrawingTool.js";
 
 export class PencilTool extends DrawingTool {
+  private minX: number | null = null;
+  private minY: number | null = null;
+  private maxX: number | null = null;
+  private maxY: number | null = null;
+
   onPointerDown(e: PointerEvent, editor: Editor) {
     this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
     ctx.beginPath();
     ctx.moveTo(e.offsetX, e.offsetY);
+    this.minX = e.offsetX;
+    this.maxX = e.offsetX;
+    this.minY = e.offsetY;
+    this.maxY = e.offsetY;
   }
 
   onPointerMove(e: PointerEvent, editor: Editor) {
@@ -15,9 +24,49 @@ export class PencilTool extends DrawingTool {
     const ctx = editor.ctx;
     ctx.lineTo(e.offsetX, e.offsetY);
     ctx.stroke();
+    this.updateBounds(e.offsetX, e.offsetY);
   }
 
-  onPointerUp(_e: PointerEvent, editor: Editor) {
+  onPointerUp(e: PointerEvent, editor: Editor) {
     editor.ctx.closePath();
+    this.updateBounds(e.offsetX, e.offsetY);
+    this.commitBounds(editor);
+  }
+
+  private updateBounds(x: number, y: number) {
+    if (this.minX === null || this.maxX === null || this.minY === null || this.maxY === null) {
+      this.minX = x;
+      this.maxX = x;
+      this.minY = y;
+      this.maxY = y;
+      return;
+    }
+    this.minX = Math.min(this.minX, x);
+    this.maxX = Math.max(this.maxX, x);
+    this.minY = Math.min(this.minY, y);
+    this.maxY = Math.max(this.maxY, y);
+  }
+
+  private commitBounds(editor: Editor) {
+    if (
+      this.minX === null ||
+      this.maxX === null ||
+      this.minY === null ||
+      this.maxY === null
+    ) {
+      return;
+    }
+    const padding = Math.ceil(editor.lineWidthValue / 2) + 2;
+    const minX = Math.min(this.minX, this.maxX);
+    const maxX = Math.max(this.minX, this.maxX);
+    const minY = Math.min(this.minY, this.maxY);
+    const maxY = Math.max(this.minY, this.maxY);
+    editor.recordDiff({
+      x: minX - padding,
+      y: minY - padding,
+      width: Math.max(1, maxX - minX + padding * 2),
+      height: Math.max(1, maxY - minY + padding * 2),
+    });
+    this.minX = this.minY = this.maxX = this.maxY = null;
   }
 }

--- a/src/tools/RectangleTool.ts
+++ b/src/tools/RectangleTool.ts
@@ -20,15 +20,7 @@ export class RectangleTool extends DrawingTool {
     ctx.putImageData(this.imageData, 0, 0);
     this.applyStroke(editor.ctx, editor);
 
-    const x = e.offsetX;
-    const y = e.offsetY;
-    let width = x - this.startX;
-    let height = y - this.startY;
-    if (e.shiftKey) {
-      const size = Math.min(Math.abs(width), Math.abs(height));
-      width = size * Math.sign(width);
-      height = size * Math.sign(height);
-    }
+    const { width, height } = this.getDimensions(e);
     ctx.strokeRect(this.startX, this.startY, width, height);
     if (editor.fill) {
       ctx.fillRect(this.startX, this.startY, width, height);
@@ -42,19 +34,39 @@ export class RectangleTool extends DrawingTool {
     }
 
     this.applyStroke(editor.ctx, editor);
-    const x = e.offsetX;
-    const y = e.offsetY;
-    let width = x - this.startX;
-    let height = y - this.startY;
+    const { width, height } = this.getDimensions(e);
+    ctx.strokeRect(this.startX, this.startY, width, height);
+    if (editor.fill) {
+      ctx.fillRect(this.startX, this.startY, width, height);
+    }
+    this.recordDiff(editor, width, height);
+    this.imageData = null;
+  }
+
+  private getDimensions(e: PointerEvent): { width: number; height: number } {
+    let width = e.offsetX - this.startX;
+    let height = e.offsetY - this.startY;
     if (e.shiftKey) {
       const size = Math.min(Math.abs(width), Math.abs(height));
       width = size * Math.sign(width);
       height = size * Math.sign(height);
     }
-    ctx.strokeRect(this.startX, this.startY, width, height);
-    if (editor.fill) {
-      ctx.fillRect(this.startX, this.startY, width, height);
-    }
-    this.imageData = null;
+    return { width, height };
+  }
+
+  private recordDiff(editor: Editor, width: number, height: number) {
+    const padding = Math.ceil(editor.lineWidthValue / 2) + 2;
+    const endX = this.startX + width;
+    const endY = this.startY + height;
+    const minX = Math.min(this.startX, endX);
+    const maxX = Math.max(this.startX, endX);
+    const minY = Math.min(this.startY, endY);
+    const maxY = Math.max(this.startY, endY);
+    editor.recordDiff({
+      x: minX - padding,
+      y: minY - padding,
+      width: Math.max(1, maxX - minX + padding * 2),
+      height: Math.max(1, maxY - minY + padding * 2),
+    });
   }
 }


### PR DESCRIPTION
## Summary
- add diff-aware history entries and dirty rectangle support to the editor
- update stroke and shape tools to compute and submit dirty rectangles when drawing
- allow undo/redo to reapply diffs on large canvases while keeping snapshot fallbacks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d60d085ee883289a55e8b81bb33653