### PR TITLE
Add transform overlay and controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,15 @@
         <img src="icons/save.svg" alt="Save" />
       </button>
 
+      <div id="transformControls" class="group" aria-live="polite">
+        <span id="transformScale">Scale: 100% × 100%</span>
+        <span id="transformRotation">Rotation: 0°</span>
+        <button id="resetTransform" type="button">Reset</button>
+        <button id="commitTransform" type="button">Commit</button>
+        <button id="flipHorizontal" type="button">Flip H</button>
+        <button id="flipVertical" type="button">Flip V</button>
+      </div>
+
     </div>
     <div id="canvasContainer">
       <canvas id="canvas" width="800" height="600"></canvas>

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -99,6 +99,27 @@ export function initEditor(): EditorHandle {
   const colorHistory = document.getElementById(
     "colorHistory",
   ) as HTMLDivElement | null;
+  const transformScale = document.getElementById(
+    "transformScale",
+  ) as HTMLSpanElement | null;
+  const transformRotation = document.getElementById(
+    "transformRotation",
+  ) as HTMLSpanElement | null;
+  const resetTransformBtn = document.getElementById(
+    "resetTransform",
+  ) as HTMLButtonElement | null;
+  const commitTransformBtn = document.getElementById(
+    "commitTransform",
+  ) as HTMLButtonElement | null;
+  const flipHorizontalBtn = document.getElementById(
+    "flipHorizontal",
+  ) as HTMLButtonElement | null;
+  const flipVerticalBtn = document.getElementById(
+    "flipVertical",
+  ) as HTMLButtonElement | null;
+  const canvasContainer = document.getElementById(
+    "canvasContainer",
+  ) as HTMLDivElement | null;
 
   if (!colorPicker) {
     throw new Error("Missing #colorPicker input");
@@ -115,6 +136,97 @@ export function initEditor(): EditorHandle {
   if (!formatSelect) {
     throw new Error("Missing #formatSelect select");
   }
+  type TransformHandle =
+    | "n"
+    | "ne"
+    | "e"
+    | "se"
+    | "s"
+    | "sw"
+    | "w"
+    | "nw"
+    | "rotate";
+
+  interface TransformState {
+    scaleX: number;
+    scaleY: number;
+    rotation: number;
+  }
+
+  interface LayerTransformState {
+    snapshot: HTMLCanvasElement | null;
+    transform: TransformState;
+  }
+
+  interface TransformSession {
+    canvas: HTMLCanvasElement;
+    handle: TransformHandle;
+    pointerId: number;
+    center: { x: number; y: number };
+    initialVector: { x: number; y: number };
+    initialTransform: TransformState;
+    startAngle?: number;
+    previousUserSelect: string;
+  }
+
+  const identityTransform = (): TransformState => ({
+    scaleX: 1,
+    scaleY: 1,
+    rotation: 0,
+  });
+
+  const MIN_SCALE = 0.01;
+
+  const overlayContainer: HTMLElement =
+    canvasContainer ?? (canvases[0]?.parentElement ?? document.body);
+
+  const createElementSafe = <K extends keyof HTMLElementTagNameMap>(
+    tag: K,
+  ): HTMLElementTagNameMap[K] => {
+    const el = document.createElement(tag) as HTMLElementTagNameMap[K];
+    const needsFallback =
+      typeof (el as unknown as { appendChild?: unknown }).appendChild !==
+        "function" ||
+      (tag === "canvas" &&
+        typeof (el as unknown as HTMLCanvasElement).getContext !== "function");
+    if (needsFallback) {
+      return document.createElementNS(
+        "http://www.w3.org/1999/xhtml",
+        tag,
+      ) as HTMLElementTagNameMap[K];
+    }
+    return el;
+  };
+
+  const transformOverlay = createElementSafe("div");
+  transformOverlay.id = "transformOverlay";
+  const transformBox = createElementSafe("div");
+  transformBox.className = "transform-box";
+  transformOverlay.appendChild(transformBox);
+  const handleTypes: TransformHandle[] = [
+    "n",
+    "ne",
+    "e",
+    "se",
+    "s",
+    "sw",
+    "w",
+    "nw",
+    "rotate",
+  ];
+  const transformHandles: HTMLElement[] = [];
+  handleTypes.forEach((handle) => {
+    const handleEl = createElementSafe("div");
+    handleEl.className = "transform-handle";
+    handleEl.dataset.handle = handle;
+    transformBox.appendChild(handleEl);
+    transformHandles.push(handleEl);
+  });
+  overlayContainer.appendChild(transformOverlay);
+
+  const canvasToEditor = new Map<HTMLCanvasElement, Editor>();
+  const transformStates = new Map<HTMLCanvasElement, LayerTransformState>();
+  let transformSession: TransformSession | null = null;
 
   if (layerSelect) {
     layerSelect.innerHTML = "";
@@ -199,6 +311,353 @@ export function initEditor(): EditorHandle {
     if (redoBtn) redoBtn.disabled = !editor?.canRedo;
   };
 
+  const getTransformState = (
+    canvas: HTMLCanvasElement,
+  ): LayerTransformState => {
+    let state = transformStates.get(canvas);
+    if (!state) {
+      state = { snapshot: null, transform: identityTransform() };
+      transformStates.set(canvas, state);
+    }
+    return state;
+  };
+
+  const sanitizeScale = (value: number) =>
+    value >= 0 ? Math.max(value, MIN_SCALE) : Math.min(value, -MIN_SCALE);
+
+  const normalizeRotation = (value: number) => {
+    let normalized = value % 360;
+    if (normalized > 180) normalized -= 360;
+    if (normalized <= -180) normalized += 360;
+    return normalized;
+  };
+
+  const isIdentityTransform = (transform: TransformState) =>
+    Math.abs(transform.scaleX - 1) < 1e-3 &&
+    Math.abs(transform.scaleY - 1) < 1e-3 &&
+    Math.abs(normalizeRotation(transform.rotation)) < 1e-1;
+
+  const formatPercent = (value: number) => {
+    const magnitude = Math.abs(value) * 100;
+    const formatted =
+      magnitude >= 1000 ? magnitude.toFixed(0) : magnitude.toFixed(1);
+    const trimmed = formatted.replace(/\.0$/, "");
+    return `${value < 0 ? "-" : ""}${trimmed}%`;
+  };
+
+  const formatAngle = (value: number) => {
+    const normalized = normalizeRotation(value);
+    const formatted =
+      Math.abs(normalized) >= 1000
+        ? normalized.toFixed(0)
+        : normalized.toFixed(1);
+    return `${formatted.replace(/\.0$/, "")}°`;
+  };
+
+  const updateTransformReadout = (state: TransformState) => {
+    if (transformScale) {
+      transformScale.textContent = `Scale: ${formatPercent(
+        state.scaleX,
+      )} × ${formatPercent(state.scaleY)}`;
+    }
+    if (transformRotation) {
+      transformRotation.textContent = `Rotation: ${formatAngle(
+        state.rotation,
+      )}`;
+    }
+  };
+
+  const updateTransformButtonsState = (state: LayerTransformState) => {
+    const pending = Boolean(state.snapshot) && !isIdentityTransform(state.transform);
+    if (resetTransformBtn) resetTransformBtn.disabled = !pending;
+    if (commitTransformBtn) commitTransformBtn.disabled = !pending;
+  };
+
+  const updateTransformUI = () => {
+    if (!editor) return;
+    const state = getTransformState(editor.canvas);
+    updateTransformReadout(state.transform);
+    updateTransformButtonsState(state);
+  };
+
+  const ensureSnapshotForCanvas = (canvas: HTMLCanvasElement) => {
+    const state = getTransformState(canvas);
+    if (!state.snapshot) {
+      const snap = createElementSafe("canvas");
+      snap.width = canvas.width;
+      snap.height = canvas.height;
+      const snapCtx = snap.getContext("2d");
+      if (!snapCtx) return null;
+      snapCtx.drawImage(canvas, 0, 0);
+      state.snapshot = snap;
+      state.transform = identityTransform();
+    }
+    return state.snapshot;
+  };
+
+  const restoreFromSnapshot = (
+    canvas: HTMLCanvasElement,
+    snapshot: HTMLCanvasElement,
+  ) => {
+    const targetEditor = canvasToEditor.get(canvas);
+    if (!targetEditor) return;
+    const { ctx } = targetEditor;
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(snapshot, 0, 0);
+    ctx.restore();
+  };
+
+  const applyTransformPreview = (canvas: HTMLCanvasElement) => {
+    const state = getTransformState(canvas);
+    const snapshot = state.snapshot;
+    if (!snapshot) return;
+    const targetEditor = canvasToEditor.get(canvas);
+    if (!targetEditor) return;
+    const { ctx } = targetEditor;
+    const { scaleX, scaleY, rotation } = state.transform;
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.translate(canvas.width / 2, canvas.height / 2);
+    ctx.rotate((rotation * Math.PI) / 180);
+    ctx.scale(scaleX, scaleY);
+    ctx.translate(-canvas.width / 2, -canvas.height / 2);
+    ctx.drawImage(snapshot, 0, 0);
+    ctx.restore();
+  };
+
+  const updateTransformOverlayBounds = () => {
+    if (!editor) return;
+    const rect = editor.canvas.getBoundingClientRect();
+    const containerRect = overlayContainer.getBoundingClientRect();
+    transformBox.style.left = `${rect.left - containerRect.left}px`;
+    transformBox.style.top = `${rect.top - containerRect.top}px`;
+    transformBox.style.width = `${rect.width}px`;
+    transformBox.style.height = `${rect.height}px`;
+  };
+
+  const updateTransformFromPointer = (event: PointerEvent) => {
+    if (!transformSession) return;
+    const { canvas, handle, center, initialVector, initialTransform } =
+      transformSession;
+    const state = getTransformState(canvas);
+    if (!state.snapshot) return;
+    const currentVector = {
+      x: event.clientX - center.x,
+      y: event.clientY - center.y,
+    };
+
+    let scaleX = initialTransform.scaleX;
+    let scaleY = initialTransform.scaleY;
+    let rotation = initialTransform.rotation;
+
+    const computeRatio = (initialValue: number, currentValue: number) => {
+      if (Math.abs(initialValue) < 1e-6) return 1;
+      const ratio = currentValue / initialValue;
+      return ratio;
+    };
+
+    switch (handle) {
+      case "e":
+      case "w": {
+        const ratio = computeRatio(initialVector.x, currentVector.x);
+        scaleX = sanitizeScale(initialTransform.scaleX * ratio);
+        break;
+      }
+      case "n":
+      case "s": {
+        const ratio = computeRatio(initialVector.y, currentVector.y);
+        scaleY = sanitizeScale(initialTransform.scaleY * ratio);
+        break;
+      }
+      case "ne":
+      case "se":
+      case "sw":
+      case "nw": {
+        const ratioX = computeRatio(initialVector.x, currentVector.x);
+        const ratioY = computeRatio(initialVector.y, currentVector.y);
+        scaleX = sanitizeScale(initialTransform.scaleX * ratioX);
+        scaleY = sanitizeScale(initialTransform.scaleY * ratioY);
+        break;
+      }
+      case "rotate": {
+        const startAngle = transformSession.startAngle ?? 0;
+        const currentAngle = Math.atan2(currentVector.y, currentVector.x);
+        const delta = currentAngle - startAngle;
+        rotation = initialTransform.rotation + (delta * 180) / Math.PI;
+        break;
+      }
+    }
+
+    const nextTransform: TransformState = {
+      scaleX,
+      scaleY,
+      rotation,
+    };
+    state.transform = nextTransform;
+    applyTransformPreview(canvas);
+    updateTransformUI();
+  };
+
+  const finishTransformDrag = () => {
+    if (!transformSession) return;
+    const { canvas, previousUserSelect } = transformSession;
+    const state = getTransformState(canvas);
+    if (state.snapshot) {
+      if (isIdentityTransform(state.transform)) {
+        restoreFromSnapshot(canvas, state.snapshot);
+        state.snapshot = null;
+        state.transform = identityTransform();
+      } else {
+        applyTransformPreview(canvas);
+      }
+    }
+    document.body.style.userSelect = previousUserSelect;
+    transformSession = null;
+    updateTransformUI();
+  };
+
+  const startTransformDrag = (
+    event: PointerEvent,
+    handle: TransformHandle,
+  ) => {
+    if (!editor) return;
+    const canvas = editor.canvas;
+    if (!ensureSnapshotForCanvas(canvas)) return;
+    const boxRect = transformBox.getBoundingClientRect();
+    const center = {
+      x: boxRect.left + boxRect.width / 2,
+      y: boxRect.top + boxRect.height / 2,
+    };
+    const initialVector = {
+      x: event.clientX - center.x,
+      y: event.clientY - center.y,
+    };
+    const state = getTransformState(canvas);
+    transformSession = {
+      canvas,
+      handle,
+      pointerId: event.pointerId,
+      center,
+      initialVector,
+      initialTransform: { ...state.transform },
+      startAngle:
+        handle === "rotate"
+          ? Math.atan2(initialVector.y, initialVector.x)
+          : undefined,
+      previousUserSelect: document.body.style.userSelect,
+    };
+
+    const handleMove = (ev: PointerEvent) => {
+      if (!transformSession || ev.pointerId !== transformSession.pointerId)
+        return;
+      updateTransformFromPointer(ev);
+    };
+    const handleUp = (ev: PointerEvent) => {
+      if (!transformSession || ev.pointerId !== transformSession.pointerId)
+        return;
+      (event.currentTarget as HTMLElement | null)?.releasePointerCapture?.(
+        transformSession.pointerId,
+      );
+      document.removeEventListener("pointermove", handleMove);
+      document.removeEventListener("pointerup", handleUp);
+      finishTransformDrag();
+    };
+
+    document.addEventListener("pointermove", handleMove);
+    document.addEventListener("pointerup", handleUp);
+    (event.currentTarget as HTMLElement | null)?.setPointerCapture?.(
+      event.pointerId,
+    );
+    document.body.style.userSelect = "none";
+    event.preventDefault();
+  };
+
+  transformHandles.forEach((handleEl) => {
+    listen<PointerEvent>(
+      handleEl,
+      "pointerdown",
+      (event) => {
+        const handleType = handleEl.dataset.handle as TransformHandle | undefined;
+        if (!handleType) return;
+        startTransformDrag(event, handleType);
+      },
+      listeners,
+    );
+  });
+
+  window.addEventListener("resize", updateTransformOverlayBounds);
+  listeners.push(() =>
+    window.removeEventListener("resize", updateTransformOverlayBounds),
+  );
+
+  const commitActiveTransform = () => {
+    if (!editor) return;
+    const canvas = editor.canvas;
+    const state = getTransformState(canvas);
+    if (!state.snapshot) return;
+    if (isIdentityTransform(state.transform)) {
+      state.snapshot = null;
+      state.transform = identityTransform();
+      updateTransformUI();
+      return;
+    }
+
+    const snapshot = state.snapshot;
+    const finalTransform: TransformState = { ...state.transform };
+    restoreFromSnapshot(canvas, snapshot);
+    editor.saveState();
+    state.snapshot = snapshot;
+    state.transform = finalTransform;
+    applyTransformPreview(canvas);
+    state.snapshot = null;
+    state.transform = identityTransform();
+    updateHistoryButtons();
+    updateTransformUI();
+  };
+
+  const resetActiveTransform = () => {
+    if (!editor) return;
+    const canvas = editor.canvas;
+    const state = getTransformState(canvas);
+    if (!state.snapshot) return;
+    restoreFromSnapshot(canvas, state.snapshot);
+    state.snapshot = null;
+    state.transform = identityTransform();
+    updateTransformUI();
+  };
+
+  const flipActiveTransform = (direction: "horizontal" | "vertical") => {
+    if (!editor) return;
+    const canvas = editor.canvas;
+    if (!ensureSnapshotForCanvas(canvas)) return;
+    const state = getTransformState(canvas);
+    const current = state.transform;
+    const next: TransformState = {
+      scaleX:
+        direction === "horizontal"
+          ? sanitizeScale(
+              current.scaleX === 0 ? -1 : -current.scaleX,
+            )
+          : current.scaleX,
+      scaleY:
+        direction === "vertical"
+          ? sanitizeScale(current.scaleY === 0 ? -1 : -current.scaleY)
+          : current.scaleY,
+      rotation: current.rotation,
+    };
+    state.transform = next;
+    applyTransformPreview(canvas);
+    updateTransformUI();
+  };
+
+  listen(resetTransformBtn, "click", resetActiveTransform, listeners);
+  listen(commitTransformBtn, "click", commitActiveTransform, listeners);
+  listen(flipHorizontalBtn, "click", () => flipActiveTransform("horizontal"), listeners);
+  listen(flipVerticalBtn, "click", () => flipActiveTransform("vertical"), listeners);
+
   const editors: Editor[] = [];
   canvases.forEach((c) => {
     try {
@@ -214,6 +673,11 @@ export function initEditor(): EditorHandle {
         fontSize ?? undefined,
       );
       editors.push(e);
+      canvasToEditor.set(c, e);
+      transformStates.set(c, {
+        snapshot: null,
+        transform: identityTransform(),
+      });
     } catch {
       /* skip canvases without 2D context */
     }
@@ -379,6 +843,8 @@ export function initEditor(): EditorHandle {
     const ToolCtor = editorToolConstructors.get(editor) ?? activeToolCtor;
     editor.setTool(new ToolCtor());
     updateHistoryButtons();
+    updateTransformOverlayBounds();
+    updateTransformUI();
     if (layerSelect) layerSelect.value = String(index);
   }
 
@@ -394,5 +860,7 @@ export function initEditor(): EditorHandle {
   };
   recordColor(colorPicker.value);
   updateHistoryButtons();
+  updateTransformOverlayBounds();
+  updateTransformUI();
   return handle;
 }

--- a/style.css
+++ b/style.css
@@ -47,6 +47,31 @@ body {
   gap: 8px;
 }
 
+#transformControls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+#transformControls span {
+  font-size: 14px;
+  color: #333;
+}
+
+#transformControls button {
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+}
+
+#transformControls button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .tool-button {
   width: 32px;
   height: 32px;
@@ -97,6 +122,98 @@ body {
   width: 100%;
   height: 100%;
   box-sizing: border-box;
+}
+
+#transformOverlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.transform-box {
+  position: absolute;
+  border: 1px dashed #1e90ff;
+  pointer-events: none;
+}
+
+.transform-handle {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background: #fff;
+  border: 2px solid #1e90ff;
+  border-radius: 50%;
+  pointer-events: auto;
+  box-sizing: border-box;
+}
+
+.transform-handle[data-handle="n"] {
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  cursor: ns-resize;
+}
+
+.transform-handle[data-handle="s"] {
+  bottom: 0;
+  left: 50%;
+  transform: translate(-50%, 50%);
+  cursor: ns-resize;
+}
+
+.transform-handle[data-handle="e"] {
+  right: 0;
+  top: 50%;
+  transform: translate(50%, -50%);
+  cursor: ew-resize;
+}
+
+.transform-handle[data-handle="w"] {
+  left: 0;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  cursor: ew-resize;
+}
+
+.transform-handle[data-handle="ne"] {
+  top: 0;
+  right: 0;
+  transform: translate(50%, -50%);
+  cursor: nesw-resize;
+}
+
+.transform-handle[data-handle="se"] {
+  bottom: 0;
+  right: 0;
+  transform: translate(50%, 50%);
+  cursor: nwse-resize;
+}
+
+.transform-handle[data-handle="sw"] {
+  bottom: 0;
+  left: 0;
+  transform: translate(-50%, 50%);
+  cursor: nesw-resize;
+}
+
+.transform-handle[data-handle="nw"] {
+  top: 0;
+  left: 0;
+  transform: translate(-50%, -50%);
+  cursor: nwse-resize;
+}
+
+.transform-handle[data-handle="rotate"] {
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -180%);
+  cursor: grab;
+  background: #1e90ff;
+  border-color: #fff;
+}
+
+.transform-handle[data-handle="rotate"]:active {
+  cursor: grabbing;
 }
 
 


### PR DESCRIPTION
## Summary
- add transform toolbar controls for reset, commit, flip, and numeric scale/rotation readouts
- render transform handles around the active canvas layer with pointer interactions for scale, rotation, and flip
- apply transforms non-destructively with snapshot previews, commit/reset actions, and safe element creation fallback

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d60d20062c8328a19f229d4dde2224