### PR TITLE
Centralize canvas pointer mapping and unify high-DPI handling

### DIFF
--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -143,6 +143,27 @@ export class Editor {
     return parseInt(this.fontSize?.value ?? "", 10) || 16;
   }
 
+  getCanvasPoint(e: PointerEvent): {
+    x: number;
+    y: number;
+    pixelX: number;
+    pixelY: number;
+  } {
+    const rect = this.canvas.getBoundingClientRect();
+    const hasOffsetCoordinates =
+      Number.isFinite(e.offsetX) && Number.isFinite(e.offsetY);
+    const x = hasOffsetCoordinates ? e.offsetX : e.clientX - rect.left;
+    const y = hasOffsetCoordinates ? e.offsetY : e.clientY - rect.top;
+    const scaleX = rect.width ? this.canvas.width / rect.width : 1;
+    const scaleY = rect.height ? this.canvas.height / rect.height : 1;
+    return {
+      x,
+      y,
+      pixelX: Math.max(0, Math.min(this.canvas.width - 1, Math.floor(x * scaleX))),
+      pixelY: Math.max(0, Math.min(this.canvas.height - 1, Math.floor(y * scaleY))),
+    };
+  }
+
   /**
    * Remove all event listeners registered by the editor.
    * Should be called before discarding the instance to prevent leaks.

--- a/src/tools/BucketFillTool.ts
+++ b/src/tools/BucketFillTool.ts
@@ -19,9 +19,9 @@ export class BucketFillTool implements Tool {
       return;
     }
 
-    const dpr = window.devicePixelRatio || 1;
-    const sx = Math.max(0, Math.min(width - 1, Math.floor(e.offsetX * dpr)));
-    const sy = Math.max(0, Math.min(height - 1, Math.floor(e.offsetY * dpr)));
+    const point = editor.getCanvasPoint(e);
+    const sx = point.pixelX;
+    const sy = point.pixelY;
     const start = sy * width + sx;
     const targetOffset = start * 4;
     const tr = data[targetOffset];

--- a/src/tools/CircleTool.ts
+++ b/src/tools/CircleTool.ts
@@ -7,8 +7,9 @@ export class CircleTool extends DrawingTool {
   private imageData: ImageData | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
-    this.startX = e.offsetX;
-    this.startY = e.offsetY;
+    const point = editor.getCanvasPoint(e);
+    this.startX = point.x;
+    this.startY = point.y;
     const ctx = editor.ctx;
     this.applyStroke(ctx, editor);
     if (typeof ctx.getImageData === "function") {
@@ -20,11 +21,12 @@ export class CircleTool extends DrawingTool {
 
   onPointerMove(e: PointerEvent, editor: Editor): void {
     if (e.buttons !== 1 || !this.imageData) return;
+    const point = editor.getCanvasPoint(e);
     const ctx = editor.ctx;
     ctx.putImageData(this.imageData, 0, 0);
     this.applyStroke(ctx, editor);
-    const dx = e.offsetX - this.startX;
-    const dy = e.offsetY - this.startY;
+    const dx = point.x - this.startX;
+    const dy = point.y - this.startY;
     let radiusX = Math.abs(dx);
     let radiusY = Math.abs(dy);
     if (e.shiftKey) {
@@ -42,13 +44,14 @@ export class CircleTool extends DrawingTool {
   }
 
   onPointerUp(e: PointerEvent, editor: Editor): void {
+    const point = editor.getCanvasPoint(e);
     const ctx = editor.ctx;
     if (this.imageData) {
       ctx.putImageData(this.imageData, 0, 0);
     }
     this.applyStroke(ctx, editor);
-    const dx = e.offsetX - this.startX;
-    const dy = e.offsetY - this.startY;
+    const dx = point.x - this.startX;
+    const dy = point.y - this.startY;
     let radiusX = Math.abs(dx);
     let radiusY = Math.abs(dy);
     if (e.shiftKey) {

--- a/src/tools/EraserTool.ts
+++ b/src/tools/EraserTool.ts
@@ -3,14 +3,15 @@ import { DrawingTool } from "./DrawingTool.js";
 
 export class EraserTool extends DrawingTool {
   onPointerDown(e: PointerEvent, editor: Editor) {
+    const point = editor.getCanvasPoint(e);
     const ctx = editor.ctx;
     ctx.globalCompositeOperation = "destination-out";
     this.applyStroke(ctx, editor);
     ctx.beginPath();
-    ctx.moveTo(e.offsetX, e.offsetY);
+    ctx.moveTo(point.x, point.y);
     ctx.clearRect(
-      e.offsetX - editor.lineWidthValue / 2,
-      e.offsetY - editor.lineWidthValue / 2,
+      point.x - editor.lineWidthValue / 2,
+      point.y - editor.lineWidthValue / 2,
       editor.lineWidthValue,
       editor.lineWidthValue,
     );
@@ -18,13 +19,14 @@ export class EraserTool extends DrawingTool {
 
   onPointerMove(e: PointerEvent, editor: Editor) {
     if (e.buttons !== 1) return;
+    const point = editor.getCanvasPoint(e);
     const ctx = editor.ctx;
     this.applyStroke(ctx, editor);
-    ctx.lineTo(e.offsetX, e.offsetY);
+    ctx.lineTo(point.x, point.y);
     ctx.stroke();
     ctx.clearRect(
-      e.offsetX - editor.lineWidthValue / 2,
-      e.offsetY - editor.lineWidthValue / 2,
+      point.x - editor.lineWidthValue / 2,
+      point.y - editor.lineWidthValue / 2,
       editor.lineWidthValue,
       editor.lineWidthValue,
     );

--- a/src/tools/EyedropperTool.ts
+++ b/src/tools/EyedropperTool.ts
@@ -9,11 +9,8 @@ export class EyedropperTool implements Tool {
   cursor = "crosshair";
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
-    const { width, height } = editor.canvas;
-    const dpr = window.devicePixelRatio || 1;
-    const x = Math.max(0, Math.min(width - 1, Math.floor(e.offsetX * dpr)));
-    const y = Math.max(0, Math.min(height - 1, Math.floor(e.offsetY * dpr)));
-    const { data } = editor.ctx.getImageData(x, y, 1, 1);
+    const point = editor.getCanvasPoint(e);
+    const { data } = editor.ctx.getImageData(point.pixelX, point.pixelY, 1, 1);
     const [r, g, b] = data;
     const toHex = (v: number) => v.toString(16).padStart(2, "0");
     editor.colorPicker.value = `#${toHex(r)}${toHex(g)}${toHex(b)}`;

--- a/src/tools/LineTool.ts
+++ b/src/tools/LineTool.ts
@@ -7,9 +7,10 @@ export class LineTool extends DrawingTool {
   private imageData: ImageData | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
+    const point = editor.getCanvasPoint(e);
     const ctx = editor.ctx;
-    this.startX = e.offsetX;
-    this.startY = e.offsetY;
+    this.startX = point.x;
+    this.startY = point.y;
     this.applyStroke(ctx, editor);
     this.imageData = ctx.getImageData(
       0,
@@ -21,13 +22,14 @@ export class LineTool extends DrawingTool {
 
   onPointerMove(e: PointerEvent, editor: Editor): void {
     if (e.buttons !== 1 || !this.imageData) return;
+    const point = editor.getCanvasPoint(e);
     const ctx = editor.ctx;
     ctx.putImageData(this.imageData, 0, 0);
     this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
-    let x = e.offsetX;
-    let y = e.offsetY;
+    let x = point.x;
+    let y = point.y;
     if (e.shiftKey) {
       const dx = x - this.startX;
       const dy = y - this.startY;
@@ -43,6 +45,7 @@ export class LineTool extends DrawingTool {
   }
 
   onPointerUp(e: PointerEvent, editor: Editor): void {
+    const point = editor.getCanvasPoint(e);
     const ctx = editor.ctx;
     if (this.imageData) {
       ctx.putImageData(this.imageData, 0, 0);
@@ -50,8 +53,8 @@ export class LineTool extends DrawingTool {
     this.applyStroke(ctx, editor);
     ctx.beginPath();
     ctx.moveTo(this.startX, this.startY);
-    let x = e.offsetX;
-    let y = e.offsetY;
+    let x = point.x;
+    let y = point.y;
     if (e.shiftKey) {
       const dx = x - this.startX;
       const dy = y - this.startY;

--- a/src/tools/PencilTool.ts
+++ b/src/tools/PencilTool.ts
@@ -3,17 +3,19 @@ import { DrawingTool } from "./DrawingTool.js";
 
 export class PencilTool extends DrawingTool {
   onPointerDown(e: PointerEvent, editor: Editor) {
+    const point = editor.getCanvasPoint(e);
     this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
     ctx.beginPath();
-    ctx.moveTo(e.offsetX, e.offsetY);
+    ctx.moveTo(point.x, point.y);
   }
 
   onPointerMove(e: PointerEvent, editor: Editor) {
     if (e.buttons !== 1) return;
+    const point = editor.getCanvasPoint(e);
     this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
-    ctx.lineTo(e.offsetX, e.offsetY);
+    ctx.lineTo(point.x, point.y);
     ctx.stroke();
   }
 

--- a/src/tools/RectangleTool.ts
+++ b/src/tools/RectangleTool.ts
@@ -7,8 +7,9 @@ export class RectangleTool extends DrawingTool {
   private imageData: ImageData | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor) {
-    this.startX = e.offsetX;
-    this.startY = e.offsetY;
+    const point = editor.getCanvasPoint(e);
+    this.startX = point.x;
+    this.startY = point.y;
     this.applyStroke(editor.ctx, editor);
     const ctx = editor.ctx;
     this.imageData = ctx.getImageData(0, 0, editor.canvas.width, editor.canvas.height);
@@ -16,12 +17,13 @@ export class RectangleTool extends DrawingTool {
 
   onPointerMove(e: PointerEvent, editor: Editor) {
     if (e.buttons !== 1 || !this.imageData) return;
+    const point = editor.getCanvasPoint(e);
     const ctx = editor.ctx;
     ctx.putImageData(this.imageData, 0, 0);
     this.applyStroke(editor.ctx, editor);
 
-    const x = e.offsetX;
-    const y = e.offsetY;
+    const x = point.x;
+    const y = point.y;
     let width = x - this.startX;
     let height = y - this.startY;
     if (e.shiftKey) {
@@ -36,14 +38,15 @@ export class RectangleTool extends DrawingTool {
   }
 
   onPointerUp(e: PointerEvent, editor: Editor) {
+    const point = editor.getCanvasPoint(e);
     const ctx = editor.ctx;
     if (this.imageData) {
       ctx.putImageData(this.imageData, 0, 0);
     }
 
     this.applyStroke(editor.ctx, editor);
-    const x = e.offsetX;
-    const y = e.offsetY;
+    const x = point.x;
+    const y = point.y;
     let width = x - this.startX;
     let height = y - this.startY;
     if (e.shiftKey) {

--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -9,12 +9,13 @@ export class TextTool implements Tool {
     | null = null;
 
   onPointerDown(e: PointerEvent, editor: Editor): void {
+    const point = editor.getCanvasPoint(e);
     this.cleanup();
     const textarea = document.createElement("textarea");
     textarea.style.position = "absolute";
     const parent = editor.canvas.parentElement || document.body;
-    textarea.style.left = `${e.offsetX}px`;
-    textarea.style.top = `${e.offsetY}px`;
+    textarea.style.left = `${point.x}px`;
+    textarea.style.top = `${point.y}px`;
     textarea.style.color = editor.strokeStyle;
     textarea.style.fontSize = `${editor.fontSizeValue}px`;
     textarea.style.fontFamily = editor.fontFamilyValue;
@@ -30,7 +31,7 @@ export class TextTool implements Tool {
       if (text) {
         editor.ctx.fillStyle = editor.strokeStyle;
         editor.ctx.font = `${editor.fontSizeValue}px ${editor.fontFamilyValue}`;
-        editor.ctx.fillText(text, e.offsetX, e.offsetY);
+        editor.ctx.fillText(text, point.x, point.y);
       }
     };
 

--- a/tests/bucketFillTool.test.ts
+++ b/tests/bucketFillTool.test.ts
@@ -14,6 +14,13 @@ describe("BucketFillTool", () => {
       <input id="fillMode" type="checkbox" />
     `;
     canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    canvas.getBoundingClientRect = () =>
+      ({
+        width: 5,
+        height: 5,
+        left: 0,
+        top: 0,
+      }) as DOMRect;
     (canvas as any).setPointerCapture = jest.fn();
     (canvas as any).releasePointerCapture = jest.fn();
 
@@ -50,7 +57,7 @@ describe("BucketFillTool", () => {
 
   it("fills enclosed areas with the selected color", () => {
     const tool = new BucketFillTool();
-    tool.onPointerDown({ offsetX: 2, offsetY: 2 } as PointerEvent, editor);
+    tool.onPointerDown({ clientX: 2, clientY: 2 } as PointerEvent, editor);
 
     const image = (ctx.getImageData as jest.Mock).mock.results[0].value as ImageData;
     const center = (2 * 5 + 2) * 4;
@@ -81,12 +88,28 @@ describe("BucketFillTool", () => {
     (ctx.getImageData as jest.Mock).mockReturnValueOnce(image);
 
     const tool = new BucketFillTool();
-    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+    tool.onPointerDown({ clientX: 0, clientY: 0 } as PointerEvent, editor);
 
     const last = (width * height - 1) * 4;
     expect(image.data[last]).toBe(0);
     expect(image.data[last + 1]).toBe(0);
     expect(image.data[last + 2]).toBe(255);
     expect(ctx.putImageData).toHaveBeenCalledWith(image, 0, 0);
+  });
+
+  it("maps high-DPI pointer positions accurately", () => {
+    Object.defineProperty(window, "devicePixelRatio", { value: 2, configurable: true });
+    canvas.getBoundingClientRect = () =>
+      ({
+        width: 2.5,
+        height: 2.5,
+        left: 0,
+        top: 0,
+      }) as DOMRect;
+    const tool = new BucketFillTool();
+    tool.onPointerDown({ clientX: 1, clientY: 1 } as PointerEvent, editor);
+    const image = (ctx.getImageData as jest.Mock).mock.results[0].value as ImageData;
+    const center = (2 * 5 + 2) * 4;
+    expect(image.data[center + 2]).toBe(255);
   });
 });

--- a/tests/eyedropperTool.test.ts
+++ b/tests/eyedropperTool.test.ts
@@ -24,8 +24,8 @@ describe("EyedropperTool", () => {
     };
     canvas.getContext = jest.fn().mockReturnValue(ctx as CanvasRenderingContext2D);
     canvas.getBoundingClientRect = () => ({
-      width: 0,
-      height: 0,
+      width: 1,
+      height: 1,
       left: 0,
       top: 0,
       right: 0,
@@ -44,7 +44,7 @@ describe("EyedropperTool", () => {
 
   it("updates the color picker based on canvas pixel", () => {
     const tool = new EyedropperTool();
-    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+    tool.onPointerDown({ clientX: 0, clientY: 0 } as PointerEvent, editor);
     expect(editor.colorPicker.value).toBe("#0c2238");
   });
 
@@ -76,12 +76,28 @@ describe("EyedropperTool", () => {
       recordColor(colorPicker.value);
     });
 
-    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, editor);
+    tool.onPointerDown({ clientX: 0, clientY: 0 } as PointerEvent, editor);
 
     expect(recentColors[0]).toBe("#0c2238");
     expect(colorHistory.children).toHaveLength(1);
     const swatch = colorHistory.children[0] as HTMLElement;
     expect(swatch.style.backgroundColor).toBe("rgb(12, 34, 56)");
+  });
+
+  it("samples the correct pixel under high DPI", () => {
+    Object.defineProperty(window, "devicePixelRatio", { value: 2, configurable: true });
+    canvas.width = 4;
+    canvas.height = 4;
+    canvas.getBoundingClientRect = () =>
+      ({
+        width: 2,
+        height: 2,
+        left: 0,
+        top: 0,
+      }) as DOMRect;
+    const tool = new EyedropperTool();
+    tool.onPointerDown({ clientX: 1, clientY: 1 } as PointerEvent, editor);
+    expect(ctx.getImageData).toHaveBeenCalledWith(2, 2, 1, 1);
   });
 });
 
@@ -140,10 +156,9 @@ describe("EyedropperTool color history", () => {
     const history = document.getElementById("colorHistory") as HTMLDivElement;
     expect(history.children).toHaveLength(1);
     const tool = new EyedropperTool();
-    tool.onPointerDown({ offsetX: 0, offsetY: 0 } as PointerEvent, handle.editor);
+    tool.onPointerDown({ clientX: 0, clientY: 0 } as PointerEvent, handle.editor);
     expect(history.children).toHaveLength(2);
     const swatch = history.children[0] as HTMLButtonElement;
     expect(swatch.style.backgroundColor).toBe("rgb(12, 34, 56)");
   });
 });
-


### PR DESCRIPTION
### Motivation
- Tools used ad-hoc `offsetX/offsetY` and duplicated device pixel ratio math which produced inconsistent behavior on high-DPI canvases.  
- Provide a single, authoritative mapping from pointer events to canvas-space and backing-store pixel coordinates to ensure hit accuracy and avoid per-tool DPR duplication.

### Description
- Add `Editor.getCanvasPoint(e)` which returns `{ x, y, pixelX, pixelY }` by using the canvas bounding rect and the scale between CSS size and backing-store size.  
- Update all tools in `src/tools/*.ts` (Pencil, Eraser, Line, Rectangle, Circle, Text, BucketFill, Eyedropper) to use `editor.getCanvasPoint(e)` instead of ad-hoc `offsetX/offsetY` or manual DPR math.  
- Remove duplicate DPR calculations from `BucketFillTool` and `EyedropperTool` and use `point.pixelX`/`point.pixelY` for `getImageData` sampling.  
- Add high-DPI-focused tests to `tests/bucketFillTool.test.ts` and `tests/eyedropperTool.test.ts` that mock `devicePixelRatio` and scaled `getBoundingClientRect` to validate hit mapping.

### Testing
- Ran a focused suite `npm test -- --runInBand tests/editor.test.ts tests/bucketFillTool.test.ts tests/eyedropperTool.test.ts` and all selected tests passed.  
- Ran the full test suite with `npm test -- --runInBand` and all tests passed (60/60).  
- Automated tests cover normal and high-DPI scenarios for drawing, text placement, eyedropper sampling, and bucket-fill behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94c96c80883288e9ba57c5b7498ee)