### PR TITLE
Fix opacity control lifecycle across editor reinitialization

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -35,6 +35,7 @@ export interface EditorHandle {
  * {@link EditorHandle} that allows tests or callers to tear down the editor.
  */
 export function initEditor(): EditorHandle {
+  const createdDynamicNodes: HTMLElement[] = [];
   const canvases = Array.from(
     document.querySelectorAll<HTMLCanvasElement>("canvas"),
   );
@@ -131,24 +132,58 @@ export function initEditor(): EditorHandle {
       layerSelect.appendChild(opt);
     }
 
-    if (!document.getElementById(`${canvasId}Opacity`) && i > 0) {
+    if (i > 0) {
+      const opacityInputId = `${canvasId}Opacity`;
+      const existingInputs = Array.from(
+        document.querySelectorAll<HTMLInputElement>(`input[id='${opacityInputId}']`),
+      );
+      const existingGeneratedInput = existingInputs.find(
+        (input) => input.dataset.generatedOpacityInput === "true",
+      );
+
+      existingInputs
+        .filter((input) => input !== existingGeneratedInput)
+        .forEach((input) => {
+          const parent = input.closest<HTMLElement>(".group");
+          if (parent?.dataset.generatedOpacityGroup === "true") {
+            parent.remove();
+          }
+        });
+
+      if (existingGeneratedInput) {
+        const group = existingGeneratedInput.closest<HTMLElement>(".group");
+        if (group && group.dataset.generatedOpacityGroup === "true") {
+          const label = group.querySelector<HTMLLabelElement>("label");
+          if (label) {
+            label.htmlFor = opacityInputId;
+            label.textContent = `${name} Opacity`;
+          }
+          existingGeneratedInput.id = opacityInputId;
+          if (!existingGeneratedInput.value) existingGeneratedInput.value = "100";
+          return;
+        }
+      }
+
       const group = document.createElement("div");
       group.className = "group";
+      group.dataset.generatedOpacityGroup = "true";
 
       const label = document.createElement("label");
-      label.htmlFor = `${canvasId}Opacity`;
+      label.htmlFor = opacityInputId;
       label.textContent = `${name} Opacity`;
 
       const input = document.createElement("input");
-      input.id = `${canvasId}Opacity`;
+      input.id = opacityInputId;
       input.type = "number";
       input.min = "0";
       input.max = "100";
       input.value = "100";
+      input.dataset.generatedOpacityInput = "true";
 
       group.appendChild(label);
       group.appendChild(input);
       toolbar.appendChild(group);
+      createdDynamicNodes.push(group);
     }
   });
 
@@ -390,6 +425,7 @@ export function initEditor(): EditorHandle {
       listeners.forEach((fn) => fn());
       shortcuts.destroy();
       editors.forEach((e) => e.destroy());
+      createdDynamicNodes.forEach((node) => node.remove());
     },
   };
   recordColor(colorPicker.value);

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -163,4 +163,56 @@ describe("editor toolbar controls", () => {
     expect(ctx.fillText).toHaveBeenCalledWith("hi", 10, 10);
     expect(document.querySelector("textarea")).toBeNull();
   });
+
+  it("does not duplicate generated opacity controls across init/destroy cycles", () => {
+    handle.destroy();
+
+    document.body.innerHTML = `
+      <div id="toolbar"></div>
+      <canvas id="layer1"></canvas>
+      <canvas id="layer2"></canvas>
+      <input id="colorPicker" value="#000000" />
+      <input id="lineWidth" value="2" />
+      <input id="fillMode" type="checkbox" />
+      <button id="pencil"></button>
+      <button id="eraser"></button>
+      <button id="rectangle"></button>
+      <button id="line"></button>
+      <button id="circle"></button>
+      <button id="text"></button>
+      <button id="bucket"></button>
+      <button id="eyedropper"></button>
+      <select id="formatSelect"><option value="png">PNG</option></select>
+      <input id="imageLoader" type="file" />
+      <button id="undo"></button>
+      <button id="redo"></button>
+      <button id="save"></button>
+    `;
+
+    document.querySelectorAll("canvas").forEach((layerCanvas) => {
+      (layerCanvas as any).setPointerCapture = jest.fn();
+      (layerCanvas as any).releasePointerCapture = jest.fn();
+      layerCanvas.getContext = jest.fn().mockReturnValue(ctx as CanvasRenderingContext2D);
+      layerCanvas.toDataURL = jest.fn().mockReturnValue("data:image/png;base64,TEST");
+      layerCanvas.getBoundingClientRect = () => ({
+        width: 100,
+        height: 100,
+        top: 0,
+        left: 0,
+        bottom: 100,
+        right: 100,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      });
+    });
+
+    for (let i = 0; i < 3; i += 1) {
+      const cycleHandle = initEditor();
+      expect(document.querySelectorAll("input[id$='Opacity']")).toHaveLength(1);
+      cycleHandle.destroy();
+    }
+
+    handle = initEditor();
+  });
 });


### PR DESCRIPTION
### Motivation
- Repeated calls to `initEditor()` could create duplicate layer opacity controls which persist across reinitialization cycles and clutter the toolbar. 
- The editor teardown did not remove dynamically generated DOM nodes, causing stale controls to remain after `destroy()`.

### Description
- Track dynamically created opacity control groups in a local array `createdDynamicNodes` so they can be removed on teardown. 
- Harden opacity-control initialization to detect existing matching inputs, prefer reusing previously generated controls (marked via `data-*` attributes), and remove stale generated duplicates before creating new groups. 
- Mark generated groups and inputs with `dataset.generatedOpacityGroup` / `dataset.generatedOpacityInput` and update label/id when reusing a generated input. 
- Extend `EditorHandle.destroy()` to remove any nodes recorded in `createdDynamicNodes`. 
- Add an integration test that repeatedly calls `initEditor()`/`destroy()` and asserts there is exactly one `input[id$='Opacity']` per cycle to prevent regressions. 

### Testing
- Ran `npm test -- --runInBand tests/editor.test.ts` and the suite passed. 
- The edited `tests/editor.test.ts` test `does not duplicate generated opacity controls across init/destroy cycles` was executed and succeeded as part of the file's tests (all tests in the file passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94c99725c8328ad8085ee8b920a16)