### PR TITLE
Improve canvas resize retention with offscreen copy

### DIFF
--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -73,14 +73,56 @@ export class Editor {
   }
 
   private handleResize = () => {
-    const data = this.ctx.getImageData(
-      0,
-      0,
-      this.canvas.width,
-      this.canvas.height,
-    );
+    const previousWidth = this.canvas.width;
+    const previousHeight = this.canvas.height;
+    const offscreen = document.createElement("canvas");
+    offscreen.width = previousWidth;
+    offscreen.height = previousHeight;
+    const offscreenCtx = offscreen.getContext("2d");
+    if (!offscreenCtx) return;
+    offscreenCtx.drawImage(this.canvas, 0, 0);
+
+    const previousState = {
+      lineJoin: this.ctx.lineJoin,
+      lineCap: this.ctx.lineCap,
+      miterLimit: this.ctx.miterLimit,
+      lineDashOffset: this.ctx.lineDashOffset,
+      globalCompositeOperation: this.ctx.globalCompositeOperation,
+      globalAlpha: this.ctx.globalAlpha,
+      imageSmoothingEnabled: this.ctx.imageSmoothingEnabled,
+      filter: this.ctx.filter,
+      lineDash: this.ctx.getLineDash(),
+    };
+
     this.adjustForPixelRatio();
-    this.ctx.putImageData(data, 0, 0);
+    const nextWidth = this.canvas.width;
+    const nextHeight = this.canvas.height;
+    /**
+     * Resize policy: top-left preserve.
+     * - Enlarging keeps existing content at the top-left and leaves new area blank.
+     * - Shrinking keeps only the top-left region (content outside new bounds is clipped).
+     */
+    this.ctx.drawImage(
+      offscreen,
+      0,
+      0,
+      Math.min(previousWidth, nextWidth),
+      Math.min(previousHeight, nextHeight),
+      0,
+      0,
+      Math.min(previousWidth, nextWidth),
+      Math.min(previousHeight, nextHeight),
+    );
+
+    this.ctx.lineJoin = previousState.lineJoin;
+    this.ctx.lineCap = previousState.lineCap;
+    this.ctx.miterLimit = previousState.miterLimit;
+    this.ctx.lineDashOffset = previousState.lineDashOffset;
+    this.ctx.globalCompositeOperation = previousState.globalCompositeOperation;
+    this.ctx.globalAlpha = previousState.globalAlpha;
+    this.ctx.imageSmoothingEnabled = previousState.imageSmoothingEnabled;
+    this.ctx.filter = previousState.filter;
+    this.ctx.setLineDash(previousState.lineDash);
   };
 
   saveState() {

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -54,6 +54,8 @@ describe("editor toolbar controls", () => {
       fillText: jest.fn(),
       setTransform: jest.fn(),
       scale: jest.fn(),
+      setLineDash: jest.fn(),
+      getLineDash: jest.fn(() => []),
       globalCompositeOperation: "source-over" as GlobalCompositeOperation,
     };
 
@@ -78,6 +80,7 @@ describe("editor toolbar controls", () => {
 
   afterEach(() => {
     handle.destroy();
+    jest.restoreAllMocks();
   });
 
   function dispatch(type: string, x: number, y: number, buttons = 0) {
@@ -162,5 +165,86 @@ describe("editor toolbar controls", () => {
     );
     expect(ctx.fillText).toHaveBeenCalledWith("hi", 10, 10);
     expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("preserves content at top-left when canvas enlarges on resize", () => {
+    const originalCreate = document.createElement.bind(document);
+    const offscreenCtx = { drawImage: jest.fn() } as Partial<CanvasRenderingContext2D>;
+    jest.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      if (tagName === "canvas") {
+        return {
+          width: 0,
+          height: 0,
+          getContext: jest.fn(() => offscreenCtx),
+        } as unknown as HTMLCanvasElement;
+      }
+      return originalCreate(tagName);
+    });
+
+    canvas.getBoundingClientRect = () => ({
+      width: 150,
+      height: 140,
+      top: 0,
+      left: 0,
+      bottom: 140,
+      right: 150,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+    window.dispatchEvent(new Event("resize"));
+
+    expect(offscreenCtx.drawImage).toHaveBeenCalledWith(canvas, 0, 0);
+    expect(ctx.drawImage).toHaveBeenCalledWith(
+      expect.anything(),
+      0,
+      0,
+      100,
+      100,
+      0,
+      0,
+      100,
+      100,
+    );
+  });
+
+  it("clips to top-left region when canvas shrinks on resize", () => {
+    const originalCreate = document.createElement.bind(document);
+    const offscreenCtx = { drawImage: jest.fn() } as Partial<CanvasRenderingContext2D>;
+    jest.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      if (tagName === "canvas") {
+        return {
+          width: 0,
+          height: 0,
+          getContext: jest.fn(() => offscreenCtx),
+        } as unknown as HTMLCanvasElement;
+      }
+      return originalCreate(tagName);
+    });
+
+    canvas.getBoundingClientRect = () => ({
+      width: 60,
+      height: 80,
+      top: 0,
+      left: 0,
+      bottom: 80,
+      right: 60,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+    window.dispatchEvent(new Event("resize"));
+
+    expect(ctx.drawImage).toHaveBeenCalledWith(
+      expect.anything(),
+      0,
+      0,
+      60,
+      80,
+      0,
+      0,
+      60,
+      80,
+    );
   });
 });


### PR DESCRIPTION
### Motivation
- Avoid lossy or brittle `getImageData` snapshot/restore across DPR-aware resizes by using an offscreen copy to preserve drawn content. 
- Ensure canvas drawing/compositing state (line join/cap, dash, alpha, composite mode, smoothing, filter) is preserved after a resize so tools behave consistently. 
- Define and document deterministic behavior for aspect/size changes to avoid surprises when the canvas is enlarged or shrunk.

### Description
- Replaced the old `getImageData`/`putImageData` flow in `Editor.handleResize` with an offscreen `canvas` copy that draws the previous content, then resizes the main canvas via `adjustForPixelRatio()` and redraws from the offscreen buffer. 
- Captured and re-applied drawing/compositing state (`lineJoin`, `lineCap`, `miterLimit`, `lineDashOffset`, `lineDash`, `globalCompositeOperation`, `globalAlpha`, `imageSmoothingEnabled`, `filter`) around the resize, and added a comment documenting the chosen resize policy. 
- Implemented a documented resize policy of `top-left preserve` where enlarging keeps previous pixels anchored at `(0,0)` and shrinking clips to the top-left region. 
- Added tests in `tests/editor.test.ts` to assert the offscreen copy is used and that `drawImage` is called with the expected source/destination rectangles for both enlarge and shrink scenarios, and updated test mocks to include `setLineDash`/`getLineDash` and restore mocks after each test.

### Testing
- Ran the full test suite with `npm test -- --runInBand`, and all suites passed. 
- Test summary: 18 test suites passed and 60 tests passed, run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94c98e668832894fc35c459fe7653)