### PR TITLE
Improve text tool positioning and commit/cancel semantics

### DIFF
--- a/src/core/Editor.ts
+++ b/src/core/Editor.ts
@@ -92,6 +92,12 @@ export class Editor {
     this.onChange?.();
   }
 
+  discardLastState() {
+    if (!this.undoStack.length) return;
+    this.undoStack.pop();
+    this.onChange?.();
+  }
+
   private restoreState(stack: ImageData[], opposite: ImageData[]) {
     if (!stack.length) return;
     opposite.push(

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -120,6 +120,13 @@ export function initEditor(): EditorHandle {
     layerSelect.innerHTML = "";
   }
 
+  canvases.forEach((canvas) => {
+    const parent = canvas.parentElement;
+    if (parent && window.getComputedStyle(parent).position === "static") {
+      parent.style.position = "relative";
+    }
+  });
+
   canvases.forEach((c, i) => {
     const canvasId = c.id || `layer${i + 1}`;
     const name = c.id || `Layer ${i + 1}`;

--- a/src/tools/TextTool.ts
+++ b/src/tools/TextTool.ts
@@ -12,9 +12,27 @@ export class TextTool implements Tool {
     this.cleanup();
     const textarea = document.createElement("textarea");
     textarea.style.position = "absolute";
+
+    const canvasRect = editor.canvas.getBoundingClientRect();
+    const scrollX = window.scrollX;
+    const scrollY = window.scrollY;
+    const x = e.clientX ? e.clientX - canvasRect.left : e.offsetX;
+    const y = e.clientY ? e.clientY - canvasRect.top : e.offsetY;
+
     const parent = editor.canvas.parentElement || document.body;
-    textarea.style.left = `${e.offsetX}px`;
-    textarea.style.top = `${e.offsetY}px`;
+    const parentStyle = window.getComputedStyle(parent);
+    if (parentStyle.position === "static") {
+      parent.style.position = "relative";
+    }
+
+    const parentRect = parent.getBoundingClientRect();
+    const absoluteLeft = canvasRect.left + scrollX + x;
+    const absoluteTop = canvasRect.top + scrollY + y;
+    const parentLeft = parentRect.left + scrollX;
+    const parentTop = parentRect.top + scrollY;
+
+    textarea.style.left = `${absoluteLeft - parentLeft}px`;
+    textarea.style.top = `${absoluteTop - parentTop}px`;
     textarea.style.color = editor.strokeStyle;
     textarea.style.fontSize = `${editor.fontSizeValue}px`;
     textarea.style.fontFamily = editor.fontFamilyValue;
@@ -24,25 +42,31 @@ export class TextTool implements Tool {
     parent.appendChild(textarea);
     textarea.focus();
 
+    const initialText = textarea.value;
     const commit = () => {
       const text = textarea.value;
+      const hasContent = text.trim().length > 0;
+      const changed = text !== initialText;
       this.cleanup();
-      if (text) {
+      if (hasContent && changed) {
         editor.ctx.fillStyle = editor.strokeStyle;
         editor.ctx.font = `${editor.fontSizeValue}px ${editor.fontFamilyValue}`;
-        editor.ctx.fillText(text, e.offsetX, e.offsetY);
+        editor.ctx.fillText(text, x, y);
+        return;
       }
+      editor.discardLastState();
     };
 
     const cancel = () => {
       this.cleanup();
+      editor.discardLastState();
     };
 
     this.blurListener = cancel;
     textarea.addEventListener("blur", this.blurListener);
 
     this.keydownListener = (ev: KeyboardEvent) => {
-      if (ev.key === "Enter") {
+      if (ev.key === "Enter" && !ev.shiftKey) {
         ev.preventDefault();
         commit();
       } else if (ev.key === "Escape") {

--- a/tests/textTool.test.ts
+++ b/tests/textTool.test.ts
@@ -9,7 +9,7 @@ describe("TextTool", () => {
 
   beforeEach(() => {
     document.body.innerHTML = `
-      <div id="container">
+      <div id="container" style="position: static;">
         <canvas id="canvas"></canvas>
       </div>
       <input id="colorPicker" value="#123456" />
@@ -43,25 +43,25 @@ describe("TextTool", () => {
       .fn()
       .mockReturnValue(ctx as CanvasRenderingContext2D);
     canvas.getBoundingClientRect = () => ({
-      left: 0,
-      top: 0,
-      right: 0,
-      bottom: 0,
-      width: 0,
-      height: 0,
-      x: 0,
-      y: 0,
+      left: 100,
+      top: 50,
+      right: 200,
+      bottom: 150,
+      width: 100,
+      height: 100,
+      x: 100,
+      y: 50,
       toJSON: () => {},
     });
     container.getBoundingClientRect = () => ({
-      left: 0,
-      top: 0,
-      right: 0,
-      bottom: 0,
-      width: 0,
-      height: 0,
-      x: 0,
-      y: 0,
+      left: 80,
+      top: 30,
+      right: 280,
+      bottom: 230,
+      width: 200,
+      height: 200,
+      x: 80,
+      y: 30,
       toJSON: () => {},
     });
 
@@ -80,60 +80,77 @@ describe("TextTool", () => {
     editor.destroy();
   });
 
-  it("creates textarea overlay on pointer down", () => {
+  it("positions textarea from canvas rect and scroll inside positioned parent", () => {
+    Object.defineProperty(window, "scrollX", { value: 15, configurable: true });
+    Object.defineProperty(window, "scrollY", { value: 25, configurable: true });
+
     const tool = new TextTool();
-    tool.onPointerDown({ offsetX: 10, offsetY: 20 } as PointerEvent, editor);
+    tool.onPointerDown(
+      { offsetX: 10, offsetY: 20, clientX: 140, clientY: 95 } as PointerEvent,
+      editor,
+    );
     const ta = document.querySelector("textarea") as HTMLTextAreaElement;
-    expect(ta).toBeTruthy();
-    expect(ta.style.left).toBe("10px");
-    expect(ta.style.top).toBe("20px");
-    const hexToRgb = (hex: string) => {
-      const v = hex.replace("#", "");
-      const r = parseInt(v.substring(0, 2), 16);
-      const g = parseInt(v.substring(2, 4), 16);
-      const b = parseInt(v.substring(4, 6), 16);
-      return `rgb(${r}, ${g}, ${b})`;
-    };
-    expect(ta.style.color).toBe(hexToRgb(editor.strokeStyle));
-    expect(ta.style.fontSize).toBe(`${editor.fontSizeValue}px`);
-    expect(ta.style.fontFamily).toBe(editor.fontFamilyValue);
+    const container = document.getElementById("container") as HTMLElement;
+    expect(container.style.position).toBe("relative");
+    expect(ta.style.left).toBe("60px");
+    expect(ta.style.top).toBe("65px");
+    expect(ta.parentElement).toBe(container);
   });
 
-  it("commits text on Enter", () => {
+  it("commits text on Enter and keeps newline behavior for Shift+Enter", () => {
     const tool = new TextTool();
+    editor.saveState();
     tool.onPointerDown({ offsetX: 5, offsetY: 6 } as PointerEvent, editor);
     const ta = document.querySelector("textarea") as HTMLTextAreaElement;
+
+    const shiftEnter = new KeyboardEvent("keydown", {
+      key: "Enter",
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    ta.dispatchEvent(shiftEnter);
+    expect(shiftEnter.defaultPrevented).toBe(false);
+    expect(ctx.fillText).not.toHaveBeenCalled();
+
     ta.value = "hello";
-    ta.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    ta.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }),
+    );
     expect(ctx.font).toBe(`${editor.fontSizeValue}px ${editor.fontFamilyValue}`);
     expect(ctx.fillText).toHaveBeenCalledWith("hello", 5, 6);
     expect(document.querySelector("textarea")).toBeNull();
   });
 
-  it("cancels text on Escape", () => {
+  it("cancels text on Escape without committing and drops pending history", () => {
     const tool = new TextTool();
+    editor.saveState();
     tool.onPointerDown({ offsetX: 7, offsetY: 8 } as PointerEvent, editor);
     const ta = document.querySelector("textarea") as HTMLTextAreaElement;
     ta.value = "cancel";
     ta.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
     expect(ctx.fillText).not.toHaveBeenCalled();
+    expect(editor.canUndo).toBe(false);
     expect(document.querySelector("textarea")).toBeNull();
   });
 
-  it("supports undo with a single step after committing text", () => {
+  it("does not commit empty or unchanged text", () => {
     const tool = new TextTool();
+
     editor.saveState();
     tool.onPointerDown({ offsetX: 9, offsetY: 10 } as PointerEvent, editor);
-    const ta = document.querySelector("textarea") as HTMLTextAreaElement;
-    ta.value = "undo";
-    ta.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
-    );
-    expect(ctx.fillText).toHaveBeenCalledWith("undo", 9, 10);
-    // Only one undo should revert the text addition
-    editor.undo();
-    expect(ctx.clearRect).toHaveBeenCalledTimes(1);
-    expect(ctx.putImageData).toHaveBeenCalledTimes(1);
+    let ta = document.querySelector("textarea") as HTMLTextAreaElement;
+    ta.value = "   ";
+    ta.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(ctx.fillText).not.toHaveBeenCalled();
+    expect(editor.canUndo).toBe(false);
+
+    editor.saveState();
+    tool.onPointerDown({ offsetX: 9, offsetY: 10 } as PointerEvent, editor);
+    ta = document.querySelector("textarea") as HTMLTextAreaElement;
+    ta.value = "";
+    ta.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(ctx.fillText).not.toHaveBeenCalled();
+    expect(editor.canUndo).toBe(false);
   });
 });
-


### PR DESCRIPTION
### Motivation
- Fix incorrect textarea overlay placement which previously relied on raw `offsetX/offsetY` and failed under scroll/layout offsets. 
- Ensure the text overlay is attached to a predictable, positioned container so absolute placement behaves reliably. 
- Make text commit behavior explicit so `Enter` commits, `Shift+Enter` inserts a newline, and `Escape` cancels. 
- Avoid recording no-op history entries when the user leaves the text empty or unchanged. 

### Description
- `src/tools/TextTool.ts`: compute placement from `canvas.getBoundingClientRect()` combined with `window.scrollX/scrollY` and convert to coordinates relative to the overlay parent, ensure the parent is `position: relative` when static, and attach the textarea to that parent. 
- `src/tools/TextTool.ts`: separate `Enter` vs `Shift+Enter` (`Enter` with no `shiftKey` commits, `Shift+Enter` preserves newline behavior) and `Escape` cancels; commit only if trimmed text is non-empty and changed versus the initial value. 
- `src/core/Editor.ts`: add `discardLastState()` to allow tools to remove a previously-saved undo snapshot when a pending action ends up being a no-op. 
- `src/editor.ts`: enforce parent positioning for canvases during editor initialization so overlays have a well-defined positioned container. 
- `tests/textTool.test.ts`: add and update tests covering positioning with canvas rect+scroll inside a positioned parent, `Enter`/`Shift+Enter` semantics, cancel behavior dropping pending history, and no-op (empty/unchanged) commit behavior. 

### Testing
- Ran the focused test suite with `npm test -- --runInBand tests/textTool.test.ts`. 
- Test run result: `PASS tests/textTool.test.ts` with 4 tests passed and 0 failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94c998c94832886dd13454aad0a8a)