### PR TITLE
Refactor editor into modular controllers and add unit tests

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -9,19 +9,13 @@ import { TextTool } from "./tools/TextTool.js";
 import { BucketFillTool } from "./tools/BucketFillTool.js";
 import { EyedropperTool } from "./tools/EyedropperTool.js";
 import type { Tool } from "./tools/Tool.js";
-
-/** Utility to listen to events and auto-remove on destroy. */
-function listen<T extends Event>(
-  el: HTMLElement | null,
-  type: string,
-  handler: (e: T) => void,
-  list: Array<() => void>,
-) {
-  if (!el) return;
-  const wrapped = handler as EventListener;
-  el.addEventListener(type, wrapped);
-  list.push(() => el.removeEventListener(type, wrapped));
-}
+import { requireElement, optionalElement, type Cleanup } from "./editor/domHelpers.js";
+import { initColorHistory } from "./editor/colorHistory.js";
+import { initHistoryControls } from "./editor/historyControls.js";
+import { initToolControls } from "./editor/toolControls.js";
+import { initLayerControls } from "./editor/layerControls.js";
+import { initSaveExport } from "./editor/saveExport.js";
+import { initImageImport } from "./editor/imageImport.js";
 
 export interface EditorHandle {
   editor: Editor;
@@ -30,369 +24,89 @@ export interface EditorHandle {
   destroy(): void;
 }
 
-/**
- * Initialize the editor by wiring up DOM controls and returning an
- * {@link EditorHandle} that allows tests or callers to tear down the editor.
- */
 export function initEditor(): EditorHandle {
-  const canvases = Array.from(
-    document.querySelectorAll<HTMLCanvasElement>("canvas"),
-  );
+  const cleanups: Cleanup[] = [];
+  const canvases = Array.from(document.querySelectorAll<HTMLCanvasElement>("canvas"));
+  const colorPicker = requireElement<HTMLInputElement>("colorPicker", "input");
+  const lineWidth = requireElement<HTMLInputElement>("lineWidth", "input");
+  const fillMode = requireElement<HTMLInputElement>("fillMode", "input");
+  const fontFamily = optionalElement<HTMLSelectElement>("fontFamily") ?? undefined;
+  const fontSize = optionalElement<HTMLInputElement>("fontSize") ?? undefined;
+  const toolbar = document.getElementById("toolbar") || document.body;
 
   const toolConstructors: Record<string, new () => Tool> = {
-    pencil: PencilTool,
-    eraser: EraserTool,
-    rectangle: RectangleTool,
-    line: LineTool,
-    circle: CircleTool,
-    text: TextTool,
-    bucket: BucketFillTool,
-    eyedropper: EyedropperTool,
-  };
-
-  const toolButtons: Record<string, HTMLButtonElement> = {};
-  const constructorToId = new Map<new () => Tool, string>();
-  const editorToolConstructors = new Map<Editor, new () => Tool>();
-  let activeToolCtor: new () => Tool = PencilTool;
-  let activeLayerIndex = 0;
-  Object.entries(toolConstructors).forEach(([id, Ctor]) => {
-    const btn = document.getElementById(id) as HTMLButtonElement | null;
-    if (!btn) {
-      throw new Error(`Missing #${id} button`);
-    }
-    toolButtons[id] = btn;
-    constructorToId.set(Ctor, id);
-  });
-
-  let activeButton: HTMLButtonElement | null = null;
-  const setActiveButton = (btn: HTMLButtonElement | null) => {
-    if (activeButton) activeButton.classList.remove("active");
-    if (btn) btn.classList.add("active");
-    activeButton = btn;
-  };
-  const buttonForTool = (tool: Tool): HTMLButtonElement | null => {
-    for (const [id, ToolCtor] of Object.entries(toolConstructors)) {
-      if (tool instanceof ToolCtor) {
-        return toolButtons[id];
-      }
-    }
-    return null;
-  };
-
-  const updateLayerInteractivity = () => {
-    canvases.forEach((canvas, index) => {
-      canvas.style.pointerEvents = index === activeLayerIndex ? "auto" : "none";
-    });
-  };
-
-  const colorPicker =
-    document.getElementById("colorPicker") as HTMLInputElement | null;
-  const lineWidth = document.getElementById("lineWidth") as HTMLInputElement | null;
-  const fillMode = document.getElementById("fillMode") as HTMLInputElement | null;
-  const fontFamily = document.getElementById("fontFamily") as HTMLSelectElement | null;
-  const fontSize = document.getElementById("fontSize") as HTMLInputElement | null;
-  const layerSelect = document.getElementById("layerSelect") as HTMLSelectElement | null;
-  const toolbar = document.getElementById("toolbar") || document.body;
-  const saveBtn = document.getElementById("save") as HTMLButtonElement | null;
-  const formatSelect =
-    document.getElementById("formatSelect") as HTMLSelectElement | null;
-  const colorHistory = document.getElementById(
-    "colorHistory",
-  ) as HTMLDivElement | null;
-
-  if (!colorPicker) {
-    throw new Error("Missing #colorPicker input");
-  }
-  if (!lineWidth) {
-    throw new Error("Missing #lineWidth input");
-  }
-  if (!fillMode) {
-    throw new Error("Missing #fillMode input");
-  }
-  if (!saveBtn) {
-    throw new Error("Missing #save button");
-  }
-  if (!formatSelect) {
-    throw new Error("Missing #formatSelect select");
-  }
-
-  if (layerSelect) {
-    layerSelect.innerHTML = "";
-  }
-
-  canvases.forEach((c, i) => {
-    const canvasId = c.id || `layer${i + 1}`;
-    const name = c.id || `Layer ${i + 1}`;
-
-    if (layerSelect) {
-      const opt = document.createElement("option");
-      opt.value = String(i);
-      opt.textContent = name;
-      layerSelect.appendChild(opt);
-    }
-
-    if (!document.getElementById(`${canvasId}Opacity`) && i > 0) {
-      const group = document.createElement("div");
-      group.className = "group";
-
-      const label = document.createElement("label");
-      label.htmlFor = `${canvasId}Opacity`;
-      label.textContent = `${name} Opacity`;
-
-      const input = document.createElement("input");
-      input.id = `${canvasId}Opacity`;
-      input.type = "number";
-      input.min = "0";
-      input.max = "100";
-      input.value = "100";
-
-      group.appendChild(label);
-      group.appendChild(input);
-      toolbar.appendChild(group);
-    }
-  });
-
-  const undoBtn = document.getElementById("undo") as HTMLButtonElement | null;
-  const redoBtn = document.getElementById("redo") as HTMLButtonElement | null;
-  const listeners: Array<() => void> = [];
-
-  const recentColors: string[] = [];
-  const maxRecentColors = 10;
-  const renderColorHistory = () => {
-    if (!colorHistory) return;
-    colorHistory.innerHTML = "";
-    recentColors.forEach((color) => {
-      const btn = document.createElement("button");
-      btn.type = "button";
-      btn.className = "color-swatch";
-      btn.style.backgroundColor = color;
-      btn.setAttribute("aria-label", `Select ${color}`);
-      btn.addEventListener("click", () => {
-        colorPicker.value = color;
-        colorPicker.dispatchEvent(new Event("input"));
-      });
-      colorHistory.appendChild(btn);
-    });
-  };
-
-  const recordColor = (color: string) => {
-    const existing = recentColors.indexOf(color);
-    if (existing !== -1) recentColors.splice(existing, 1);
-    recentColors.unshift(color);
-    if (recentColors.length > maxRecentColors) recentColors.pop();
-    renderColorHistory();
-  };
-
-  listen(
-    colorPicker,
-    "input",
-    () => {
-      recordColor(colorPicker.value);
-    },
-    listeners,
-  );
-
-  let editor: Editor; // set after editors created
-
-  const updateHistoryButtons = () => {
-    if (undoBtn) undoBtn.disabled = !editor?.canUndo;
-    if (redoBtn) redoBtn.disabled = !editor?.canRedo;
+    pencil: PencilTool, eraser: EraserTool, rectangle: RectangleTool, line: LineTool,
+    circle: CircleTool, text: TextTool, bucket: BucketFillTool, eyedropper: EyedropperTool,
   };
 
   const editors: Editor[] = [];
+  let editor: Editor;
+  let activeLayerIndex = 0;
+  let activeToolCtor: new () => Tool = PencilTool;
+  const editorToolConstructors = new Map<Editor, new () => Tool>();
+
   canvases.forEach((c) => {
     try {
-      const e = new Editor(
-        c,
-        colorPicker,
-        lineWidth,
-        fillMode,
-        () => {
-          updateHistoryButtons();
-        },
-        fontFamily ?? undefined,
-        fontSize ?? undefined,
-      );
-      editors.push(e);
-    } catch {
-      /* skip canvases without 2D context */
-    }
+      editors.push(new Editor(c, colorPicker, lineWidth, fillMode, () => history.updateHistoryButtons(), fontFamily, fontSize));
+    } catch {}
   });
+  if (editors.length === 0) throw new Error("initEditor() requires at least one <canvas> element with a 2D context");
+  editor = editors[0];
 
-  if (editors.length === 0) {
-    throw new Error(
-      "initEditor() requires at least one <canvas> element with a 2D context",
-    );
-  }
+  const history = initHistoryControls({ getEditor: () => editor, cleanups });
+  const tools = initToolControls({
+    toolConstructors,
+    editorToolConstructors,
+    getEditor: () => editor,
+    getActiveToolCtor: () => activeToolCtor,
+    setActiveToolCtor: (ctor) => (activeToolCtor = ctor),
+    cleanups,
+  });
+  const layers = initLayerControls({
+    canvases, editors, toolbar, cleanups,
+    getActiveLayerIndex: () => activeLayerIndex,
+    setActiveLayerIndex: (index) => (activeLayerIndex = index),
+    onLayerSelected: (index) => activateLayer(index),
+  });
+  initColorHistory({ cleanups });
+  initSaveExport({ canvases, getEditor: () => editor, cleanups });
+  initImageImport({ getEditor: () => editor, onImported: () => history.updateHistoryButtons(), cleanups });
 
   editors.forEach((e) => {
     const original = e.setTool.bind(e);
     e.setTool = (tool: Tool) => {
       original(tool);
-      const ctor = tool.constructor as new () => Tool;
-      editorToolConstructors.set(e, ctor);
-      activeToolCtor = ctor;
-      setActiveButton(buttonForTool(tool));
+      tools.syncActiveButtonFromTool(tool);
     };
   });
 
-  // active editor defaults to the first successfully created editor
-  editor = editors[0];
-
-  // default tool
-  editor.setTool(new PencilTool());
-  editorToolConstructors.set(editor, PencilTool);
-  updateLayerInteractivity();
-
-  // keyboard shortcuts
   const shortcuts = new Shortcuts(editor);
-
-  // map button id to tool constructor
-  Object.entries(toolConstructors).forEach(([id, ToolCtor]) =>
-    listen(toolButtons[id], "click", () => editor.setTool(new ToolCtor()), listeners),
-  );
-
-  listen(
-    undoBtn,
-    "click",
-    () => {
-      editor.undo();
-      updateHistoryButtons();
-    },
-    listeners,
-  );
-
-  listen(
-    redoBtn,
-    "click",
-    () => {
-      editor.redo();
-      updateHistoryButtons();
-    },
-    listeners,
-  );
-
-  // saving
-  listen(
-    saveBtn,
-    "click",
-    () => {
-      const format =
-        formatSelect.value.toLowerCase() === "jpeg" ? "jpeg" : "png";
-      const mime = format === "jpeg" ? "image/jpeg" : "image/png";
-      const quality = format === "jpeg" ? 0.9 : undefined;
-
-      let exportCanvas: HTMLCanvasElement;
-      if (canvases.length > 1) {
-        // composite all layers respecting their opacity
-        exportCanvas = document.createElement("canvas");
-        exportCanvas.width = canvases[0].width;
-        exportCanvas.height = canvases[0].height;
-        const tempCtx = exportCanvas.getContext("2d")!;
-        canvases.forEach((cv) => {
-          const opacity = parseFloat(cv.style.opacity) || 1;
-          tempCtx.globalAlpha = opacity;
-          tempCtx.drawImage(cv, 0, 0);
-        });
-        tempCtx.globalAlpha = 1;
-      } else {
-        exportCanvas = editor.canvas;
-      }
-
-      const data =
-        quality !== undefined
-          ? exportCanvas.toDataURL(mime, quality)
-          : exportCanvas.toDataURL(mime);
-      const a = document.createElement("a");
-      a.href = data;
-      a.download = `canvas.${format === "jpeg" ? "jpg" : "png"}`;
-      a.click();
-    },
-    listeners,
-  );
-
-  // image loading
-  const imageLoader = document.getElementById("imageLoader") as HTMLInputElement | null;
-  listen(
-    imageLoader,
-    "change",
-    (e: Event) => {
-      const file = (e.target as HTMLInputElement).files?.[0];
-      if (!file) return;
-      const reader = new FileReader();
-      reader.onload = () => {
-        const img = new Image();
-        img.onload = () => {
-          editor.saveState();
-          editor.ctx.drawImage(
-            img,
-            0,
-            0,
-            editor.canvas.width,
-            editor.canvas.height,
-          );
-          updateHistoryButtons();
-          if (imageLoader) imageLoader.value = "";
-        };
-        img.src = reader.result as string;
-      };
-      reader.readAsDataURL(file);
-    },
-    listeners,
-  );
-
-  document
-    .querySelectorAll<HTMLInputElement>('input[id$="Opacity"]')
-    .forEach((input) => {
-      const targetId = input.id.replace(/Opacity$/, "");
-      const layer = document.getElementById(targetId) as HTMLCanvasElement | null;
-      if (!layer) return;
-      listen(
-        input,
-        "input",
-        () => {
-          const value = parseFloat(input.value);
-          layer.style.opacity = isNaN(value) ? "1" : String(value / 100);
-        },
-        listeners,
-      );
-    });
-
-  // layer selection
-  listen(
-    layerSelect,
-    "change",
-    () => {
-      const idx = parseInt(layerSelect!.value, 10);
-      activateLayer(idx);
-    },
-    listeners,
-  );
-
   function activateLayer(index: number) {
     if (index < 0 || index >= editors.length) return;
     activeLayerIndex = index;
     editor = editors[index];
     handle.editor = editor;
     shortcuts.switchEditor(editor);
-    updateLayerInteractivity();
-    const ToolCtor = editorToolConstructors.get(editor) ?? activeToolCtor;
-    editor.setTool(new ToolCtor());
-    updateHistoryButtons();
-    if (layerSelect) layerSelect.value = String(index);
+    layers.updateLayerInteractivity();
+    tools.applyCurrentToolToEditor(editor);
+    history.updateHistoryButtons();
+    layers.syncLayerSelect(index);
   }
+
+  editor.setTool(new PencilTool());
+  editorToolConstructors.set(editor, PencilTool);
+  layers.updateLayerInteractivity();
+  history.updateHistoryButtons();
 
   const handle: EditorHandle = {
     editor,
     editors,
     activateLayer,
     destroy() {
-      listeners.forEach((fn) => fn());
+      cleanups.forEach((fn) => fn());
       shortcuts.destroy();
       editors.forEach((e) => e.destroy());
     },
   };
-  recordColor(colorPicker.value);
-  updateHistoryButtons();
   return handle;
 }

--- a/src/editor/colorHistory.ts
+++ b/src/editor/colorHistory.ts
@@ -1,0 +1,46 @@
+import { listen, optionalElement, requireElement, type Cleanup } from "./domHelpers.js";
+
+export interface ColorHistoryInput {
+  cleanups: Cleanup[];
+}
+
+export interface ColorHistoryOutput {
+  recordColor: (color: string) => void;
+  destroy: Cleanup;
+}
+
+export function initColorHistory({ cleanups }: ColorHistoryInput): ColorHistoryOutput {
+  const colorPicker = requireElement<HTMLInputElement>("colorPicker", "input");
+  const colorHistory = optionalElement<HTMLDivElement>("colorHistory");
+  const recentColors: string[] = [];
+
+  const render = () => {
+    if (!colorHistory) return;
+    colorHistory.innerHTML = "";
+    recentColors.forEach((color) => {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "color-swatch";
+      btn.style.backgroundColor = color;
+      btn.setAttribute("aria-label", `Select ${color}`);
+      btn.addEventListener("click", () => {
+        colorPicker.value = color;
+        colorPicker.dispatchEvent(new Event("input"));
+      });
+      colorHistory.appendChild(btn);
+    });
+  };
+
+  const recordColor = (color: string) => {
+    const i = recentColors.indexOf(color);
+    if (i !== -1) recentColors.splice(i, 1);
+    recentColors.unshift(color);
+    if (recentColors.length > 10) recentColors.pop();
+    render();
+  };
+
+  listen(colorPicker, "input", () => recordColor(colorPicker.value), cleanups);
+  recordColor(colorPicker.value);
+
+  return { recordColor, destroy: () => {} };
+}

--- a/src/editor/domHelpers.ts
+++ b/src/editor/domHelpers.ts
@@ -1,0 +1,26 @@
+export type Cleanup = () => void;
+
+export function listen<T extends Event>(
+  el: EventTarget | null | undefined,
+  type: string,
+  handler: (e: T) => void,
+  cleanups: Cleanup[],
+) {
+  if (!el) return;
+  const wrapped = handler as EventListener;
+  el.addEventListener(type, wrapped);
+  cleanups.push(() => el.removeEventListener(type, wrapped));
+}
+
+export function requireElement<T extends HTMLElement>(
+  id: string,
+  kind: string,
+): T {
+  const el = document.getElementById(id) as T | null;
+  if (!el) throw new Error(`Missing #${id} ${kind}`);
+  return el;
+}
+
+export function optionalElement<T extends HTMLElement>(id: string): T | null {
+  return document.getElementById(id) as T | null;
+}

--- a/src/editor/historyControls.ts
+++ b/src/editor/historyControls.ts
@@ -1,0 +1,38 @@
+import type { Editor } from "../core/Editor.js";
+import { listen, optionalElement, type Cleanup } from "./domHelpers.js";
+
+export interface HistoryControlsInput {
+  getEditor: () => Editor;
+  cleanups: Cleanup[];
+}
+
+export interface HistoryControlsOutput {
+  updateHistoryButtons: () => void;
+  destroy: Cleanup;
+}
+
+export function initHistoryControls({
+  getEditor,
+  cleanups,
+}: HistoryControlsInput): HistoryControlsOutput {
+  const undoBtn = optionalElement<HTMLButtonElement>("undo");
+  const redoBtn = optionalElement<HTMLButtonElement>("redo");
+
+  const updateHistoryButtons = () => {
+    const editor = getEditor();
+    if (undoBtn) undoBtn.disabled = !editor.canUndo;
+    if (redoBtn) redoBtn.disabled = !editor.canRedo;
+  };
+
+  listen(undoBtn, "click", () => {
+    getEditor().undo();
+    updateHistoryButtons();
+  }, cleanups);
+
+  listen(redoBtn, "click", () => {
+    getEditor().redo();
+    updateHistoryButtons();
+  }, cleanups);
+
+  return { updateHistoryButtons, destroy: () => {} };
+}

--- a/src/editor/imageImport.ts
+++ b/src/editor/imageImport.ts
@@ -1,0 +1,30 @@
+import type { Editor } from "../core/Editor.js";
+import { listen, optionalElement, type Cleanup } from "./domHelpers.js";
+
+export interface ImageImportInput {
+  getEditor: () => Editor;
+  onImported: () => void;
+  cleanups: Cleanup[];
+}
+
+export function initImageImport({ getEditor, onImported, cleanups }: ImageImportInput): Cleanup {
+  const imageLoader = optionalElement<HTMLInputElement>("imageLoader");
+  listen(imageLoader, "change", (e: Event) => {
+    const file = (e.target as HTMLInputElement).files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        const editor = getEditor();
+        editor.saveState();
+        editor.ctx.drawImage(img, 0, 0, editor.canvas.width, editor.canvas.height);
+        onImported();
+        if (imageLoader) imageLoader.value = "";
+      };
+      img.src = reader.result as string;
+    };
+    reader.readAsDataURL(file);
+  }, cleanups);
+  return () => {};
+}

--- a/src/editor/layerControls.ts
+++ b/src/editor/layerControls.ts
@@ -1,0 +1,76 @@
+import type { Editor } from "../core/Editor.js";
+import { listen, optionalElement, type Cleanup } from "./domHelpers.js";
+
+export interface LayerControlsInput {
+  canvases: HTMLCanvasElement[];
+  editors: Editor[];
+  toolbar: HTMLElement;
+  getActiveLayerIndex: () => number;
+  setActiveLayerIndex: (index: number) => void;
+  onLayerSelected: (index: number) => void;
+  cleanups: Cleanup[];
+}
+
+export interface LayerControlsOutput {
+  updateLayerInteractivity: () => void;
+  syncLayerSelect: (index: number) => void;
+  destroy: Cleanup;
+}
+
+export function initLayerControls(input: LayerControlsInput): LayerControlsOutput {
+  const layerSelect = optionalElement<HTMLSelectElement>("layerSelect");
+  if (layerSelect) layerSelect.innerHTML = "";
+
+  input.canvases.forEach((c, i) => {
+    const canvasId = c.id || `layer${i + 1}`;
+    const name = c.id || `Layer ${i + 1}`;
+    if (layerSelect) {
+      const opt = document.createElement("option");
+      opt.value = String(i);
+      opt.textContent = name;
+      layerSelect.appendChild(opt);
+    }
+    if (!document.getElementById(`${canvasId}Opacity`) && i > 0) {
+      const group = document.createElement("div");
+      group.className = "group";
+      const label = document.createElement("label");
+      label.htmlFor = `${canvasId}Opacity`;
+      label.textContent = `${name} Opacity`;
+      const opacity = document.createElement("input");
+      opacity.id = `${canvasId}Opacity`;
+      opacity.type = "number";
+      opacity.min = "0";
+      opacity.max = "100";
+      opacity.value = "100";
+      group.append(label, opacity);
+      input.toolbar.appendChild(group);
+    }
+  });
+
+  const updateLayerInteractivity = () => {
+    input.canvases.forEach((canvas, index) => {
+      canvas.style.pointerEvents = index === input.getActiveLayerIndex() ? "auto" : "none";
+    });
+  };
+
+  listen(layerSelect, "change", () => {
+    input.onLayerSelected(parseInt(layerSelect!.value, 10));
+  }, input.cleanups);
+
+  document.querySelectorAll<HTMLInputElement>('input[id$="Opacity"]').forEach((opacityInput) => {
+    const layer = document.getElementById(opacityInput.id.replace(/Opacity$/, "")) as HTMLCanvasElement | null;
+    if (!layer) return;
+    listen(opacityInput, "input", () => {
+      const value = parseFloat(opacityInput.value);
+      layer.style.opacity = isNaN(value) ? "1" : String(value / 100);
+    }, input.cleanups);
+  });
+
+  return {
+    updateLayerInteractivity,
+    syncLayerSelect: (index) => {
+      if (layerSelect) layerSelect.value = String(index);
+    },
+    destroy: () => {},
+  };
+}

--- a/src/editor/saveExport.ts
+++ b/src/editor/saveExport.ts
@@ -1,0 +1,38 @@
+import type { Editor } from "../core/Editor.js";
+import { listen, requireElement, type Cleanup } from "./domHelpers.js";
+
+export interface SaveExportInput {
+  canvases: HTMLCanvasElement[];
+  getEditor: () => Editor;
+  cleanups: Cleanup[];
+}
+
+export function initSaveExport({ canvases, getEditor, cleanups }: SaveExportInput): Cleanup {
+  const saveBtn = requireElement<HTMLButtonElement>("save", "button");
+  const formatSelect = requireElement<HTMLSelectElement>("formatSelect", "select");
+  listen(saveBtn, "click", () => {
+    const format = formatSelect.value.toLowerCase() === "jpeg" ? "jpeg" : "png";
+    const mime = format === "jpeg" ? "image/jpeg" : "image/png";
+    const quality = format === "jpeg" ? 0.9 : undefined;
+    let exportCanvas: HTMLCanvasElement;
+    if (canvases.length > 1) {
+      exportCanvas = document.createElement("canvas");
+      exportCanvas.width = canvases[0].width;
+      exportCanvas.height = canvases[0].height;
+      const ctx = exportCanvas.getContext("2d")!;
+      canvases.forEach((cv) => {
+        ctx.globalAlpha = parseFloat(cv.style.opacity) || 1;
+        ctx.drawImage(cv, 0, 0);
+      });
+      ctx.globalAlpha = 1;
+    } else {
+      exportCanvas = getEditor().canvas;
+    }
+    const data = quality !== undefined ? exportCanvas.toDataURL(mime, quality) : exportCanvas.toDataURL(mime);
+    const a = document.createElement("a");
+    a.href = data;
+    a.download = `canvas.${format === "jpeg" ? "jpg" : "png"}`;
+    a.click();
+  }, cleanups);
+  return () => {};
+}

--- a/src/editor/toolControls.ts
+++ b/src/editor/toolControls.ts
@@ -1,0 +1,58 @@
+import type { Editor } from "../core/Editor.js";
+import type { Tool } from "../tools/Tool.js";
+import { listen, requireElement, type Cleanup } from "./domHelpers.js";
+
+export interface ToolControlsInput {
+  toolConstructors: Record<string, new () => Tool>;
+  editorToolConstructors: Map<Editor, new () => Tool>;
+  setActiveToolCtor: (ctor: new () => Tool) => void;
+  getActiveToolCtor: () => new () => Tool;
+  getEditor: () => Editor;
+  cleanups: Cleanup[];
+}
+
+export interface ToolControlsOutput {
+  syncActiveButtonFromTool: (tool: Tool) => void;
+  applyCurrentToolToEditor: (editor: Editor) => void;
+  destroy: Cleanup;
+}
+
+export function initToolControls(input: ToolControlsInput): ToolControlsOutput {
+  const { toolConstructors, editorToolConstructors, cleanups } = input;
+  const toolButtons: Record<string, HTMLButtonElement> = {};
+  Object.entries(toolConstructors).forEach(([id]) => {
+    toolButtons[id] = requireElement<HTMLButtonElement>(id, "button");
+  });
+
+  let activeButton: HTMLButtonElement | null = null;
+  const setActiveButton = (btn: HTMLButtonElement | null) => {
+    if (activeButton) activeButton.classList.remove("active");
+    if (btn) btn.classList.add("active");
+    activeButton = btn;
+  };
+
+  const buttonForTool = (tool: Tool): HTMLButtonElement | null => {
+    for (const [id, ToolCtor] of Object.entries(toolConstructors)) {
+      if (tool instanceof ToolCtor) return toolButtons[id];
+    }
+    return null;
+  };
+
+  Object.entries(toolConstructors).forEach(([id, ToolCtor]) =>
+    listen(toolButtons[id], "click", () => input.getEditor().setTool(new ToolCtor()), cleanups),
+  );
+
+  return {
+    syncActiveButtonFromTool: (tool) => {
+      const ctor = tool.constructor as new () => Tool;
+      editorToolConstructors.set(input.getEditor(), ctor);
+      input.setActiveToolCtor(ctor);
+      setActiveButton(buttonForTool(tool));
+    },
+    applyCurrentToolToEditor: (editor) => {
+      const ToolCtor = editorToolConstructors.get(editor) ?? input.getActiveToolCtor();
+      editor.setTool(new ToolCtor());
+    },
+    destroy: () => {},
+  };
+}

--- a/tests/colorHistoryController.test.ts
+++ b/tests/colorHistoryController.test.ts
@@ -1,0 +1,9 @@
+import { initColorHistory } from "../src/editor/colorHistory.js";
+
+test("color history renders swatches", () => {
+  document.body.innerHTML = `<input id='colorPicker' value='#111111' /><div id='colorHistory'></div>`;
+  initColorHistory({ cleanups: [] });
+  (document.getElementById("colorPicker") as HTMLInputElement).value = "#222222";
+  document.getElementById("colorPicker")!.dispatchEvent(new Event("input"));
+  expect(document.querySelectorAll(".color-swatch").length).toBe(2);
+});

--- a/tests/historyControls.test.ts
+++ b/tests/historyControls.test.ts
@@ -1,0 +1,13 @@
+import { initHistoryControls } from "../src/editor/historyControls.js";
+
+test("history controls wire undo/redo", () => {
+  document.body.innerHTML = `<button id='undo'></button><button id='redo'></button>`;
+  const editor = { canUndo: true, canRedo: false, undo: jest.fn(), redo: jest.fn() } as any;
+  const cleanups: Array<() => void> = [];
+  const { updateHistoryButtons } = initHistoryControls({ getEditor: () => editor, cleanups });
+  updateHistoryButtons();
+  expect((document.getElementById("undo") as HTMLButtonElement).disabled).toBe(false);
+  expect((document.getElementById("redo") as HTMLButtonElement).disabled).toBe(true);
+  (document.getElementById("undo") as HTMLButtonElement).click();
+  expect(editor.undo).toHaveBeenCalled();
+});

--- a/tests/imageImportController.test.ts
+++ b/tests/imageImportController.test.ts
@@ -1,0 +1,9 @@
+import { initImageImport } from "../src/editor/imageImport.js";
+
+test("image import does nothing without file", () => {
+  document.body.innerHTML = `<input id='imageLoader' type='file' />`;
+  const onImported = jest.fn();
+  initImageImport({ getEditor: () => ({ saveState: jest.fn(), ctx: { drawImage: jest.fn() }, canvas: { width: 10, height: 10 } } as any), onImported, cleanups: [] });
+  document.getElementById("imageLoader")!.dispatchEvent(new Event("change"));
+  expect(onImported).not.toHaveBeenCalled();
+});

--- a/tests/layerControls.test.ts
+++ b/tests/layerControls.test.ts
@@ -1,0 +1,10 @@
+import { initLayerControls } from "../src/editor/layerControls.js";
+
+test("layer controls set pointerEvents by active layer", () => {
+  document.body.innerHTML = `<div id='toolbar'></div><select id='layerSelect'></select><canvas id='c1'></canvas><canvas id='c2'></canvas>`;
+  const canvases = Array.from(document.querySelectorAll("canvas"));
+  const out = initLayerControls({ canvases: canvases as any, editors: [] as any, toolbar: document.getElementById("toolbar")!, getActiveLayerIndex: () => 1, setActiveLayerIndex: () => {}, onLayerSelected: () => {}, cleanups: [] });
+  out.updateLayerInteractivity();
+  expect((canvases[0] as HTMLCanvasElement).style.pointerEvents).toBe("none");
+  expect((canvases[1] as HTMLCanvasElement).style.pointerEvents).toBe("auto");
+});

--- a/tests/saveExportController.test.ts
+++ b/tests/saveExportController.test.ts
@@ -1,0 +1,12 @@
+import { initSaveExport } from "../src/editor/saveExport.js";
+
+test("save export triggers anchor click", () => {
+  document.body.innerHTML = `<button id='save'></button><select id='formatSelect'><option>png</option></select><canvas id='c'></canvas>`;
+  const canvas = document.getElementById("c") as HTMLCanvasElement;
+  canvas.toDataURL = jest.fn().mockReturnValue("data:image/png;base64,X");
+  const click = jest.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+  initSaveExport({ canvases: [canvas], getEditor: () => ({ canvas } as any), cleanups: [] });
+  (document.getElementById("save") as HTMLButtonElement).click();
+  expect(click).toHaveBeenCalled();
+  click.mockRestore();
+});

--- a/tests/toolControls.test.ts
+++ b/tests/toolControls.test.ts
@@ -1,0 +1,11 @@
+import { initToolControls } from "../src/editor/toolControls.js";
+class A {}
+class B {}
+
+test("tool controls activate selected tool", () => {
+  document.body.innerHTML = `<button id='pencil'></button><button id='eraser'></button>`;
+  const editor = { setTool: jest.fn() } as any;
+  initToolControls({ toolConstructors: { pencil: A as any, eraser: B as any }, editorToolConstructors: new Map(), setActiveToolCtor: () => {}, getActiveToolCtor: () => A as any, getEditor: () => editor, cleanups: [] });
+  (document.getElementById("eraser") as HTMLButtonElement).click();
+  expect(editor.setTool).toHaveBeenCalled();
+});


### PR DESCRIPTION
### Motivation
- Break the large `initEditor()` implementation into focused, testable modules to improve maintainability and reasoning about each UI concern.
- Centralize repeated DOM query/listener patterns into shared helpers to reduce duplication and make cleanup deterministic.
- Define minimal controller interfaces (inputs + cleanup callbacks) so each controller can be unit tested and composed from a single root.

### Description
- Split editor responsibilities into new modules: `src/editor/historyControls.ts`, `src/editor/toolControls.ts`, `src/editor/layerControls.ts`, `src/editor/saveExport.ts`, `src/editor/colorHistory.ts`, and `src/editor/imageImport.ts` and added shared helpers in `src/editor/domHelpers.ts`.
- Kept `initEditor()` as the composition root in `src/editor.ts` that wires controllers together, passes `cleanups` and `getEditor` callbacks, and coordinates layer/tool switching.
- Introduced small input/output interfaces for each controller and used a `Cleanup[]` listener pattern so controllers register removal callbacks instead of managing listeners inline.
- Added module-level unit tests covering each controller under `tests/` to reduce reliance on the existing monolithic integration test (`tests/*Controller.test.ts` for history, tool, layer, save/export, color history, image import).

### Testing
- Ran the full test suite with `npm test -- --runInBand` and all automated tests passed successfully.
- Result: `24/24` test suites passing and `64/64` tests passed, including the newly added controller unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94c9a8e7883289a8de0b107a52436)